### PR TITLE
Add support for the password tag helper's show/hide customisation (previously marked TODO)

### DIFF
--- a/docs/components/password-input.md
+++ b/docs/components/password-input.md
@@ -27,12 +27,18 @@
 | `described-by` | `string` | One or more element IDs to add to the `aria-describedby` attribute of the generated `input` element. |
 | `disabled` | `bool?` | Whether the `disabled` attribute should be added to the generated `input` element. |
 | `for` | `Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression` | An expression to be evaluated against the current model. |
+| `hide-password-aria-label-text` | `string` | The button text exposed to assistive technologies, like screen readers, when the password is visible. The default is `"Hide password"`. |
+| `hide-password-text` | `string` | The button text when the password is visible. The default is `"Hide"`. |
 | `id` | `string` | The `id` attribute for the generated `input` element. If not specified then a value is generated from the `name` attribute. |
 | `ignore-modelstate-errors` | `bool?` | Whether the `Errors` for the `For` expression should be used to deduce an error message. When there are multiple errors in the `ModelErrorCollection` the first is used. |
 | `input-*` |  | Additional attributes to add to the generated `input` element. |
 | `label-class` | `string` | Additional classes for the generated `label` element. |
 | `name` | `string` | The `name` attribute for the generated `input` element. Required unless `For` is specified. |
+| `password-hidden-announcement-text` | `string` | The announcement made to screen reader users when their password has been obscured and is not visible. The default is `"Your password is hidden"`. |
+| `password-shown-announcement-text` | `string` | The announcement made to screen reader users when their password has become visible in plain text. The default is `"Your password is visible"`. |
 | `readonly` | `bool?` | Whether the `readonly` attribute should be added to the generated `input` element. |
+| `show-password-aria-label-text` | `string` | The button text exposed to assistive technologies, like screen readers, when the password is hidden. The default is `"Show password"`. |
+| `show-password-text` | `string` | The button text when the password is hidden. The default is `"Show"`. |
 | `value` | `string` | The `value` attribute for the generated `input` element. If not specified and `For` is not `null` then the value for the specified model expression will be used. |
 
 

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/PasswordInputTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/PasswordInputTagHelper.cs
@@ -45,7 +45,13 @@ public class PasswordInputTagHelper : TagHelper
     private const string IgnoreModelStateErrorsAttributeName = "ignore-modelstate-errors";
     private const string LabelClassAttributeName = "label-class";
     private const string NameAttributeName = "name";
+    private const string HidePasswordAriaLabelTextAttributeName = "hide-password-aria-label-text";
+    private const string HidePasswordTextAttributeName = "hide-password-text";
+    private const string PasswordHiddenAnnouncementTextAttributeName = "password-hidden-announcement-text";
+    private const string PasswordShownAnnouncementTextAttributeName = "password-shown-announcement-text";
     private const string ReadOnlyAttributeName = "readonly";
+    private const string ShowPasswordAriaLabelTextAttributeName = "show-password-aria-label-text";
+    private const string ShowPasswordTextAttributeName = "show-password-text";
     private const string ValueAttributeName = "value";
 
     private readonly IComponentGenerator _componentGenerator;
@@ -151,6 +157,60 @@ public class PasswordInputTagHelper : TagHelper
     /// </summary>
     [HtmlAttributeName(ReadOnlyAttributeName)]
     public bool? ReadOnly { get; set; }
+
+    /// <summary>
+    /// The button text when the password is hidden.
+    /// </summary>
+    /// <remarks>
+    /// The default is <c>&quot;Show&quot;</c>.
+    /// </remarks>
+    [HtmlAttributeName(ShowPasswordTextAttributeName)]
+    public string? ShowPasswordText { get; set; }
+
+    /// <summary>
+    /// The button text when the password is visible.
+    /// </summary>
+    /// <remarks>
+    /// The default is <c>&quot;Hide&quot;</c>.
+    /// </remarks>
+    [HtmlAttributeName(HidePasswordTextAttributeName)]
+    public string? HidePasswordText { get; set; }
+
+    /// <summary>
+    /// The button text exposed to assistive technologies, like screen readers, when the password is hidden.
+    /// </summary>
+    /// <remarks>
+    /// The default is <c>&quot;Show password&quot;</c>.
+    /// </remarks>
+    [HtmlAttributeName(ShowPasswordAriaLabelTextAttributeName)]
+    public string? ShowPasswordAriaLabelText { get; set; }
+
+    /// <summary>
+    /// The button text exposed to assistive technologies, like screen readers, when the password is visible.
+    /// </summary>
+    /// <remarks>
+    /// The default is <c>&quot;Hide password&quot;</c>.
+    /// </remarks>
+    [HtmlAttributeName(HidePasswordAriaLabelTextAttributeName)]
+    public string? HidePasswordAriaLabelText { get; set; }
+
+    /// <summary>
+    /// The announcement made to screen reader users when their password has become visible in plain text.
+    /// </summary>
+    /// <remarks>
+    /// The default is <c>&quot;Your password is visible&quot;</c>.
+    /// </remarks>
+    [HtmlAttributeName(PasswordShownAnnouncementTextAttributeName)]
+    public string? PasswordShownAnnouncementText { get; set; }
+
+    /// <summary>
+    /// The announcement made to screen reader users when their password has been obscured and is not visible.
+    /// </summary>
+    /// <remarks>
+    /// The default is <c>&quot;Your password is hidden&quot;</c>.
+    /// </remarks>
+    [HtmlAttributeName(PasswordHiddenAnnouncementTextAttributeName)]
+    public string? PasswordHiddenAnnouncementText { get; set; }
 
     /// <summary>
     /// The <c>value</c> attribute for the generated <c>input</c> element.
