### PR TITLE
Use DateOnly as our base model type for Date Input

### DIFF
--- a/samples/Samples.DateInput/LocalDateDateInputModelConverter.cs
+++ b/samples/Samples.DateInput/LocalDateDateInputModelConverter.cs
@@ -6,19 +6,19 @@ namespace Samples.DateInput
 {
     public class LocalDateDateInputModelConverter : DateInputModelConverter
     {
-        public override bool CanConvertModelType(Type modelType) => modelType == typeof(LocalDate) || modelType == typeof(LocalDate?);
+        public override bool CanConvertModelType(Type modelType) => modelType == typeof(LocalDate);
 
-        public override object CreateModelFromDate(Type modelType, Date date)
+        public override object CreateModelFromDate(Type modelType, DateOnly date)
         {
             return new LocalDate(date.Year, date.Month, date.Day);
         }
 
-        public override Date? GetDateFromModel(Type modelType, object model)
+        public override DateOnly? GetDateFromModel(Type modelType, object model)
         {
             var localDate = (LocalDate?)model;
 
             return localDate.HasValue ?
-                new Date(localDate.Value.Year, localDate.Value.Month, localDate.Value.Day) :
+                new DateOnly(localDate.Value.Year, localDate.Value.Month, localDate.Value.Day) :
                 null;
         }
     }

--- a/src/GovUk.Frontend.AspNetCore/Date.cs
+++ b/src/GovUk.Frontend.AspNetCore/Date.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 
 namespace GovUk.Frontend.AspNetCore
@@ -6,10 +7,12 @@ namespace GovUk.Frontend.AspNetCore
     /// <summary>
     /// Represents a date.
     /// </summary>
+    [Obsolete("Use DateOnly instead.", error: false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [StructLayout(LayoutKind.Auto)]
     public readonly struct Date : IComparable, IComparable<Date>, IEquatable<Date>
     {
-        private readonly DateTime _dt;
+        private readonly DateOnly _d;
 
         /// <summary>
         /// Creates a new instance of the <see cref="Date"/> structure to the specified year, month and day.
@@ -18,34 +21,40 @@ namespace GovUk.Frontend.AspNetCore
         /// <param name="month">The month (1 through 12).</param>
         /// <param name="day">The day (1 through the number of days in <paramref name="month" />).</param>
         public Date(int year, int month, int day)
-            : this(new DateTime(year, month, day))
+            : this(new DateOnly(year, month, day))
         {
         }
 
-        private Date(DateTime dateTime)
+        private Date(DateOnly date)
         {
-            _dt = dateTime;
+            _d = date;
         }
 
         /// <summary>
         /// Gets the current date.
         /// </summary>
-        public static Date Today => new(DateTime.Today);
+        public static Date Today => new(DateOnly.FromDateTime(DateTime.Today));
 
         /// <summary>
         /// Gets the day component of the date.
         /// </summary>
-        public int Day => _dt.Day;
+        public int Day => _d.Day;
 
         /// <summary>
         /// Gets the month component of the date.
         /// </summary>
-        public int Month => _dt.Month;
+        public int Month => _d.Month;
 
         /// <summary>
         /// Gets the year component of the date.
         /// </summary>
-        public int Year => _dt.Year;
+        public int Year => _d.Year;
+
+        /// <summary>
+        /// Converts the specified <see cref="Date"/> to a <see cref="DateOnly"/>.
+        /// </summary>
+        /// <param name="date">The <see cref="Date"/> to convert.</param>
+        public static implicit operator DateOnly(Date date) => date._d;
 
         /// <summary>
         /// Determines whether two specified instances of <see cref="Date"/> are equal.
@@ -69,7 +78,7 @@ namespace GovUk.Frontend.AspNetCore
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns><see langword="true"/> if left is earlier than right; otherwise, <see langword="false"/>.</returns>
-        public static bool operator <(Date left, Date right) => left._dt < right._dt;
+        public static bool operator <(Date left, Date right) => left._d < right._d;
 
         /// <summary>
         /// Determines whether one specified <see cref="Date"/> represents a date that is the same as or earlier than another specified <see cref="Date"/>.
@@ -77,7 +86,7 @@ namespace GovUk.Frontend.AspNetCore
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns><see langword="true"/> if left is the same as or earlier than right; otherwise, <see langword="false"/>.</returns>
-        public static bool operator <=(Date left, Date right) => left._dt <= right._dt;
+        public static bool operator <=(Date left, Date right) => left._d <= right._d;
 
         /// <summary>
         /// Determines whether one specified <see cref="Date"/> is later than another specified <see cref="Date"/>.
@@ -85,7 +94,7 @@ namespace GovUk.Frontend.AspNetCore
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns><see langword="true"/> if left is later than right; otherwise, <see langword="false"/>.</returns>
-        public static bool operator >(Date left, Date right) => left._dt > right._dt;
+        public static bool operator >(Date left, Date right) => left._d > right._d;
 
         /// <summary>
         /// Determines whether one specified <see cref="Date"/> represents a date that is the same as or later than another specified <see cref="Date"/>.
@@ -93,7 +102,7 @@ namespace GovUk.Frontend.AspNetCore
         /// <param name="left">The first object to compare.</param>
         /// <param name="right">The second object to compare.</param>
         /// <returns><see langword="true"/> if left is the same as or later than right; otherwise, <see langword="false"/>.</returns>
-        public static bool operator >=(Date left, Date right) => left._dt >= right._dt;
+        public static bool operator >=(Date left, Date right) => left._d >= right._d;
 
         /// <inheritdoc/>
         public int CompareTo(object? value)
@@ -112,7 +121,7 @@ namespace GovUk.Frontend.AspNetCore
         }
 
         /// <inheritdoc/>
-        public int CompareTo(Date value) => _dt.CompareTo(value);
+        public int CompareTo(Date value) => _d.CompareTo(value);
 
         /// <inheritdoc/>
         public override bool Equals(object? obj) => obj is Date date && Equals(date);
@@ -128,7 +137,7 @@ namespace GovUk.Frontend.AspNetCore
         /// </summary>
         /// <param name="value">The <see cref="DateTime"/> instance.</param>
         /// <returns>The <see cref="Date"/> instance composed of the date part of the specified input time <see cref="DateTime"/> instance.</returns>
-        public static Date FromDateTime(DateTime value) => new(value);
+        public static Date FromDateTime(DateTime value) => new(value.Year, value.Minute, value.Day);
 
         /// <summary>
         /// Returns a <see cref="DateTime"/> that is set to the date of this <see cref="Date"/> instance.

--- a/src/GovUk.Frontend.AspNetCore/DateDateInputModelConverter.cs
+++ b/src/GovUk.Frontend.AspNetCore/DateDateInputModelConverter.cs
@@ -1,14 +1,22 @@
+#pragma warning disable CS0618 // Type or member is obsolete
 using System;
 
 namespace GovUk.Frontend.AspNetCore
 {
     internal class DateDateInputModelConverter : DateInputModelConverter
     {
-        public override bool CanConvertModelType(Type modelType) =>
-            modelType == typeof(Date) || modelType == typeof(Date?);
+        public override bool CanConvertModelType(Type modelType) => modelType == typeof(Date);
 
-        public override object CreateModelFromDate(Type modelType, Date date) => date;
+        public override object CreateModelFromDate(Type modelType, DateOnly date) => new Date(date.Year, date.Month, date.Day);
 
-        public override Date? GetDateFromModel(Type modelType, object model) => (Date?)model;
+        public override DateOnly? GetDateFromModel(Type modelType, object model)
+        {
+            if (model is null)
+            {
+                return null;
+            }
+
+            return (Date)model;
+        }
     }
 }

--- a/src/GovUk.Frontend.AspNetCore/DateInputModelConverter.cs
+++ b/src/GovUk.Frontend.AspNetCore/DateInputModelConverter.cs
@@ -20,7 +20,7 @@ namespace GovUk.Frontend.AspNetCore
         /// <param name="modelType">The model type to convert to.</param>
         /// <param name="date">The <see cref="Date"/> instance to convert.</param>
         /// <returns>An instance of <paramref name="modelType"/> that represents the <paramref name="date"/> argument.</returns>
-        public abstract object CreateModelFromDate(Type modelType, Date date);
+        public abstract object CreateModelFromDate(Type modelType, DateOnly date);
 
         /// <summary>
         /// Converts <paramref name="model"/> to instance of <see cref="Date"/>.
@@ -28,7 +28,7 @@ namespace GovUk.Frontend.AspNetCore
         /// <param name="modelType">The model type to convert from.</param>
         /// <param name="model">The model instance to convert.</param>
         /// <returns>The converted model instance.</returns>
-        public abstract Date? GetDateFromModel(Type modelType, object model);
+        public abstract DateOnly? GetDateFromModel(Type modelType, object model);
 
         /// <summary>
         /// Creates an instance of the specified model type from a set of parse errors.

--- a/src/GovUk.Frontend.AspNetCore/DateOnlyDateInputModelConverter.cs
+++ b/src/GovUk.Frontend.AspNetCore/DateOnlyDateInputModelConverter.cs
@@ -1,0 +1,14 @@
+#nullable enable
+using System;
+
+namespace GovUk.Frontend.AspNetCore
+{
+    internal class DateOnlyDateInputModelConverter : DateInputModelConverter
+    {
+        public override bool CanConvertModelType(Type modelType) => modelType == typeof(DateOnly);
+
+        public override object CreateModelFromDate(Type modelType, DateOnly date) => date;
+
+        public override DateOnly? GetDateFromModel(Type modelType, object model) => (DateOnly?)model;
+    }
+}

--- a/src/GovUk.Frontend.AspNetCore/DateTimeDateInputModelConverter.cs
+++ b/src/GovUk.Frontend.AspNetCore/DateTimeDateInputModelConverter.cs
@@ -4,19 +4,18 @@ namespace GovUk.Frontend.AspNetCore
 {
     internal class DateTimeDateInputModelConverter : DateInputModelConverter
     {
-        public override bool CanConvertModelType(Type modelType) =>
-            modelType == typeof(DateTime) || modelType == typeof(DateTime?);
+        public override bool CanConvertModelType(Type modelType) => modelType == typeof(DateTime);
 
-        public override object CreateModelFromDate(Type modelType, Date date) => new DateTime(date.Year, date.Month, date.Day);
+        public override object CreateModelFromDate(Type modelType, DateOnly date) => new DateTime(date.Year, date.Month, date.Day);
 
-        public override Date? GetDateFromModel(Type modelType, object model)
+        public override DateOnly? GetDateFromModel(Type modelType, object model)
         {
             if (model is null)
             {
                 return null;
             }
 
-            return Date.FromDateTime((DateTime)model);
+            return DateOnly.FromDateTime((DateTime)model);
         }
     }
 }

--- a/src/GovUk.Frontend.AspNetCore/GovUkFrontendAspNetCoreOptions.cs
+++ b/src/GovUk.Frontend.AspNetCore/GovUkFrontendAspNetCoreOptions.cs
@@ -21,7 +21,8 @@ namespace GovUk.Frontend.AspNetCore
             DateInputModelConverters = new List<DateInputModelConverter>()
             {
                 new DateDateInputModelConverter(),
-                new DateTimeDateInputModelConverter()
+                new DateTimeDateInputModelConverter(),
+                new DateOnlyDateInputModelConverter()
             };
 
             PrependErrorSummaryToForms = true;

--- a/src/GovUk.Frontend.AspNetCore/ModelBinding/DateInputModelBinder.cs
+++ b/src/GovUk.Frontend.AspNetCore/ModelBinding/DateInputModelBinder.cs
@@ -24,7 +24,7 @@ namespace GovUk.Frontend.AspNetCore.ModelBinding
         {
             Guard.ArgumentNotNull(nameof(bindingContext), bindingContext);
 
-            var modelType = bindingContext.ModelType;
+            var modelType = bindingContext.ModelMetadata.UnderlyingOrModelType;
             if (!_dateInputModelConverter.CanConvertModelType(modelType))
             {
                 throw new InvalidOperationException($"Cannot bind {modelType.Name}.");
@@ -118,7 +118,7 @@ namespace GovUk.Frontend.AspNetCore.ModelBinding
         }
 
         // internal for testing
-        internal static DateInputParseErrors Parse(string? day, string? month, string? year, out Date? date)
+        internal static DateInputParseErrors Parse(string? day, string? month, string? year, out DateOnly? date)
         {
             day ??= string.Empty;
             month ??= string.Empty;

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputTagHelper.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using GovUk.Frontend.AspNetCore.HtmlGeneration;
 using GovUk.Frontend.AspNetCore.ModelBinding;
 using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Options;
@@ -244,7 +245,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers
                 DateInputAttributes.ToAttributeDictionary());
 
             DateInputItem CreateDateInputItem(
-                Func<Date?, string?> getComponentFromValue,
+                Func<DateOnly?, string?> getComponentFromValue,
                 string defaultLabel,
                 string defaultName,
                 string defaultClass,
@@ -316,7 +317,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers
                 }
             }
 
-            Date? GetValueAsDate()
+            DateOnly? GetValueAsDate()
             {
                 if (Value is null)
                 {
@@ -337,12 +338,12 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers
                 return null;
             }
 
-            Date? GetValueFromModel()
+            DateOnly? GetValueFromModel()
             {
                 Debug.Assert(AspFor != null);
 
                 var modelValue = AspFor!.Model;
-                var modelType = AspFor.ModelExplorer.ModelType;
+                var underlyingModelType = Nullable.GetUnderlyingType(AspFor.ModelExplorer.ModelType) ?? AspFor.ModelExplorer.ModelType;
 
                 if (modelValue is null)
                 {
@@ -353,9 +354,9 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers
 
                 foreach (var converter in dateInputModelConverters)
                 {
-                    if (converter.CanConvertModelType(modelType))
+                    if (converter.CanConvertModelType(underlyingModelType))
                     {
-                        return converter.GetDateFromModel(modelType, modelValue);
+                        return converter.GetDateFromModel(underlyingModelType, modelValue);
                     }
                 }
 

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/ErrorSummaryItemTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/ErrorSummaryItemTagHelper.cs
@@ -167,7 +167,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers
             {
                 Debug.Assert(AspFor != null);
 
-                var modelType = AspFor!.Metadata.ModelType;
+                var modelType = Nullable.GetUnderlyingType(AspFor!.Metadata.ModelType) ?? AspFor!.Metadata.ModelType;
                 return _options.DateInputModelConverters.Any(c => c.CanConvertModelType(modelType));
             }
         }

--- a/test/GovUk.Frontend.AspNetCore.IntegrationTests/DateInputTests.cs
+++ b/test/GovUk.Frontend.AspNetCore.IntegrationTests/DateInputTests.cs
@@ -247,7 +247,7 @@ namespace GovUk.Frontend.AspNetCore.IntegrationTests
     {
         [Display(Name = "Date of birth")]
         [Required(ErrorMessage = "Enter your date of birth")]
-        public Date? Date { get; set; }
+        public DateOnly? Date { get; set; }
 
         [Display(Name = "Date of birth")]
         [Required(ErrorMessage = "Enter your date of birth")]
@@ -272,9 +272,9 @@ namespace GovUk.Frontend.AspNetCore.IntegrationTests
     {
         public override bool CanConvertModelType(Type modelType) => modelType == typeof(CustomDateType);
 
-        public override object CreateModelFromDate(Type modelType, Date date) => new CustomDateType(date.Year, date.Month, date.Day);
+        public override object CreateModelFromDate(Type modelType, DateOnly date) => new CustomDateType(date.Year, date.Month, date.Day);
 
-        public override Date? GetDateFromModel(Type modelType, object model)
+        public override DateOnly? GetDateFromModel(Type modelType, object model)
         {
             if (model is null)
             {
@@ -282,7 +282,7 @@ namespace GovUk.Frontend.AspNetCore.IntegrationTests
             }
 
             var cdt = (CustomDateType)model;
-            return new Date(cdt.Y, cdt.M, cdt.D);
+            return new DateOnly(cdt.Y, cdt.M, cdt.D);
         }
     }
 }

--- a/test/GovUk.Frontend.AspNetCore.Tests/DateOnlyDateInputModelConverterTests.cs
+++ b/test/GovUk.Frontend.AspNetCore.Tests/DateOnlyDateInputModelConverterTests.cs
@@ -1,10 +1,9 @@
-#pragma warning disable CS0618 // Type or member is obsolete
 using System;
 using Xunit;
 
 namespace GovUk.Frontend.AspNetCore.Tests
 {
-    public class DateDateInputModelConverterTests
+    public class DateOnlyDateInputModelConverterTests
     {
         [Theory]
         [MemberData(nameof(CreateDateFromElementsData))]
@@ -14,7 +13,7 @@ namespace GovUk.Frontend.AspNetCore.Tests
             object expectedResult)
         {
             // Arrange
-            var converter = new DateDateInputModelConverter();
+            var converter = new DateOnlyDateInputModelConverter();
 
             // Act
             var result = converter.CreateModelFromDate(modelType, date);
@@ -31,7 +30,7 @@ namespace GovUk.Frontend.AspNetCore.Tests
            DateOnly? expectedResult)
         {
             // Arrange
-            var converter = new DateDateInputModelConverter();
+            var converter = new DateOnlyDateInputModelConverter();
 
             // Act
             var result = converter.GetDateFromModel(modelType, model);
@@ -42,14 +41,14 @@ namespace GovUk.Frontend.AspNetCore.Tests
 
         public static TheoryData<Type, DateOnly?, object> CreateDateFromElementsData { get; } = new()
         {
-            { typeof(Date), new DateOnly(2020, 4, 1), new Date(2020, 4, 1) },
-            { typeof(Date?), new DateOnly(2020, 4, 1), (Date?)new Date(2020, 4, 1) }
+            { typeof(DateOnly), new DateOnly(2020, 4, 1), new DateOnly(2020, 4, 1) },
+            { typeof(DateOnly?), new DateOnly(2020, 4, 1), (DateOnly?)new DateOnly(2020, 4, 1) }
         };
 
         public static TheoryData<Type, object, DateOnly?> GetDateFromModelData { get; } = new()
         {
-            { typeof(Date), new Date(2020, 4, 1), new DateOnly(2020, 4, 1) },
-            { typeof(Date?), (Date?)new Date(2020, 4, 1), new Date(2020, 4, 1) },
+            { typeof(DateOnly), new DateOnly(2020, 4, 1), new DateOnly(2020, 4, 1) },
+            { typeof(DateOnly?), (DateOnly?)new DateOnly(2020, 4, 1), new DateOnly(2020, 4, 1) },
         };
     }
 }

--- a/test/GovUk.Frontend.AspNetCore.Tests/DateTimeDateInputModelConverterTests.cs
+++ b/test/GovUk.Frontend.AspNetCore.Tests/DateTimeDateInputModelConverterTests.cs
@@ -9,7 +9,7 @@ namespace GovUk.Frontend.AspNetCore.Tests
         [MemberData(nameof(CreateModelFromDateData))]
         public void CreateModelFromDate_ReturnsExpectedResult(
             Type modelType,
-            Date date,
+            DateOnly date,
             object expectedResult)
         {
             // Arrange
@@ -27,7 +27,7 @@ namespace GovUk.Frontend.AspNetCore.Tests
         public void GetDateFromModel_ReturnsExpectedResult(
            Type modelType,
            object model,
-           Date? expectedResult)
+           DateOnly? expectedResult)
         {
             // Arrange
             var converter = new DateTimeDateInputModelConverter();
@@ -39,16 +39,16 @@ namespace GovUk.Frontend.AspNetCore.Tests
             Assert.Equal(expectedResult, result);
         }
 
-        public static TheoryData<Type, Date?, object> CreateModelFromDateData { get; } = new TheoryData<Type, Date?, object>()
+        public static TheoryData<Type, DateOnly?, object> CreateModelFromDateData { get; } = new()
         {
-            { typeof(DateTime), new Date(2020, 4, 1), new DateTime(2020, 4, 1) },
-            { typeof(DateTime?), new Date(2020, 4, 1), (DateTime?)new DateTime(2020, 4, 1) }
+            { typeof(DateTime), new DateOnly(2020, 4, 1), new DateTime(2020, 4, 1) },
+            { typeof(DateTime?), new DateOnly(2020, 4, 1), (DateTime?)new DateTime(2020, 4, 1) }
         };
 
-        public static TheoryData<Type, object, Date?> GetDateFromModelData { get; } = new TheoryData<Type, object, Date?>()
+        public static TheoryData<Type, object, DateOnly?> GetDateFromModelData { get; } = new()
         {
-            { typeof(DateTime), new DateTime(2020, 4, 1), new Date(2020, 4, 1) },
-            { typeof(DateTime?), (DateTime?)new DateTime(2020, 4, 1), new Date(2020, 4, 1) }
+            { typeof(DateTime), new DateTime(2020, 4, 1), new DateOnly(2020, 4, 1) },
+            { typeof(DateTime?), (DateTime?)new DateTime(2020, 4, 1), new DateOnly(2020, 4, 1) },
         };
     }
 }

--- a/test/GovUk.Frontend.AspNetCore.Tests/ModelBinding/DateInputModelBinderTests.cs
+++ b/test/GovUk.Frontend.AspNetCore.Tests/ModelBinding/DateInputModelBinderTests.cs
@@ -19,7 +19,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.ModelBinding
         public async Task BindModelAsync_AllComponentsEmpty_DoesNotBind()
         {
             // Arrange
-            var modelType = typeof(Date);
+            var modelType = typeof(DateOnly);
 
             ModelBindingContext bindingContext = new DefaultModelBindingContext()
             {
@@ -46,7 +46,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.ModelBinding
         public async Task BindModelAsync_AllComponentsProvided_PassesValuesToConverterAndBindsResult()
         {
             // Arrange
-            var modelType = typeof(Date);
+            var modelType = typeof(DateOnly);
 
             ModelBindingContext bindingContext = new DefaultModelBindingContext()
             {
@@ -66,8 +66,8 @@ namespace GovUk.Frontend.AspNetCore.Tests.ModelBinding
             converterMock.Setup(mock => mock.CanConvertModelType(modelType)).Returns(true);
 
             converterMock
-                .Setup(mock => mock.CreateModelFromDate(modelType, new Date(2020, 4, 1)))
-                .Returns(new Date(2020, 4, 1))
+                .Setup(mock => mock.CreateModelFromDate(modelType, new DateOnly(2020, 4, 1)))
+                .Returns(new DateOnly(2020, 4, 1))
                 .Verifiable();
 
             var modelBinder = new DateInputModelBinder(converterMock.Object);
@@ -80,7 +80,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.ModelBinding
 
             Assert.True(bindingContext.Result.IsModelSet);
 
-            var date = Assert.IsType<Date>(bindingContext.Result.Model);
+            var date = Assert.IsType<DateOnly>(bindingContext.Result.Model);
             Assert.Equal(2020, date.Year);
             Assert.Equal(4, date.Month);
             Assert.Equal(1, date.Day);
@@ -108,7 +108,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.ModelBinding
         public async Task BindModelAsync_MissingOrInvalidComponents_FailsBinding(string day, string month, string year)
         {
             // Arrange
-            var modelType = typeof(Date);
+            var modelType = typeof(DateOnly);
 
             var valueProvider = new SimpleValueProvider();
 
@@ -275,7 +275,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.ModelBinding
         private class DisplayNameModelMetadata : ModelMetadata
         {
             public DisplayNameModelMetadata(string displayName)
-                : base(ModelMetadataIdentity.ForType(typeof(Date?)))
+                : base(ModelMetadataIdentity.ForType(typeof(DateOnly?)))
             {
                 DisplayName = displayName;
             }

--- a/test/GovUk.Frontend.AspNetCore.Tests/TagHelpers/DateInputTagHelperTests.cs
+++ b/test/GovUk.Frontend.AspNetCore.Tests/TagHelpers/DateInputTagHelperTests.cs
@@ -42,7 +42,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers
             {
                 Id = "my-id",
                 NamePrefix = "my-name",
-                Value = new Date(2020, 4, 1)
+                Value = new DateOnly(2020, 4, 1)
             };
 
             // Act
@@ -95,7 +95,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
 
-            var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model() { Date = new Date(2020, 4, 1) })
+            var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model() { Date = new DateOnly(2020, 4, 1) })
                 .GetExplorerForProperty(nameof(Model.Date));
 
             var viewContext = new ViewContext();
@@ -158,7 +158,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
 
-            var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model() { Date = new Date(2020, 4, 1) })
+            var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model() { Date = new DateOnly(2020, 4, 1) })
                 .GetExplorerForProperty(nameof(Model.Date));
 
             var viewContext = new ViewContext();
@@ -169,7 +169,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers
                 Id = "my-id",
                 NamePrefix = "my-name",
                 ViewContext = viewContext,
-                Value = new Date(2022, 5, 3)
+                Value = new DateOnly(2022, 5, 3)
             };
 
             // Act
@@ -235,7 +235,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers
                 DescribedBy = "describedby",
                 Id = "my-id",
                 NamePrefix = "my-name",
-                Value = new Date(2020, 4, 1)
+                Value = new DateOnly(2020, 4, 1)
             };
 
             // Act
@@ -372,7 +372,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers
             {
                 Id = "my-id",
                 NamePrefix = "my-name",
-                Value = new Date(2020, 4, 1)
+                Value = new DateOnly(2020, 4, 1)
             };
 
             // Act
@@ -433,7 +433,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers
             {
                 Id = "my-id",
                 NamePrefix = "my-name",
-                Value = new Date(2020, 4, 1)
+                Value = new DateOnly(2020, 4, 1)
             };
 
             // Act
@@ -495,7 +495,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers
             {
                 Id = "my-id",
                 NamePrefix = "my-name",
-                Value = new Date(2020, 4, 1)
+                Value = new DateOnly(2020, 4, 1)
             };
 
             // Act
@@ -560,7 +560,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers
             {
                 Id = "my-id",
                 NamePrefix = "my-name",
-                Value = new Date(2020, 4, 1)
+                Value = new DateOnly(2020, 4, 1)
             };
 
             // Act
@@ -604,7 +604,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers
             {
                 Id = "my-id",
                 NamePrefix = "my-name",
-                Value = new Date(2020, 4, 1)
+                Value = new DateOnly(2020, 4, 1)
             };
 
             // Act
@@ -646,7 +646,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers
             {
                 Id = "my-id",
                 NamePrefix = "my-name",
-                Value = new Date(2020, 4, 1)
+                Value = new DateOnly(2020, 4, 1)
             };
 
             // Act
@@ -853,7 +853,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers
                 Id = "my-id",
                 DescribedBy = "describedby",
                 NamePrefix = "my-name",
-                Value = new Date(2020, 4, 1)
+                Value = new DateOnly(2020, 4, 1)
             };
 
             // Act
@@ -921,7 +921,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
 
-            var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model() { Date = new Date(2020, 4, 1) })
+            var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model() { Date = new DateOnly(2020, 4, 1) })
                 .GetExplorerForProperty(nameof(Model.Date));
 
             var viewContext = new ViewContext();
