### PR TITLE
First draft of support for summary card - NOT READY FOR MERGE

### DIFF
--- a/src/GovUk.Frontend.AspNetCore/HtmlGeneration/ComponentGenerator.SummaryCard.cs
+++ b/src/GovUk.Frontend.AspNetCore/HtmlGeneration/ComponentGenerator.SummaryCard.cs
@@ -1,0 +1,102 @@
+#nullable enable
+
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace GovUk.Frontend.AspNetCore.HtmlGeneration
+{
+    public partial class ComponentGenerator
+    {
+        internal const string SummaryCardElement = "div";
+        internal const int SummaryCardDefaultHeadingLevel = 2;
+        internal const int SummaryCardMinHeadingLevel = 1;
+        internal const int SummaryCardMaxHeadingLevel = 6;
+        internal const string SummaryCardActionsElement = "ul";
+        internal const string SummaryCardActionElement = "li";
+
+        public TagBuilder GenerateSummaryCard(SummaryCard summaryCard)
+        {
+            Guard.ArgumentValidNotNull(
+                nameof(summaryCard.TitleContent),
+                $"Summary card is not valid; {nameof(summaryCard.TitleContent)} cannot be null.",
+                summaryCard.TitleContent,
+                summaryCard.TitleContent != null);
+
+            Guard.ArgumentValidNotNull(
+               nameof(summaryCard.SummaryList),
+               $"Summary card is not valid; {nameof(summaryCard.SummaryList)} cannot be null.",
+               summaryCard.SummaryList,
+               summaryCard.SummaryList != null && !string.IsNullOrWhiteSpace(summaryCard.SummaryList.ToString()));
+
+            var tagBuilder = new TagBuilder(SummaryCardElement);
+            if (summaryCard.CardAttributes != null) { tagBuilder.MergeAttributes(summaryCard.CardAttributes); }
+            tagBuilder.MergeCssClass("govuk-summary-card");
+
+            var titleTagBuilder = new TagBuilder($"h{summaryCard.HeadingLevel}");
+            if (summaryCard.TitleAttributes != null) { titleTagBuilder.MergeAttributes(summaryCard.TitleAttributes); }
+            titleTagBuilder.MergeCssClass("govuk-summary-card__title");
+            titleTagBuilder.InnerHtml.AppendHtml(summaryCard.TitleContent);
+
+            var headerTagBuilder = new TagBuilder("div");
+            headerTagBuilder.MergeCssClass("govuk-summary-card__title-wrapper");
+            headerTagBuilder.InnerHtml.AppendHtml(titleTagBuilder);
+            tagBuilder.InnerHtml.AppendHtml(headerTagBuilder);
+
+            if (summaryCard.Actions?.Items != null && summaryCard.Actions.Items.Count > 0)
+            {
+                var actionsWrapper = new TagBuilder(summaryCard.Actions.Items.Count == 1 ? "div" : SummaryCardActionsElement);
+                if (summaryCard.Actions.Attributes != null) { actionsWrapper.MergeAttributes(summaryCard.Actions.Attributes); }
+                actionsWrapper.MergeCssClass("govuk-summary-card__actions");
+
+                var actionIndex = 1;
+                foreach (var action in summaryCard.Actions.Items)
+                {
+                    var actionElement = new TagBuilder(summaryCard.Actions.Items.Count == 1 ? "div" : SummaryCardActionElement);
+                    if (action.Attributes != null) { actionElement.MergeAttributes(action.Attributes); }
+                    actionElement.MergeCssClass("govuk-summary-card__action");
+                    actionElement.InnerHtml.AppendHtml(GenerateLink(action, actionIndex));
+
+                    actionsWrapper.InnerHtml.AppendHtml(actionElement);
+                    actionIndex++;
+                }
+
+                headerTagBuilder.InnerHtml.AppendHtml(actionsWrapper);
+            }
+
+            if (summaryCard.SummaryList != null)
+            {
+                var contentTagBuilder = new TagBuilder("div");
+                contentTagBuilder.MergeCssClass("govuk-summary-card__content");
+                tagBuilder.InnerHtml.AppendHtml(contentTagBuilder);
+                contentTagBuilder.InnerHtml.AppendHtml(summaryCard.SummaryList);
+            }
+
+            return tagBuilder;
+        }
+
+        static TagBuilder GenerateLink(SummaryCardAction action, int actionIndex)
+        {
+            Guard.ArgumentValidNotNull(
+                nameof(SummaryCard.Actions),
+                $"Action {actionIndex} is not valid; {nameof(SummaryCardAction.Content)} cannot be null.",
+                action.Content,
+                action.Content != null);
+
+            Guard.ArgumentNotNullOrEmpty(nameof(action.Href), action.Href);
+
+            var anchor = new TagBuilder("a");
+            anchor.MergeAttribute("href", action.Href);
+            anchor.MergeCssClass("govuk-link");
+            anchor.InnerHtml.AppendHtml(action.Content);
+
+            if (action.VisuallyHiddenText != null)
+            {
+                var vht = new TagBuilder("span");
+                vht.MergeCssClass("govuk-visually-hidden");
+                vht.InnerHtml.Append(action.VisuallyHiddenText);
+                anchor.InnerHtml.AppendHtml(vht);
+            }
+
+            return anchor;
+        }
+    }
+}