@@ -263,12 +323,12 @@ public class PasswordInputTagHelper : TagHelper
             Classes = classes,
             AutoComplete = AutoComplete,
             Attributes = attributes,
-            ShowPasswordText = null,  // TODO
-            HidePasswordText = null,  // TODO
-            ShowPasswordAriaLabelText = null,  // TODO
-            HidePasswordAriaLabelText = null,  // TODO
-            PasswordShownAnnouncementText = null,  // TODO
-            PasswordHiddenAnnouncementText = null,  // TODO
+            ShowPasswordText = ShowPasswordText,
+            HidePasswordText = HidePasswordText,
+            ShowPasswordAriaLabelText = ShowPasswordAriaLabelText,
+            HidePasswordAriaLabelText = HidePasswordAriaLabelText,
+            PasswordShownAnnouncementText = PasswordShownAnnouncementText,
+            PasswordHiddenAnnouncementText = PasswordHiddenAnnouncementText,
             Button = buttonOptions
         });
 

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PasswordInputTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PasswordInputTagHelperTests.cs
@@ -29,6 +29,12 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
         var dataFooAttrValue = "foo";
         var labelContent = "The label";
         var hintContent = "The hint";
+        var showPasswordText = "Reveal";
+        var hidePasswordText = "Conceal";
+        var showPasswordAriaLabelText = "Reveal your password";
+        var hidePasswordAriaLabelText = "Conceal your password";
+        var passwordShownAnnouncementText = "Your password is now visible";
+        var passwordHiddenAnnouncementText = "Your password is now hidden";
 
         var context = CreateTagHelperContext(className: className, attributes: attributes);
 
@@ -71,6 +77,12 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
             ReadOnly = readOnly,
             LabelClass = labelClass,
             ButtonClass = buttonClass,
+            ShowPasswordText = showPasswordText,
+            HidePasswordText = hidePasswordText,
+            ShowPasswordAriaLabelText = showPasswordAriaLabelText,
+            HidePasswordAriaLabelText = hidePasswordAriaLabelText,
+            PasswordShownAnnouncementText = passwordShownAnnouncementText,
+            PasswordHiddenAnnouncementText = passwordHiddenAnnouncementText,
             ViewContext = new ViewContext(),
             InputAttributes = new Dictionary<string, string?>()
             {
@@ -97,6 +109,12 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
         Assert.Null(actualOptions.ErrorMessage);
         Assert.Equal(className, actualOptions.Classes);
         Assert.Equal(autocomplete, actualOptions.AutoComplete);
+        Assert.Equal(showPasswordText, actualOptions.ShowPasswordText);
+        Assert.Equal(hidePasswordText, actualOptions.HidePasswordText);
+        Assert.Equal(showPasswordAriaLabelText, actualOptions.ShowPasswordAriaLabelText);
+        Assert.Equal(hidePasswordAriaLabelText, actualOptions.HidePasswordAriaLabelText);
+        Assert.Equal(passwordShownAnnouncementText, actualOptions.PasswordShownAnnouncementText);
+        Assert.Equal(passwordHiddenAnnouncementText, actualOptions.PasswordHiddenAnnouncementText);
 
         Assert.NotNull(actualOptions.Attributes);
         Assert.Collection(actualOptions.Attributes,


### PR DESCRIPTION
I was tracking down some unexpected issues and it turned out these properties were marked as `// TODO`: 

https://github.com/x-govuk/govuk-frontend-aspnetcore/blob/d14305f65a932bf41bb6dfc8ae61a3c40ffcc3a8/src/GovUk.Frontend.AspNetCore/TagHelpers/PasswordInputTagHelper.cs#L264-L273

I see the liquid template already has these implemented with the keys already defined, so the heavy lifting is already done - the tag helper attribute bits just needed to be plumbed together.