### PR TITLE
Fix pagination component bugs #255 #256

### DIFF
--- a/src/GovUk.Frontend.AspNetCore/HtmlGeneration/ComponentGenerator.Pagination.cs
+++ b/src/GovUk.Frontend.AspNetCore/HtmlGeneration/ComponentGenerator.Pagination.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
@@ -58,6 +59,7 @@ namespace GovUk.Frontend.AspNetCore.HtmlGeneration
 
                 var previousArrow = GeneratePreviousArrow();
                 link.InnerHtml.AppendHtml(previousArrow);
+                link.InnerHtml.Append(" ");
 
                 var title = new TagBuilder("span");
                 title.AddCssClass("govuk-pagination__link-title");
@@ -119,7 +121,7 @@ namespace GovUk.Frontend.AspNetCore.HtmlGeneration
                         li.MergeOptionalAttributes(paginationItem.Attributes);
                         itemLink.AddCssClass("govuk-link");
                         itemLink.AddCssClass("govuk-pagination__link");
-                        itemLink.Attributes.Add("aria-label", paginationItem.VisuallyHiddenText ?? $"Page {paginationItem.Number}");
+                        itemLink.Attributes.Add("aria-label", paginationItem.VisuallyHiddenText ?? $"Page {GetString(paginationItem.Number)}");
 
                         if (paginationItem.Href is not null)
                         {
@@ -177,6 +179,7 @@ namespace GovUk.Frontend.AspNetCore.HtmlGeneration
                 if (blockLevel)
                 {
                     link.InnerHtml.AppendHtml(nextArrow);
+                    link.InnerHtml.Append(" ");
                 }
 
                 var title = new TagBuilder("span");
@@ -207,6 +210,7 @@ namespace GovUk.Frontend.AspNetCore.HtmlGeneration
                 if (!blockLevel)
                 {
                     link.InnerHtml.AppendHtml(nextArrow);
+                    link.InnerHtml.Append(" ");
                 }
 
                 nextTagBuilder.InnerHtml.AppendHtml(link);
@@ -254,6 +258,15 @@ namespace GovUk.Frontend.AspNetCore.HtmlGeneration
                 svg.InnerHtml.AppendHtml(path);
 
                 return svg;
+            }
+        }
+
+        private static string GetString(IHtmlContent content)
+        {
+            using (var writer = new System.IO.StringWriter())
+            {
+                content.WriteTo(writer, HtmlEncoder.Default);
+                return writer.ToString();
             }
         }
     }


### PR DESCRIPTION
Adds a missing space to fix a misalignment on the `<govuk-pagination-previous />` and `<govuk-pagination-next />` components. Fixes #255.

Fixes the default `aria-label` on the `<govuk-pagination-item />` component. Fixes #256.

I would've liked to have updated your tests for these issues but when I run your ConformanceTests project I get an error (for each component): `System.IO.FileNotFoundException : Could not find fixtures file at: 'Fixtures\pagination\fixtures.json'.`

I was unable to test it in your MvcStarter example because when I run that I get an error: `System.InvalidOperationException : Could not load the embedded file manifest 'Microsoft.Extensions.FileProviders.Embedded.Manifest.xml' for assembly 'GovUk.Frontend.AspNetCore'.`

The IntegrationTests project throws the same error for each test.

I created my own temporary web app to test these changes instead.