--- a/src/GovUk.Frontend.AspNetCore/HtmlGeneration/SummaryCard.cs
+++ b/src/GovUk.Frontend.AspNetCore/HtmlGeneration/SummaryCard.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+namespace GovUk.Frontend.AspNetCore.HtmlGeneration
+{
+    public class SummaryCard
+    {
+        public AttributeDictionary CardAttributes { get; set; }
+        public AttributeDictionary TitleAttributes { get; set; }
+        public IHtmlContent TitleContent { get; set; }
+        public int HeadingLevel { get; set; }
+        public IHtmlContent SummaryList { get; set; }
+        public SummaryCardActions Actions { get; set; }
+    }
+}

--- a/src/GovUk.Frontend.AspNetCore/HtmlGeneration/SummaryCardAction.cs
+++ b/src/GovUk.Frontend.AspNetCore/HtmlGeneration/SummaryCardAction.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+namespace GovUk.Frontend.AspNetCore.HtmlGeneration
+{
+    public class SummaryCardAction
+    {
+        public string VisuallyHiddenText { get; set; }
+        public IHtmlContent Content { get; set; }
+        public AttributeDictionary Attributes { get; set; }
+        public string Href { get; internal set; }
+    }
+}

--- a/src/GovUk.Frontend.AspNetCore/HtmlGeneration/SummaryCardActions.cs
+++ b/src/GovUk.Frontend.AspNetCore/HtmlGeneration/SummaryCardActions.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+namespace GovUk.Frontend.AspNetCore.HtmlGeneration
+{
+    public class SummaryCardActions
+    {
+        public IReadOnlyList<SummaryCardAction> Items { get; set; }
+        public AttributeDictionary Attributes { get; set; }
+    }
+}

--- a/src/GovUk.Frontend.AspNetCore/IGovUkHtmlGenerator.cs
+++ b/src/GovUk.Frontend.AspNetCore/IGovUkHtmlGenerator.cs
@@ -151,6 +151,8 @@ namespace GovUk.Frontend.AspNetCore
 
         TagBuilder GenerateSummaryList(AttributeDictionary attributes, IEnumerable<SummaryListRow> rows);
 