@@ -989,7 +989,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers
                     return Task.FromResult<TagHelperContent>(tagHelperContent);
                 });
 
-            var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model() { Date = new Date(2020, 4, 1) })
+            var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model() { Date = new DateOnly(2020, 4, 1) })
                 .GetExplorerForProperty(nameof(Model.Date));
 
             var viewContext = new ViewContext();
@@ -1069,7 +1069,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers
                 Id = "my-id",
                 DescribedBy = "describedby",
                 NamePrefix = "my-name",
-                Value = new Date(2020, 4, 1)
+                Value = new DateOnly(2020, 4, 1)
             };
 
             // Act
@@ -1098,7 +1098,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers
 
         private class Model
         {
-            public Date? Date { get; set; }
+            public DateOnly? Date { get; set; }
             public CustomDateType? CustomDate { get; set; }
         }
 
@@ -1120,9 +1120,9 @@ namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers
         {
             public override bool CanConvertModelType(Type modelType) => modelType == typeof(CustomDateType);
 
-            public override object CreateModelFromDate(Type modelType, Date date) => new CustomDateType(date.Year, date.Month, date.Day);
+            public override object CreateModelFromDate(Type modelType, DateOnly date) => new CustomDateType(date.Year, date.Month, date.Day);
 
-            public override Date? GetDateFromModel(Type modelType, object model)
+            public override DateOnly? GetDateFromModel(Type modelType, object model)
             {
                 if (model is null)
                 {
@@ -1130,7 +1130,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers
                 }
 
                 var cdt = (CustomDateType)model;
-                return new Date(cdt.Y, cdt.M, cdt.D);
+                return new DateOnly(cdt.Y, cdt.M, cdt.D);
             }
         }
     }

--- a/test/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ErrorSummaryItemTagHelperTests.cs
+++ b/test/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ErrorSummaryItemTagHelperTests.cs
@@ -454,7 +454,7 @@ namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers
 
         private class Model
         {
-            public Date? Date { get; set; }
+            public DateOnly? Date { get; set; }
             public string? Field { get; set; }
         }
     }


### PR DESCRIPTION
Up until now we've had our own Date type for use with the Date Input component. Now that we have access to a built-in one - `DateOnly` - ours is going away. For now it's `[Obsolete]`ed with a view to removing it in the final 1.0 release.