### PR TITLE
Don't use ModelState to determine if page has errors

### DIFF
--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/ErrorSummaryTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/ErrorSummaryTagHelper.cs
@@ -1,8 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using GovUk.Frontend.AspNetCore.HtmlGeneration;
 using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.TagHelpers;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.TagHelpers;
@@ -40,6 +43,14 @@ public class ErrorSummaryTagHelper : TagHelper
     [HtmlAttributeName(DisableAutoFocusAttributeName)]
     public bool? DisableAutoFocus { get; set; }
 
+    /// <summary>
+    /// Gets the <see cref="ViewContext"/> of the executing view.
+    /// </summary>
+    [HtmlAttributeNotBound]
+    [ViewContext]
+    [DisallowNull]
+    public ViewContext? ViewContext { get; set; }
+
     /// <inheritdoc/>
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
     {
@@ -57,6 +68,8 @@ public class ErrorSummaryTagHelper : TagHelper
             output.SuppressOutput();
             return;
         }
+
+        ViewContext!.ViewData.SetPageHasErrors(true);
 
         var tagBuilder = _htmlGenerator.GenerateErrorSummary(
             DisableAutoFocus,

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FormErrorSummaryTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FormErrorSummaryTagHelper.cs
@@ -1,8 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using GovUk.Frontend.AspNetCore.HtmlGeneration;
 using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Options;
 
@@ -44,6 +47,14 @@ public class FormErrorSummaryTagHelper : TagHelper
     [HtmlAttributeName(PrependErrorSummaryAttributeName)]
     public bool? PrependErrorSummary { get; set; }
 
+    /// <summary>
+    /// Gets the <see cref="ViewContext"/> of the executing view.
+    /// </summary>
+    [HtmlAttributeNotBound]
+    [ViewContext]
+    [DisallowNull]
+    public ViewContext? ViewContext { get; set; }
+
     /// <inheritdoc/>
     public override void Init(TagHelperContext context)
     {
@@ -67,6 +78,8 @@ public class FormErrorSummaryTagHelper : TagHelper
         {
             return;
         }
+
+        ViewContext!.ViewData.SetPageHasErrors(true);
 
         var errorItems = formErrorContext.Errors.Select(i => new ErrorSummaryItem()
         {

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/TitleTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/TitleTagHelper.cs
@@ -54,7 +54,7 @@ public class TitleTagHelper : TagHelper
     {
         await base.ProcessAsync(context, output);
 
-        if (_options.PrependErrorToTitle && !string.IsNullOrEmpty(ErrorPrefix) && !ViewContext!.ModelState.IsValid)
+        if (_options.PrependErrorToTitle && !string.IsNullOrEmpty(ErrorPrefix) && ViewContext!.ViewData.GetPageHasErrors())
         {
             output.PreContent.Append(ErrorPrefix + " ");
         }

--- a/src/GovUk.Frontend.AspNetCore/ViewDataExtensions.cs
+++ b/src/GovUk.Frontend.AspNetCore/ViewDataExtensions.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+namespace GovUk.Frontend.AspNetCore;
+
+/// <summary>
+/// Extensions for <see cref="ViewDataDictionary"/>.
+/// </summary>
+public static class ViewDataExtensions
+{
+    private const string PageHasErrorsKey = $"GovUk.Frontend.AspNetCore.{nameof(PageHasErrorsKey)}";
+
+    /// <summary>
+    /// Gets whether the page has errors.
+    /// </summary>
+    /// <param name="viewData">The <see cref="ViewDataDictionary"/>.</param>
+    /// <returns><c>true</c> if the page has errors otherwise <c>false</c>.</returns>
+    public static bool GetPageHasErrors(this ViewDataDictionary viewData)
+    {
+        Guard.ArgumentNotNull(nameof(viewData), viewData);
+
+        return viewData.TryGetValue(PageHasErrorsKey, out var hasErrorsObj) && (bool)hasErrorsObj!;
+    }
+
+    /// <summary>
+    /// Sets whether the page has errors.
+    /// </summary>
+    /// <param name="viewData">The <see cref="ViewDataDictionary"/>.</param>
+    /// <param name="pageHasErrors">Whether the page has errors.</param>
+    public static void SetPageHasErrors(this ViewDataDictionary viewData, bool pageHasErrors)
+    {
+        Guard.ArgumentNotNull(nameof(viewData), viewData);
+
+        viewData[PageHasErrorsKey] = pageHasErrors;
+    }
+}

--- a/test/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ErrorSummaryTagHelperTests.cs
+++ b/test/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ErrorSummaryTagHelperTests.cs
@@ -6,6 +6,7 @@ using GovUk.Frontend.AspNetCore.TagHelpers;
 using GovUk.Frontend.AspNetCore.TestCommon;
 using HtmlAgilityPack;
 using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Xunit;
@@ -50,7 +51,10 @@ public class ErrorSummaryTagHelperTests
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var tagHelper = new ErrorSummaryTagHelper();
+        var tagHelper = new ErrorSummaryTagHelper()
+        {
+            ViewContext = new ViewContext()
+        };
 
         // Act
         await tagHelper.ProcessAsync(context, output);
@@ -111,7 +115,8 @@ public class ErrorSummaryTagHelperTests
 
         var tagHelper = new ErrorSummaryTagHelper()
         {
-            DisableAutoFocus = true
+            DisableAutoFocus = true,
+            ViewContext = new ViewContext()
         };
 
         // Act
@@ -152,7 +157,10 @@ public class ErrorSummaryTagHelperTests
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var tagHelper = new ErrorSummaryTagHelper();
+        var tagHelper = new ErrorSummaryTagHelper()
+        {
+            ViewContext = new ViewContext()
+        };
 
         // Act
         await tagHelper.ProcessAsync(context, output);
@@ -189,7 +197,10 @@ public class ErrorSummaryTagHelperTests
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var tagHelper = new ErrorSummaryTagHelper(new ComponentGenerator());
+        var tagHelper = new ErrorSummaryTagHelper(new ComponentGenerator())
+        {
+            ViewContext = new ViewContext()
+        };
 
         // Act
         await tagHelper.ProcessAsync(context, output);

--- a/test/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FormErrorSummaryTagHelperTests.cs
+++ b/test/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FormErrorSummaryTagHelperTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using GovUk.Frontend.AspNetCore.TagHelpers;
 using GovUk.Frontend.AspNetCore.TestCommon;
 using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Options;
 using Xunit;
@@ -49,7 +50,8 @@ public class FormErrorSummaryTagHelperTests
 
         var tagHelper = new FormErrorSummaryTagHelper(options)
         {
-            PrependErrorSummary = prependErrorSummary
+            PrependErrorSummary = prependErrorSummary,
+            ViewContext = new ViewContext()
         };
 
         tagHelper.Init(context);

--- a/test/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TitleTagHelperTests.cs
+++ b/test/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TitleTagHelperTests.cs
@@ -18,7 +18,7 @@ public class TitleTagHelperTests
     [InlineData(true, true, true)]
     public async Task ProcessAsync_GeneratesExpectedOutput(
         bool prependErrorToTitleOption,
-        bool modelStateHasErrors,
+        bool pageHasErrors,
         bool expectErrorInTitle)
     {
         // Arrange
@@ -43,11 +43,7 @@ public class TitleTagHelperTests
             });
 
         var viewContext = new ViewContext();
-
-        if (modelStateHasErrors)
-        {
-            viewContext.ModelState.AddModelError("Key", "An error");
-        }
+        viewContext.ViewData.SetPageHasErrors(pageHasErrors);
 
         var tagHelper = new TitleTagHelper(options)
         {


### PR DESCRIPTION
Up until now, we've used the presence of errors within `ModelState` to know whether we should prepend 'Error: ' to the page title. However, we don't require that errors go into `ModelState`; they could be explicitly rendered by using the appropriate `-error-message` tag helpers.

This change moves to using a `ViewData` entry to know whether page has errors. The two error summary-producing tag helpers have been updated to set this to `true` so effectively if the page has an error summary component we infer the page has errors. There's also a pair of public extension methods to get and set this ViewData value, respectively.