### PR TITLE
Add text customisation attributes to FileUploadTagHelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ The `RestoreGovUkFrontendNpmPackage`, `GovUkFrontendNpmPackageLocation` and `Cop
 In their place is `EnableGovUkFrontendSupport`, `GovUkFrontendNpmPackageDirectory`, `GovUkFrontendAssetsDirectory`, `GovUkFrontendJavaScriptDirectory` and
 `GovUkFrontendStylesheetDirectory`, enabling more fine-grained control over assets.
 
+### Tag helpers
+
+`<govuk-file-upload>` now supports attributes for customising the text used by the JavaScript-enhanced file upload component:
+`choose-files-button-text`, `drop-instruction-text`, `entered-drop-zone-text`, `left-drop-zone-text`,
+`multiple-files-chosen-text-one`, `multiple-files-chosen-text-other` and `no-file-chosen-text`.
+
 ### Fixes
 
 Fixes default navigation ID and menu button text on service navigation components.

--- a/docs/components/file-upload.md
+++ b/docs/components/file-upload.md
@@ -40,17 +40,24 @@
 
 | Attribute                  | Type              | Description                                                                                                                                                             |
 |----------------------------|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `described-by`             | `string`          | One or more element IDs to add to the `aria-describedby` attribute of the generated `input` element.                                                                    |
-| `disabled`                 | `bool`            | Whether the input should be disabled. The default is `false`.                                                                                                           |
-| `for`                      | `ModelExpression` | The model expression used to generate the `name` and `id` attributes as well as the error message content. See [documentation on forms](forms.md) for more information. |
-| `id`                       | `string`          | The `id` attribute for the generated `input` element. If not specified then a value is generated from the `name` attribute.                                             |
-| `ignore-modelstate-errors` | `bool`            | Whether ModelState errors on the ModelExpression specified by the `for` attribute should be ignored when generating an error message. The default is `false`.           |
-| `input-*`                  |                   | Additional attributes to add to the generated `input` element.                                                                                                          |
-| `javascript-enhancements`  | `bool?`           | Whether to enable JavaScript enhancements for the component.                                                                                                            |
-| `label-class`              | `string`          | Additional classes for the generated `label` element.                                                                                                                   |
-| `multiple`                 | `bool?`           | The `multiple` attribute for the generated `input` element.                                                                                                             |
-| `name`                     | `string`          | The `name` attribute for the generated `input` element. Required unless the `for` attribute is specified.                                                               |
-| `wrapper-*`                |                   | Additional attributes to add to the Javascript enhanced component's wrapper element.                                                                                    |
+| `choose-files-button-text`        | `string`          | Text for the button that opens the file picker. Only applies when JavaScript enhancements are enabled.                                                                  |
+| `described-by`                    | `string`          | One or more element IDs to add to the `aria-describedby` attribute of the generated `input` element.                                                                    |
+| `disabled`                        | `bool`            | Whether the input should be disabled. The default is `false`.                                                                                                           |
+| `drop-instruction-text`           | `string`          | Text instructing users to drop files in the drop zone. Only applies when JavaScript enhancements are enabled.                                                           |
+| `entered-drop-zone-text`          | `string`          | Text announced to screen reader users when a user drags files into the drop zone. Only applies when JavaScript enhancements are enabled.                                |
+| `for`                             | `ModelExpression` | The model expression used to generate the `name` and `id` attributes as well as the error message content. See [documentation on forms](forms.md) for more information. |
+| `id`                              | `string`          | The `id` attribute for the generated `input` element. If not specified then a value is generated from the `name` attribute.                                             |
+| `ignore-modelstate-errors`        | `bool`            | Whether ModelState errors on the ModelExpression specified by the `for` attribute should be ignored when generating an error message. The default is `false`.           |
+| `input-*`                         |                   | Additional attributes to add to the generated `input` element.                                                                                                          |
+| `javascript-enhancements`         | `bool?`           | Whether to enable JavaScript enhancements for the component.                                                                                                            |
+| `label-class`                     | `string`          | Additional classes for the generated `label` element.                                                                                                                   |
+| `left-drop-zone-text`             | `string`          | Text announced to screen reader users when a user drags files out of the drop zone. Only applies when JavaScript enhancements are enabled.                              |
+| `multiple`                        | `bool?`           | The `multiple` attribute for the generated `input` element.                                                                                                             |
+| `multiple-files-chosen-text-one`  | `string`          | Text shown when exactly one file has been chosen. Only applies when `multiple` is `true` and JavaScript enhancements are enabled.                                       |
+| `multiple-files-chosen-text-other`| `string`          | Text shown when more than one file has been chosen. Only applies when `multiple` is `true` and JavaScript enhancements are enabled.                                     |
+| `name`                            | `string`          | The `name` attribute for the generated `input` element. Required unless the `for` attribute is specified.                                                               |
+| `no-file-chosen-text`             | `string`          | Text shown when no file has been chosen. Only applies when JavaScript enhancements are enabled.                                                                         |
+| `wrapper-*`                       |                   | Additional attributes to add to the Javascript enhanced component's wrapper element.                                                                                    |
 
 ### `<govuk-file-upload-label>`
 

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FileUploadTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FileUploadTagHelper.cs
@@ -33,15 +33,22 @@ public class FileUploadTagHelper : TagHelper
     internal const string TagName = "govuk-file-upload";
 
     private const string AttributesPrefix = "input-";
+    private const string ChooseFilesButtonTextAttributeName = "choose-files-button-text";
     private const string DescribedByAttributeName = "described-by";
     private const string DisabledAttributeName = "disabled";
+    private const string DropInstructionTextAttributeName = "drop-instruction-text";
+    private const string EnteredDropZoneTextAttributeName = "entered-drop-zone-text";
     private const string ForAttributeName = "for";
     private const string IdAttributeName = "id";
     private const string IgnoreModelStateErrorsAttributeName = "ignore-modelstate-errors";
     private const string JavaScriptEnhancementsAttributeName = "javascript-enhancements";
     private const string LabelClassAttributeName = "label-class";
+    private const string LeftDropZoneTextAttributeName = "left-drop-zone-text";
     private const string MultipleAttributeName = "multiple";
+    private const string MultipleFilesChosenTextOneAttributeName = "multiple-files-chosen-text-one";
+    private const string MultipleFilesChosenTextOtherAttributeName = "multiple-files-chosen-text-other";
     private const string NameAttributeName = "name";
+    private const string NoFileChosenTextAttributeName = "no-file-chosen-text";
     private const string WrapperAttributesPrefix = "wrapper-";
 
     private readonly IComponentGenerator _componentGenerator;
@@ -127,6 +134,48 @@ public class FileUploadTagHelper : TagHelper
     /// </summary>
     [HtmlAttributeName(MultipleAttributeName)]
     public bool? Multiple { get; set; }
+
+    /// <summary>
+    /// Text for the button that opens the file picker.
+    /// </summary>
+    [HtmlAttributeName(ChooseFilesButtonTextAttributeName)]
+    public string? ChooseFilesButtonText { get; set; }
+
+    /// <summary>
+    /// Text instructing users to drop files in the drop zone.
+    /// </summary>
+    [HtmlAttributeName(DropInstructionTextAttributeName)]
+    public string? DropInstructionText { get; set; }
+
+    /// <summary>
+    /// Text announced when a user enters the drop zone while dragging files.
+    /// </summary>
+    [HtmlAttributeName(EnteredDropZoneTextAttributeName)]
+    public string? EnteredDropZoneText { get; set; }
+
+    /// <summary>
+    /// Text announced when a user leaves the drop zone while dragging files.
+    /// </summary>
+    [HtmlAttributeName(LeftDropZoneTextAttributeName)]
+    public string? LeftDropZoneText { get; set; }
+
+    /// <summary>
+    /// Text shown when exactly one file has been chosen (used when <see cref="Multiple"/> is <c>true</c>).
+    /// </summary>
+    [HtmlAttributeName(MultipleFilesChosenTextOneAttributeName)]
+    public string? MultipleFilesChosenTextOne { get; set; }
+
+    /// <summary>
+    /// Text shown when more than one file has been chosen (used when <see cref="Multiple"/> is <c>true</c>).
+    /// </summary>
+    [HtmlAttributeName(MultipleFilesChosenTextOtherAttributeName)]
+    public string? MultipleFilesChosenTextOther { get; set; }
+
+    /// <summary>
+    /// Text shown when no file has been chosen.
+    /// </summary>
+    [HtmlAttributeName(NoFileChosenTextAttributeName)]
+    public string? NoFileChosenText { get; set; }
 
     /// <summary>
     /// The <c>name</c> attribute for the generated <c>input</c> element.
@@ -218,12 +267,18 @@ public class FileUploadTagHelper : TagHelper
             ErrorMessage = errorMessageOptions,
             FormGroup = formGroupOptions,
             JavaScript = JavaScriptEnhancements,
-            ChooseFilesButtonText = null,
-            DropInstructionText = null,
-            MultipleFilesChosenText = null,
-            NoFileChosenText = null,
-            EnteredDropZoneText = null,
-            LeftDropZoneText = null,
+            ChooseFilesButtonText = ChooseFilesButtonText,
+            DropInstructionText = DropInstructionText,
+            MultipleFilesChosenText = MultipleFilesChosenTextOne is not null || MultipleFilesChosenTextOther is not null
+                ? new FileUploadOptionsMultipleFilesChosenText
+                {
+                    One = MultipleFilesChosenTextOne,
+                    Other = MultipleFilesChosenTextOther
+                }
+                : null,
+            NoFileChosenText = NoFileChosenText,
+            EnteredDropZoneText = EnteredDropZoneText,
+            LeftDropZoneText = LeftDropZoneText,
             WrapperClasses = wrapperClasses,
             WrapperAttributes = wrapperAttributes,
             Classes = classes,

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FileUploadTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FileUploadTagHelperTests.cs
@@ -712,6 +712,80 @@ public class FileUploadTagHelperTests
             });
     }
 
+    [Fact]
+    public async Task ProcessAsync_WithTextProperties_GeneratesOptionsWithTextProperties()
+    {
+        // Arrange
+        var id = "my-id";
+        var name = "my-name";
+        var labelHtml = "The label";
+        var chooseFilesButtonText = "Choose files";
+        var dropInstructionText = "Drop files here";
+        var enteredDropZoneText = "You are in the drop zone";
+        var leftDropZoneText = "You have left the drop zone";
+        var multipleFilesChosenTextOne = "1 file chosen";
+        var multipleFilesChosenTextOther = "{count} files chosen";
+        var noFileChosenText = "No file chosen";
+
+        var context = new TagHelperContext(
+            tagName: "govuk-input",
+            allAttributes: [],
+            items: new Dictionary<object, object>(),
+            uniqueId: "test");
+
+        var output = new TagHelperOutput(
+            "govuk-input",
+            attributes: [],
+            getChildContentAsync: (useCachedResult, encoder) =>
+            {
+                var inputContext = context.GetContextItem<FileUploadContext>();
+
+                inputContext.SetLabel(
+                    isPageHeading: false,
+                    attributes: [],
+                    labelHtml,
+                    FileUploadLabelTagHelper.TagName);
+
+                var tagHelperContent = new DefaultTagHelperContent();
+                return Task.FromResult<TagHelperContent>(tagHelperContent);
+            });
+
+        var modelHelperMock = new Mock<IModelHelper>();
+
+        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
+        FileUploadOptions? actualOptions = null;
+        componentGeneratorMock.Setup(mock => mock.GenerateFileUploadAsync(It.IsAny<FileUploadOptions>())).Callback<FileUploadOptions>(o => actualOptions = o);
+
+        var tagHelper = new FileUploadTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        {
+            Id = id,
+            Name = name,
+            ViewContext = new ViewContext(),
+            ChooseFilesButtonText = chooseFilesButtonText,
+            DropInstructionText = dropInstructionText,
+            EnteredDropZoneText = enteredDropZoneText,
+            LeftDropZoneText = leftDropZoneText,
+            MultipleFilesChosenTextOne = multipleFilesChosenTextOne,
+            MultipleFilesChosenTextOther = multipleFilesChosenTextOther,
+            NoFileChosenText = noFileChosenText,
+        };
+        tagHelper.Init(context);
+
+        // Act
+        await tagHelper.ProcessAsync(context, output);
+
+        // Assert
+        Assert.NotNull(actualOptions);
+        Assert.Equal(chooseFilesButtonText, actualOptions.ChooseFilesButtonText);
+        Assert.Equal(dropInstructionText, actualOptions.DropInstructionText);
+        Assert.Equal(enteredDropZoneText, actualOptions.EnteredDropZoneText);
+        Assert.Equal(leftDropZoneText, actualOptions.LeftDropZoneText);
+        Assert.NotNull(actualOptions.MultipleFilesChosenText);
+        Assert.Equal(multipleFilesChosenTextOne, actualOptions.MultipleFilesChosenText.One);
+        Assert.Equal(multipleFilesChosenTextOther, actualOptions.MultipleFilesChosenText.Other);
+        Assert.Equal(noFileChosenText, actualOptions.NoFileChosenText);
+    }
+
     private class Model
     {
         public string? SimpleProperty { get; set; }


### PR DESCRIPTION
## What

Adds tag helper attributes to `<govuk-file-upload>` for the text properties used by the JavaScript-enhanced file upload component. Previously these were always passed as `null` to `FileUploadOptions`, making them inaccessible to Razor views.

The following attributes are now supported:

| Attribute | Maps to |
|---|---|
| `choose-files-button-text` | `FileUploadOptions.ChooseFilesButtonText` |
| `drop-instruction-text` | `FileUploadOptions.DropInstructionText` |
| `entered-drop-zone-text` | `FileUploadOptions.EnteredDropZoneText` |
| `left-drop-zone-text` | `FileUploadOptions.LeftDropZoneText` |
| `multiple-files-chosen-text-one` | `FileUploadOptions.MultipleFilesChosenText.One` |
| `multiple-files-chosen-text-other` | `FileUploadOptions.MultipleFilesChosenText.Other` |
| `no-file-chosen-text` | `FileUploadOptions.NoFileChosenText` |

The `MultipleFilesChosenText` nested object is only constructed when at least one of `multiple-files-chosen-text-one` or `multiple-files-chosen-text-other` is set.

## Changes

- `FileUploadTagHelper.cs` — new properties with `[HtmlAttributeName]` and wired into `GenerateFileUploadAsync`
- `FileUploadTagHelperTests.cs` — new test covering all seven attributes
- `docs/components/file-upload.md` — API table updated with new attributes (in alphabetical order)
- `CHANGELOG.md` — entry added under Unreleased