+        TagBuilder GenerateSummaryCard(SummaryCard summaryCard);
+
         TagBuilder GenerateTabs(
             string id,
             string title,

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/SummaryCardActionTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/SummaryCardActionTagHelper.cs
@@ -1,0 +1,48 @@
+using System.Threading.Tasks;
+using GovUk.Frontend.AspNetCore.HtmlGeneration;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace GovUk.Frontend.AspNetCore.TagHelpers
+{
+    /// <summary>
+    /// Represents an action in a GDS summary card.
+    /// </summary>
+    [HtmlTargetElement(TagName, ParentTag = SummaryCardActionsTagHelper.TagName)]
+    [OutputElementHint(ComponentGenerator.SummaryCardActionElement)]
+    public class SummaryCardActionTagHelper : TagHelper
+    {
+        internal const string TagName = "govuk-summary-card-action";
+
+        private const string VisuallyHiddenTextAttributeName = "visually-hidden-text";
+
+        /// <summary>
+        /// The destination URL for the action link.
+        /// </summary>
+        [HtmlAttributeName("href")]
+        public string Href { get; set; }
+
+        /// <summary>
+        /// The visually hidden text for the action link.
+        /// </summary>
+        [HtmlAttributeName(VisuallyHiddenTextAttributeName)]
+        public string VisuallyHiddenText { get; set; }
+
+        /// <inheritdoc/>
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+        {
+            var cardContext = context.GetContextItem<SummaryCardContext>();
+
+            var content = await output.GetChildContentAsync();
+
+            cardContext.AddAction(new SummaryCardAction
+            {
+                Attributes = output.Attributes.ToAttributeDictionary(),
+                Content = content.Snapshot(),
+                VisuallyHiddenText = VisuallyHiddenText,
+                Href = Href
+            });
+
+            output.SuppressOutput();
+        }
+    }
+}

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/SummaryCardActionsTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/SummaryCardActionsTagHelper.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using GovUk.Frontend.AspNetCore.HtmlGeneration;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace GovUk.Frontend.AspNetCore.TagHelpers
+{
+    /// <summary>
+    /// Represents the actions wrapper in a GDS summary card.
+    /// </summary>
+    [HtmlTargetElement(TagName, ParentTag = SummaryCardTagHelper.TagName)]
+    [RestrictChildren(SummaryCardActionTagHelper.TagName)]
+    [OutputElementHint(ComponentGenerator.SummaryCardActionsElement)]
+    public class SummaryCardActionsTagHelper : TagHelper
+    {
+        internal const string TagName = "govuk-summary-card-actions";
+
+        /// <inheritdoc/>
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+        {
+            var cardContext = context.GetContextItem<SummaryCardContext>();
+            cardContext.SetActionsAttributes(output.Attributes.ToAttributeDictionary());
+
+            await output.GetChildContentAsync();
+
+            output.SuppressOutput();
+        }
+    }
+}

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/SummaryCardContext.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/SummaryCardContext.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using GovUk.Frontend.AspNetCore.HtmlGeneration;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+namespace GovUk.Frontend.AspNetCore.TagHelpers
+{
+    internal class SummaryCardContext
+    {
+        public (AttributeDictionary Attributes, IHtmlContent Content)? Title { get; private set; }
+        public int HeadingLevel { get; internal set; }
+
+        private readonly List<SummaryCardAction> _actions = new();
+
+        public IReadOnlyList<SummaryCardAction> Actions => _actions;
+
+        public AttributeDictionary ActionsAttributes { get; private set; }
+
+        public void SetTitle(AttributeDictionary attributes, IHtmlContent content)
+        {
+            Guard.ArgumentNotNull(nameof(content), content);
+
+            if (Title != null)
+            {
+                throw ExceptionHelper.OnlyOneElementIsPermittedIn(
+                    SummaryCardTitleTagHelper.TagName,
+                    SummaryCardTagHelper.TagName);
+            }
+
+            Title = (attributes, content);
+        }
+
+        public void AddAction(SummaryCardAction action)
+        {
+            Guard.ArgumentNotNull(nameof(action), action);
+
+            _actions.Add(action);
+        }
+
+        public void SetActionsAttributes(AttributeDictionary attributes)
+        {
+            Guard.ArgumentNotNull(nameof(attributes), attributes);
+
+            if (ActionsAttributes != null)
+            {
+                throw ExceptionHelper.OnlyOneElementIsPermittedIn(
+                    SummaryCardActionsTagHelper.TagName,
+                    SummaryCardTagHelper.TagName);
+            }
+
+            if (_actions.Count > 0)
+            {
+                throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(
+                    SummaryCardActionsTagHelper.TagName,
+                    SummaryCardActionTagHelper.TagName);
+            }
+
+            ActionsAttributes = attributes;
+        }
+    }
+}

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/SummaryCardTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/SummaryCardTagHelper.cs
@@ -1,0 +1,66 @@
+using System.Threading.Tasks;
+using GovUk.Frontend.AspNetCore.HtmlGeneration;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace GovUk.Frontend.AspNetCore.TagHelpers
+{
+    /// <summary>
+    /// Generates a GOV.UK summary card component.
+    /// </summary>
+    [HtmlTargetElement(TagName)]
+    [RestrictChildren(SummaryListTagHelper.TagName, SummaryCardTitleTagHelper.TagName, SummaryCardActionsTagHelper.TagName)]
+    [OutputElementHint(ComponentGenerator.SummaryCardElement)]
+    public class SummaryCardTagHelper : TagHelper
+    {
+        internal const string TagName = "govuk-summary-card";
+
+        private readonly IGovUkHtmlGenerator _htmlGenerator;
+
+        /// <summary>
+        /// Creates a new <see cref="SummaryCardTagHelper"/>.
+        /// </summary>
+        public SummaryCardTagHelper()
+            : this(htmlGenerator: null)
+        {
+        }
+
+        internal SummaryCardTagHelper(IGovUkHtmlGenerator htmlGenerator)
+        {
+            _htmlGenerator = htmlGenerator ?? new ComponentGenerator();
+        }
+
+        /// <inheritdoc/>
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+        {
+            var cardContext = new SummaryCardContext();
+
+            TagHelperContent summaryList = null;
+            using (context.SetScopedContextItem(cardContext))
+            {
+                summaryList = await output.GetChildContentAsync();
+            }
+
+            var tagBuilder = _htmlGenerator.GenerateSummaryCard(new SummaryCard
+            {
+                CardAttributes = output.Attributes.ToAttributeDictionary(),
+                TitleContent = cardContext.Title?.Content,
+                TitleAttributes = cardContext.Title?.Attributes,
+                HeadingLevel = cardContext.HeadingLevel,
+                SummaryList = summaryList?.Snapshot(),
+                Actions = new SummaryCardActions
+                {
+                    Items = cardContext.Actions,
+                    Attributes = cardContext.ActionsAttributes
+                }
+            });
+
+            output.TagName = tagBuilder.TagName;
+            output.TagMode = TagMode.StartTagAndEndTag;
+
+            output.Attributes.Clear();
+            output.MergeAttributes(tagBuilder);
+            output.Content.SetHtmlContent(tagBuilder.InnerHtml);
+        }
+    }
+}

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/SummaryCardTitleTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/SummaryCardTitleTagHelper.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading.Tasks;
+using GovUk.Frontend.AspNetCore.HtmlGeneration;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace GovUk.Frontend.AspNetCore.TagHelpers
+{
+    /// <summary>
+    /// Represents the title in the GDS summary card component.
+    /// </summary>
+    [HtmlTargetElement(TagName, ParentTag = SummaryCardTagHelper.TagName)]
+    public class SummaryCardTitleTagHelper : TagHelper
+    {
+        internal const string TagName = "govuk-summary-card-title";
+        private int _headingLevel = ComponentGenerator.SummaryCardDefaultHeadingLevel;
+
+        /// <summary>
+        /// The heading level.
+        /// </summary>
+        /// <remarks>
+        /// Must be between <c>1</c> and <c>6</c> (inclusive). The default is <c>2</c>.
+        /// </remarks>
+        [HtmlAttributeName("heading-level")]
+        public int HeadingLevel
+        {
+            get => _headingLevel;
+            set
+            {
+                if (value < ComponentGenerator.SummaryCardMinHeadingLevel ||
+                    value > ComponentGenerator.SummaryCardMaxHeadingLevel)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value),
+                        $"{nameof(HeadingLevel)} must be between {ComponentGenerator.SummaryCardMinHeadingLevel} and {ComponentGenerator.SummaryCardMaxHeadingLevel}.");
+                }
+
+                _headingLevel = value;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+        {
+            var cardContext = context.GetContextItem<SummaryCardContext>();
+
+            var childContent = await output.GetChildContentAsync();
+
+            cardContext.SetTitle(output.Attributes.ToAttributeDictionary(), childContent.Snapshot());
+            cardContext.HeadingLevel = HeadingLevel;
+
+            output.SuppressOutput();
+        }
+    }
+}


### PR DESCRIPTION
I've built out support for the summary card component in our repo, so I wanted to share the relevant code with you to give you a head start when you get there.

I'm not asking you to merge this. In fact don't, because it relies on govuk-frontend 4.5.0 and you're not on that yet.

I've also written documentation following your style, but ours is in Markdown format so I haven't included it in the PR. In case it's useful you can find it at https://github.com/thepensionsregulator/govuk-frontend-aspnetcore-extensions/blob/develop/docs/components/summary-card.md