### PR TITLE
Don't render empty aria-describedby attributes

### DIFF
--- a/src/GovUk.Frontend.AspNetCore/HtmlGeneration/ComponentGenerator.Checkboxes.cs
+++ b/src/GovUk.Frontend.AspNetCore/HtmlGeneration/ComponentGenerator.Checkboxes.cs
@@ -133,7 +133,7 @@ namespace GovUk.Frontend.AspNetCore.HtmlGeneration
                     AppendToDescribedBy(ref itemDescribedBy, hintId);
                 }
 
-                if (itemDescribedBy != null)
+                if (!string.IsNullOrEmpty(itemDescribedBy))
                 {
                     input.Attributes.Add("aria-describedby", itemDescribedBy);
                 }

--- a/src/GovUk.Frontend.AspNetCore/HtmlGeneration/ComponentGenerator.Fieldset.cs
+++ b/src/GovUk.Frontend.AspNetCore/HtmlGeneration/ComponentGenerator.Fieldset.cs
@@ -25,12 +25,12 @@ namespace GovUk.Frontend.AspNetCore.HtmlGeneration
             tagBuilder.MergeOptionalAttributes(attributes);
             tagBuilder.MergeCssClass("govuk-fieldset");
 
-            if (role != null)
+            if (!string.IsNullOrEmpty(role))
             {
                 tagBuilder.Attributes.Add("role", role);
             }
 
-            if (describedBy != null)
+            if (!string.IsNullOrEmpty(describedBy))
             {
                 tagBuilder.Attributes.Add("aria-describedby", describedBy);
             }

--- a/src/GovUk.Frontend.AspNetCore/HtmlGeneration/ComponentGenerator.FileUpload.cs
+++ b/src/GovUk.Frontend.AspNetCore/HtmlGeneration/ComponentGenerator.FileUpload.cs
@@ -30,7 +30,7 @@ namespace GovUk.Frontend.AspNetCore.HtmlGeneration
             tagBuilder.Attributes.Add("name", name);
             tagBuilder.Attributes.Add("type", "file");
 
-            if (describedBy != null)
+            if (!string.IsNullOrEmpty(describedBy))
             {
                 tagBuilder.Attributes.Add("aria-describedby", describedBy);
             }

--- a/src/GovUk.Frontend.AspNetCore/HtmlGeneration/ComponentGenerator.InsetText.cs
+++ b/src/GovUk.Frontend.AspNetCore/HtmlGeneration/ComponentGenerator.InsetText.cs
@@ -19,7 +19,7 @@ namespace GovUk.Frontend.AspNetCore.HtmlGeneration
             tagBuilder.MergeOptionalAttributes(attributes);
             tagBuilder.MergeCssClass("govuk-inset-text");
 
-            if (id != null)
+            if (!string.IsNullOrEmpty(id))
             {
                 tagBuilder.Attributes.Add("id", id);
             }

--- a/src/GovUk.Frontend.AspNetCore/HtmlGeneration/ComponentGenerator.Select.cs
+++ b/src/GovUk.Frontend.AspNetCore/HtmlGeneration/ComponentGenerator.Select.cs
@@ -36,7 +36,7 @@ namespace GovUk.Frontend.AspNetCore.HtmlGeneration
             tagBuilder.Attributes.Add("id", id);
             tagBuilder.Attributes.Add("name", name);
 
-            if (describedBy != null)
+            if (!string.IsNullOrEmpty(describedBy))
             {
                 tagBuilder.Attributes.Add("aria-describedby", describedBy);
             }

--- a/src/GovUk.Frontend.AspNetCore/HtmlGeneration/ComponentGenerator.TextArea.cs
+++ b/src/GovUk.Frontend.AspNetCore/HtmlGeneration/ComponentGenerator.TextArea.cs
@@ -39,12 +39,12 @@ namespace GovUk.Frontend.AspNetCore.HtmlGeneration
             tagBuilder.Attributes.Add("name", name);
             tagBuilder.Attributes.Add("rows", rows.ToString());
 
-            if (describedBy != null)
+            if (!string.IsNullOrEmpty(describedBy))
             {
                 tagBuilder.Attributes.Add("aria-describedby", describedBy);
             }
 
-            if (autocomplete != null)
+            if (!string.IsNullOrEmpty(autocomplete))
             {
                 tagBuilder.Attributes.Add("autocomplete", autocomplete);
             }

--- a/src/GovUk.Frontend.AspNetCore/HtmlGeneration/ComponentGenerator.TextInput.cs
+++ b/src/GovUk.Frontend.AspNetCore/HtmlGeneration/ComponentGenerator.TextInput.cs
@@ -52,12 +52,12 @@ namespace GovUk.Frontend.AspNetCore.HtmlGeneration
                 tagBuilder.Attributes.Add("value", value);
             }
 
-            if (describedBy != null)
+            if (!string.IsNullOrEmpty(describedBy))
             {
                 tagBuilder.Attributes.Add("aria-describedby", describedBy);
             }
 
-            if (autocomplete != null)
+            if (!string.IsNullOrEmpty(autocomplete))
             {
                 tagBuilder.Attributes.Add("autocomplete", autocomplete);
             }
@@ -67,7 +67,7 @@ namespace GovUk.Frontend.AspNetCore.HtmlGeneration
                 tagBuilder.Attributes.Add("pattern", pattern);
             }
 
-            if (inputMode != null)
+            if (!string.IsNullOrEmpty(inputMode))
             {
                 tagBuilder.Attributes.Add("inputmode", inputMode);
             }


### PR DESCRIPTION
Also adds a few other checks for other attributes where empty values don't make sense.

Fixes #246