### PR TITLE
Don't parse and re-render HTML blocks provided to the component generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+Fix mangling non-conformant HTML blocks.
+
 Fix `id` attribute name on `<govuk-notification-banner>`.
 
 ## 3.4.1

--- a/src/GovUk.Frontend.AspNetCore.Docs/GovUk.Frontend.AspNetCore.Docs.csproj
+++ b/src/GovUk.Frontend.AspNetCore.Docs/GovUk.Frontend.AspNetCore.Docs.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Fluid.Core" Version="2.24.0" />
     <PackageReference Include="PuppeteerSharp" Version="20.1.3" />
+    <PackageReference Include="SoftCircuits.HtmlMonkey" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GovUk.Frontend.AspNetCore/GovUk.Frontend.AspNetCore.csproj
+++ b/src/GovUk.Frontend.AspNetCore/GovUk.Frontend.AspNetCore.csproj
@@ -76,6 +76,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Fluid.Core" Version="[2.15.0,3.0)" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.13.61">
       <PrivateAssets>all</PrivateAssets>
@@ -85,7 +86,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SoftCircuits.HtmlMonkey" Version="[3.1.0,]" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/TagHelperAdapterTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/TagHelperAdapterTests.cs
@@ -22,10 +22,10 @@ public class TagHelperAdapterTests
     }
 
     [Theory]
-    [InlineData("<br>")]
-    [InlineData("<br/>")]
-    [InlineData("<br />")]
-    public void VoidElementWithNoAttributes(string html)
+    [InlineData("<br>", TagMode.StartTagOnly)]
+    [InlineData("<br/>", TagMode.SelfClosing)]
+    [InlineData("<br />", TagMode.SelfClosing)]
+    public void VoidElementWithNoAttributes(string html, TagMode expectedTagMode)
     {
         // Arrange
 
@@ -34,7 +34,7 @@ public class TagHelperAdapterTests
 
         // Assert
         Assert.Equal("br", result.TagName);
-        Assert.Equal(TagMode.SelfClosing, result.TagMode);
+        Assert.Equal(expectedTagMode, result.TagMode);
         Assert.Empty(result.Attributes);
         Assert.Equal("", result.InnerHtml.ToHtmlString());
     }
@@ -50,6 +50,19 @@ public class TagHelperAdapterTests
 
         // Assert
         Assert.Equal("<a href=\"foo?bar=baz\">Hello world</a>", result.InnerHtml.ToHtmlString());
+    }
+
+    [Fact]
+    public void MalformedInnerHtml()
+    {
+        // Arrange
+        var html = "<div><a href=https://some.url>Hello world</div>";
+
+        // Act
+        var result = TagHelperAdapter.UnwrapComponent(html);
+
+        // Assert
+        Assert.Equal("<a href=https://some.url>Hello world", result.InnerHtml.ToHtmlString());
     }
 
     [Fact]


### PR DESCRIPTION
When we're applying the HTML from the component generator to a tag helper's output, we parse the entire HTML block in order to get the root element's tag name, tag mode and attributes. That root element's content is then re-converted back to HTML. The parser we're using is not handling some HTML, particularly attributes without quotes and is producing garbled output.

This PR removes that parser, swaps in HtmlAgilityPack and only parses the root element returned by the component generator. This means that any HTML blocks provided to us are returned 'as-is', without the parse step.