### PR TITLE
Migrate remaining tag helper tests to use TagHelperTestBase

### DIFF
--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/AccordionItemContentTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/AccordionItemContentTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class AccordionItemContentTagHelperTests
+public class AccordionItemContentTagHelperTests : TagHelperTestBase<AccordionItemContentTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_AddsContentToContext()
@@ -13,19 +13,9 @@ public class AccordionItemContentTagHelperTests
         var accordionContext = new AccordionContext();
         var itemContext = new AccordionItemContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-accordion-item-content",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(AccordionContext), accordionContext },
-                { typeof(AccordionItemContext), itemContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [accordionContext, itemContext]);
 
-        var output = new TagHelperOutput(
-            "govuk-accordion-item-content",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -51,19 +41,9 @@ public class AccordionItemContentTagHelperTests
         var itemContext = new AccordionItemContext();
         itemContext.SetContent(new AttributeCollection(), content: new TemplateString("Existing content"));
 
-        var context = new TagHelperContext(
-            tagName: "govuk-accordion-item-content",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(AccordionContext), accordionContext },
-                { typeof(AccordionItemContext), itemContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [accordionContext, itemContext]);
 
-        var output = new TagHelperOutput(
-            "govuk-accordion-item-content",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/AccordionItemHeadingTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/AccordionItemHeadingTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class AccordionItemHeadingTagHelperTests
+public class AccordionItemHeadingTagHelperTests : TagHelperTestBase<AccordionItemHeadingTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_AddsHeadingToContext()
@@ -13,19 +13,9 @@ public class AccordionItemHeadingTagHelperTests
         var accordionContext = new AccordionContext();
         var itemContext = new AccordionItemContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-accordion-item-heading",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(AccordionContext), accordionContext },
-                { typeof(AccordionItemContext), itemContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [accordionContext, itemContext]);
 
-        var output = new TagHelperOutput(
-            "govuk-accordion-item-heading",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -51,19 +41,9 @@ public class AccordionItemHeadingTagHelperTests
         var itemContext = new AccordionItemContext();
         itemContext.SetHeading(new AttributeCollection(), content: new TemplateString("Existing heading"));
 
-        var context = new TagHelperContext(
-            tagName: "govuk-accordion-item-heading",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(AccordionContext), accordionContext },
-                { typeof(AccordionItemContext), itemContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [accordionContext, itemContext]);
 
-        var output = new TagHelperOutput(
-            "govuk-accordion-item-heading",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -89,19 +69,9 @@ public class AccordionItemHeadingTagHelperTests
         var itemContext = new AccordionItemContext();
         itemContext.SetSummary(attributes: new AttributeCollection(), content: new TemplateString("Summary"));
 
-        var context = new TagHelperContext(
-            tagName: "govuk-accordion-item-heading",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(AccordionContext), accordionContext },
-                { typeof(AccordionItemContext), itemContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [accordionContext, itemContext]);
 
-        var output = new TagHelperOutput(
-            "govuk-accordion-item-heading",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/AccordionItemSummaryTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/AccordionItemSummaryTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class AccordionItemSummaryTagHelperTests
+public class AccordionItemSummaryTagHelperTests : TagHelperTestBase<AccordionItemSummaryTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_AddsSummaryToContext()
@@ -13,19 +13,9 @@ public class AccordionItemSummaryTagHelperTests
         var accordionContext = new AccordionContext();
         var itemContext = new AccordionItemContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-accordion-item-summary",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(AccordionContext), accordionContext },
-                { typeof(AccordionItemContext), itemContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [accordionContext, itemContext]);
 
-        var output = new TagHelperOutput(
-            "govuk-accordion-item-summary",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -51,19 +41,9 @@ public class AccordionItemSummaryTagHelperTests
         var itemContext = new AccordionItemContext();
         itemContext.SetSummary(new AttributeCollection(), new TemplateString("Existing summary"));
 
-        var context = new TagHelperContext(
-            tagName: "govuk-accordion-item-summary",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(AccordionContext), accordionContext },
-                { typeof(AccordionItemContext), itemContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [accordionContext, itemContext]);
 
-        var output = new TagHelperOutput(
-            "govuk-accordion-item-summary",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/AccordionItemTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/AccordionItemTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class AccordionItemTagHelperTests
+public class AccordionItemTagHelperTests : TagHelperTestBase<AccordionItemTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_AddsItemToContext()
@@ -12,18 +12,9 @@ public class AccordionItemTagHelperTests
         // Arrange
         var accordionContext = new AccordionContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-accordion-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(AccordionContext), accordionContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: accordionContext);
 
-        var output = new TagHelperOutput(
-            "govuk-accordion-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var itemContext = context.GetContextItem<AccordionItemContext>();
@@ -57,18 +48,9 @@ public class AccordionItemTagHelperTests
         // Arrange
         var accordionContext = new AccordionContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-accordion-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(AccordionContext), accordionContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: accordionContext);
 
-        var output = new TagHelperOutput(
-            "govuk-accordion-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var itemContext = context.GetContextItem<AccordionItemContext>();
@@ -96,18 +78,9 @@ public class AccordionItemTagHelperTests
         // Arrange
         var accordionContext = new AccordionContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-accordion-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(AccordionContext), accordionContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: accordionContext);
 
-        var output = new TagHelperOutput(
-            "govuk-accordion-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var itemContext = context.GetContextItem<AccordionItemContext>();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/AccordionTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/AccordionTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class AccordionTagHelperTests
+public class AccordionTagHelperTests : TagHelperTestBase<AccordionTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_InvokesComponentGeneratorWithExpectedOptions()
@@ -19,8 +19,8 @@ public class AccordionTagHelperTests
         var showAllSectionsText = "Expand all";
         var showSectionText = "Expand";
         var showSectionAriaLabelText = "Expand this";
-        var classes = "custom-class";
-        var dataFooAttrValue = "bar";
+        var className = CreateDummyClassName();
+        var attributes = CreateDummyDataAttributes();
 
         var items = new[]
         {
@@ -39,19 +39,11 @@ public class AccordionTagHelperTests
             }
         };
 
-        var context = new TagHelperContext(
-            tagName: "govuk-accordion",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext(className: className, attributes: attributes);
 
-        var output = new TagHelperOutput(
-            "govuk-accordion",
-            attributes: new TagHelperAttributeList()
-            {
-                { "class", classes },
-                { "data-foo", dataFooAttrValue }
-            },
+        var output = CreateTagHelperOutput(
+            className: className,
+            attributes: attributes,
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var accordionContext = context.GetContextItem<AccordionContext>();
@@ -65,11 +57,9 @@ public class AccordionTagHelperTests
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        AccordionOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateAccordionAsync(It.IsAny<AccordionOptions>())).Callback<AccordionOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<AccordionOptions>(nameof(IComponentGenerator.GenerateAccordionAsync));
 
-        var tagHelper = new AccordionTagHelper(componentGeneratorMock.Object)
+        var tagHelper = new AccordionTagHelper(componentGenerator)
         {
             Id = id,
             HeadingLevel = headingLevel,
@@ -87,7 +77,7 @@ public class AccordionTagHelperTests
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(id, actualOptions.Id);
         Assert.Equal(headingLevel, actualOptions.HeadingLevel);
         Assert.Equal(rememberExpanded, actualOptions.RememberExpanded);
@@ -97,13 +87,8 @@ public class AccordionTagHelperTests
         Assert.Equal(showAllSectionsText, actualOptions.ShowAllSectionsText);
         Assert.Equal(showSectionText, actualOptions.ShowSectionText);
         Assert.Equal(showSectionAriaLabelText, actualOptions.ShowSectionAriaLabelText);
-        Assert.Equal(classes, actualOptions.Classes);
-        Assert.NotNull(actualOptions.Attributes);
-        Assert.Collection(actualOptions.Attributes, kvp =>
-        {
-            Assert.Equal("data-foo", kvp.Key);
-            Assert.Equal(dataFooAttrValue, kvp.Value);
-        });
+        Assert.Equal(className, actualOptions.Classes);
+        AssertContainsAttributes(attributes, actualOptions.Attributes);
         Assert.NotNull(actualOptions.Items);
         Assert.Equal(2, actualOptions.Items.Count);
 
@@ -131,15 +116,9 @@ public class AccordionTagHelperTests
     public async Task ProcessAsync_NoId_ThrowsInvalidOperationException()
     {
         // Arrange
-        var context = new TagHelperContext(
-            tagName: "govuk-accordion",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-accordion",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var accordionContext = context.GetContextItem<AccordionContext>();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/BackLinkTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/BackLinkTagHelperTests.cs
@@ -4,31 +4,23 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class BackLinkTagHelperTests
+public class BackLinkTagHelperTests : TagHelperTestBase<BackLinkTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_InvokesComponentGeneratorWithExpectedOptions()
     {
         // Arrange
         var href = "http://foo.com";
-        var classes = "custom-class";
-        var dataFooAttrValue = "bar";
+        var className = CreateDummyClassName();
+        var attributes = CreateDummyDataAttributes();
+        attributes.Add("href", href);
         var content = "My custom link content";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-back-link",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext(className: className, attributes: attributes);
 
-        var output = new TagHelperOutput(
-            "govuk-back-link",
-            attributes: new TagHelperAttributeList()
-            {
-                { "href", href },
-                { "class", classes },
-                { "data-foo", dataFooAttrValue }
-            },
+        var output = CreateTagHelperOutput(
+            className: className,
+            attributes: attributes,
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -36,26 +28,19 @@ public class BackLinkTagHelperTests
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        BackLinkOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateBackLinkAsync(It.IsAny<BackLinkOptions>())).Callback<BackLinkOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<BackLinkOptions>(nameof(IComponentGenerator.GenerateBackLinkAsync));
 
-        var tagHelper = new BackLinkTagHelper(componentGeneratorMock.Object);
+        var tagHelper = new BackLinkTagHelper(componentGenerator);
 
         // Act
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
-        Assert.Equal(content, actualOptions!.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(content, actualOptions.Html);
         Assert.Null(actualOptions.Text);
         Assert.Equal(href, actualOptions.Href);
-        Assert.Equal(classes, actualOptions.Classes);
-        Assert.NotNull(actualOptions.Attributes);
-        Assert.Collection(actualOptions.Attributes, kvp =>
-        {
-            Assert.Equal("data-foo", kvp.Key);
-            Assert.Equal(dataFooAttrValue, kvp.Value);
-        });
+        Assert.Equal(className, actualOptions.Classes);
+        AssertContainsAttributes(attributes, actualOptions.Attributes, except: "href");
     }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/BreadcrumbsItemTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/BreadcrumbsItemTagHelperTests.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class BreadcrumbsItemTagHelperTests
+public class BreadcrumbsItemTagHelperTests : TagHelperTestBase<BreadcrumbsItemTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_NoLink_AddsItemToContext()
@@ -13,18 +13,9 @@ public class BreadcrumbsItemTagHelperTests
 
         var breadcrumbsContext = new BreadcrumbsContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-breadcrumbs-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(BreadcrumbsContext), breadcrumbsContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: breadcrumbsContext);
 
-        var output = new TagHelperOutput(
-            "govuk-breadcrumbs-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -52,14 +43,7 @@ public class BreadcrumbsItemTagHelperTests
 
         var breadcrumbsContext = new BreadcrumbsContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-breadcrumbs-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(BreadcrumbsContext), breadcrumbsContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: breadcrumbsContext);
 
         var attributes = new TagHelperAttributeList();
         var output = new TagHelperOutput(

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/BreadcrumbsTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/BreadcrumbsTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class BreadcrumbsTagHelperTests
+public class BreadcrumbsTagHelperTests : TagHelperTestBase<BreadcrumbsTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_InvokesComponentGeneratorWithExpectedOptions()
@@ -31,15 +31,9 @@ public class BreadcrumbsTagHelperTests
         var collapseOnMobile = true;
         var labelText = "Label text";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-breadcrumbs",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-breadcrumbs",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var breadcrumbsContext = context.GetContextItem<BreadcrumbsContext>();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/BreadcrumbsTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/BreadcrumbsTagHelperTests.cs
@@ -47,11 +47,9 @@ public class BreadcrumbsTagHelperTests : TagHelperTestBase<BreadcrumbsTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        BreadcrumbsOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateBreadcrumbsAsync(It.IsAny<BreadcrumbsOptions>())).Callback<BreadcrumbsOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<BreadcrumbsOptions>(nameof(IComponentGenerator.GenerateBreadcrumbsAsync));
 
-        var tagHelper = new BreadcrumbsTagHelper(componentGeneratorMock.Object)
+        var tagHelper = new BreadcrumbsTagHelper(componentGenerator)
         {
             CollapseOnMobile = collapseOnMobile,
             LabelText = labelText,
@@ -62,7 +60,7 @@ public class BreadcrumbsTagHelperTests : TagHelperTestBase<BreadcrumbsTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(collapseOnMobile, actualOptions.CollapseOnMobile);
         Assert.NotNull(actualOptions.Items);
         Assert.Collection(

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ButtonLinkTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ButtonLinkTagHelperTests.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class ButtonLinkTagHelperTests
+public class ButtonLinkTagHelperTests : TagHelperTestBase<ButtonLinkTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_InvokesComponentGeneratorWithExpectedOptions()
@@ -14,24 +14,16 @@ public class ButtonLinkTagHelperTests
         var id = "my-button";
         var isStartButton = true;
         var href = "http://foo.com";
-        var classes = "custom-class";
-        var dataFooAttrValue = "bar";
+        var className = CreateDummyClassName();
+        var attributes = CreateDummyDataAttributes();
+        attributes.Add("href", href);
         var content = "Button text";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-button-link",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext(className: className, attributes: attributes);
 
-        var output = new TagHelperOutput(
-            "govuk-button-link",
-            attributes: new TagHelperAttributeList()
-            {
-                { "href", href },
-                { "class", classes },
-                { "data-foo", dataFooAttrValue },
-            },
+        var output = CreateTagHelperOutput(
+            className: className,
+            attributes: attributes,
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -39,11 +31,9 @@ public class ButtonLinkTagHelperTests
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        ButtonOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateButtonAsync(It.IsAny<ButtonOptions>())).Callback<ButtonOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<ButtonOptions>(nameof(IComponentGenerator.GenerateButtonAsync));
 
-        var tagHelper = new ButtonLinkTagHelper(componentGeneratorMock.Object)
+        var tagHelper = new ButtonLinkTagHelper(componentGenerator)
         {
             Id = id,
             IsStartButton = isStartButton,
@@ -53,8 +43,8 @@ public class ButtonLinkTagHelperTests
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
-        Assert.Equal("a", actualOptions!.Element);
+        var actualOptions = getActualOptions();
+        Assert.Equal("a", actualOptions.Element);
         Assert.Equal(HtmlEncoder.Default.Encode(content), actualOptions.Html);
         Assert.Null(actualOptions.Text);
         Assert.Null(actualOptions.Name);
@@ -62,9 +52,8 @@ public class ButtonLinkTagHelperTests
         Assert.Null(actualOptions.Value);
         Assert.Null(actualOptions.Disabled);
         Assert.Equal(href, actualOptions.Href);
-        Assert.Equal(classes, actualOptions.Classes);
-        Assert.NotNull(actualOptions.Attributes);
-        Assert.Contains(actualOptions.Attributes, kvp => kvp.Key == "data-foo" && kvp.Value == dataFooAttrValue);
+        Assert.Equal(className, actualOptions.Classes);
+        AssertContainsAttributes(attributes, actualOptions.Attributes, except: "href");
         Assert.Null(actualOptions.PreventDoubleClick);
         Assert.Equal(isStartButton, actualOptions.IsStartButton);
         Assert.Equal(id, actualOptions.Id);

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ButtonTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ButtonTagHelperTests.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class ButtonTagHelperTests
+public class ButtonTagHelperTests : TagHelperTestBase<ButtonTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_InvokesComponentGeneratorWithExpectedOptions()
@@ -18,23 +18,15 @@ public class ButtonTagHelperTests
         var preventDoubleClick = true;
         var type = "button";
         var value = "Value";
-        var classes = "custom-class";
-        var dataFooAttrValue = "bar";
+        var className = CreateDummyClassName();
+        var attributes = CreateDummyDataAttributes();
         var content = "Button text";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-button",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext(className: className, attributes: attributes);
 
-        var output = new TagHelperOutput(
-            "govuk-button",
-            attributes: new TagHelperAttributeList()
-            {
-                { "class", classes },
-                { "data-foo", dataFooAttrValue },
-            },
+        var output = CreateTagHelperOutput(
+            className: className,
+            attributes: attributes,
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -42,11 +34,9 @@ public class ButtonTagHelperTests
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        ButtonOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateButtonAsync(It.IsAny<ButtonOptions>())).Callback<ButtonOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<ButtonOptions>(nameof(IComponentGenerator.GenerateButtonAsync));
 
-        var tagHelper = new ButtonTagHelper(componentGeneratorMock.Object)
+        var tagHelper = new ButtonTagHelper(componentGenerator)
         {
             Disabled = disabled,
             Id = id,
@@ -61,8 +51,8 @@ public class ButtonTagHelperTests
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
-        Assert.Equal("button", actualOptions!.Element);
+        var actualOptions = getActualOptions();
+        Assert.Equal("button", actualOptions.Element);
         Assert.Equal(HtmlEncoder.Default.Encode(content), actualOptions.Html);
         Assert.Null(actualOptions.Text);
         Assert.Equal(name, actualOptions.Name);
@@ -70,9 +60,8 @@ public class ButtonTagHelperTests
         Assert.Equal(value, actualOptions.Value);
         Assert.Equal(disabled, actualOptions.Disabled);
         Assert.Null(actualOptions.Href);
-        Assert.Equal(classes, actualOptions.Classes);
-        Assert.NotNull(actualOptions.Attributes);
-        Assert.Contains(actualOptions.Attributes, kvp => kvp.Key == "data-foo" && kvp.Value == dataFooAttrValue);
+        Assert.Equal(className, actualOptions.Classes);
+        AssertContainsAttributes(attributes, actualOptions.Attributes);
         Assert.Equal(preventDoubleClick, actualOptions.PreventDoubleClick);
         Assert.Equal(isStartButton, actualOptions.IsStartButton);
         Assert.Equal(id, actualOptions.Id);

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CharacterCountTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CharacterCountTagHelperTests.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class CharacterCountTagHelperTests
+public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_InvokesComponentGeneratorWithExpectedOptions()
@@ -34,15 +34,9 @@ public class CharacterCountTagHelperTests
         var labelHtml = "The label";
         var hintHtml = "The hint";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-character-count",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-character-count",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var characterCountContext = context.GetContextItem<CharacterCountContext>();
@@ -143,15 +137,9 @@ public class CharacterCountTagHelperTests
         var maxWords = 42;
         var labelHtml = "The label";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-character-count",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-character-count",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var characterCountContext = context.GetContextItem<CharacterCountContext>();
@@ -199,15 +187,9 @@ public class CharacterCountTagHelperTests
         var errorVht = "visually hidden text";
         var errorDataFooAttribute = "bar";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-character-count",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-character-count",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var characterCountContext = context.GetContextItem<CharacterCountContext>();
@@ -269,15 +251,9 @@ public class CharacterCountTagHelperTests
         var description = "The hint";
         var modelStateError = "The error message";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-character-count",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-character-count",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -351,15 +327,9 @@ public class CharacterCountTagHelperTests
         var modelStateDisplayName = "ModelState label";
         var value = "Explicit value";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-character-count",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-character-count",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var characterCountContext = context.GetContextItem<CharacterCountContext>();
@@ -420,15 +390,9 @@ public class CharacterCountTagHelperTests
         var modelStateDisplayName = "ModelState label";
         var labelHtml = "Explicit label";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-character-count",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-character-count",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var characterCountContext = context.GetContextItem<CharacterCountContext>();
@@ -494,15 +458,9 @@ public class CharacterCountTagHelperTests
         var modelStateDescription = "The hint";
         var hintHtml = "Explicit hint";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-character-count",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-character-count",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var characterCountContext = context.GetContextItem<CharacterCountContext>();
@@ -568,15 +526,9 @@ public class CharacterCountTagHelperTests
         var modelStateError = "ModelState error";
         var errorHtml = "Explicit error";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-character-count",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-character-count",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var characterCountContext = context.GetContextItem<CharacterCountContext>();
@@ -648,15 +600,9 @@ public class CharacterCountTagHelperTests
         var displayName = "The label";
         var modelStateError = "ModelState error";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-character-count",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-character-count",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -722,15 +668,9 @@ public class CharacterCountTagHelperTests
         var modelStateError = "ModelState error";
         var errorHtml = "Explicit error";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-character-count",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-character-count",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var characterCountContext = context.GetContextItem<CharacterCountContext>();
@@ -804,15 +744,9 @@ public class CharacterCountTagHelperTests
         var labelHtml = "The label";
         var errorHtml = "The error message";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-character-count",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-character-count",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var characterCountContext = context.GetContextItem<CharacterCountContext>();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CharacterCountTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CharacterCountTagHelperTests.cs
@@ -60,11 +60,9 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
 
         var modelHelperMock = new Mock<IModelHelper>();
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        CharacterCountOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateCharacterCountAsync(It.IsAny<CharacterCountOptions>())).Callback<CharacterCountOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<CharacterCountOptions>(nameof(IComponentGenerator.GenerateCharacterCountAsync));
 
-        var tagHelper = new CharacterCountTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new CharacterCountTagHelper(componentGenerator, modelHelperMock.Object)
         {
             Id = id,
             Name = name,
@@ -98,7 +96,7 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(id, actualOptions.Id);
         Assert.Equal(name, actualOptions.Name);
         Assert.Equal(rows, actualOptions.Rows);
@@ -156,11 +154,9 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
 
         var modelHelperMock = new Mock<IModelHelper>();
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        CharacterCountOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateCharacterCountAsync(It.IsAny<CharacterCountOptions>())).Callback<CharacterCountOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<CharacterCountOptions>(nameof(IComponentGenerator.GenerateCharacterCountAsync));
 
-        var tagHelper = new CharacterCountTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new CharacterCountTagHelper(componentGenerator, modelHelperMock.Object)
         {
             Id = id,
             Name = name,
@@ -172,7 +168,7 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(maxWords, actualOptions.MaxWords);
     }
 
@@ -215,11 +211,9 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
 
         var modelHelperMock = new Mock<IModelHelper>();
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        CharacterCountOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateCharacterCountAsync(It.IsAny<CharacterCountOptions>())).Callback<CharacterCountOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<CharacterCountOptions>(nameof(IComponentGenerator.GenerateCharacterCountAsync));
 
-        var tagHelper = new CharacterCountTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new CharacterCountTagHelper(componentGenerator, modelHelperMock.Object)
         {
             Id = id,
             Name = name,
@@ -231,7 +225,8 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions?.ErrorMessage);
+        var actualOptions = getActualOptions();
+        Assert.NotNull(actualOptions.ErrorMessage);
         Assert.Equal(errorHtml, actualOptions.ErrorMessage.Html);
         Assert.Equal(errorVht, actualOptions.ErrorMessage.VisuallyHiddenText);
         Assert.NotNull(actualOptions.ErrorMessage.Attributes);
@@ -295,11 +290,9 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        CharacterCountOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateCharacterCountAsync(It.IsAny<CharacterCountOptions>())).Callback<CharacterCountOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<CharacterCountOptions>(nameof(IComponentGenerator.GenerateCharacterCountAsync));
 
-        var tagHelper = new CharacterCountTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new CharacterCountTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = TestUtils.CreateViewContext()
@@ -310,7 +303,7 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.NotNull(actualOptions.Id);
         Assert.NotNull(actualOptions.Name);
         Assert.Equal(modelStateValue, actualOptions.Value);
@@ -364,11 +357,9 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        CharacterCountOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateCharacterCountAsync(It.IsAny<CharacterCountOptions>())).Callback<CharacterCountOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<CharacterCountOptions>(nameof(IComponentGenerator.GenerateCharacterCountAsync));
 
-        var tagHelper = new CharacterCountTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new CharacterCountTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = new ViewContext(),
@@ -379,7 +370,8 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal(value, actualOptions?.Value);
+        var actualOptions = getActualOptions();
+        Assert.Equal(value, actualOptions.Value);
     }
 
     [Fact]
@@ -431,11 +423,9 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        CharacterCountOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateCharacterCountAsync(It.IsAny<CharacterCountOptions>())).Callback<CharacterCountOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<CharacterCountOptions>(nameof(IComponentGenerator.GenerateCharacterCountAsync));
 
-        var tagHelper = new CharacterCountTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new CharacterCountTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = new ViewContext(),
@@ -446,7 +436,8 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal(labelHtml, actualOptions?.Label?.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(labelHtml, actualOptions.Label?.Html);
     }
 
     [Fact]
@@ -499,11 +490,9 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        CharacterCountOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateCharacterCountAsync(It.IsAny<CharacterCountOptions>())).Callback<CharacterCountOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<CharacterCountOptions>(nameof(IComponentGenerator.GenerateCharacterCountAsync));
 
-        var tagHelper = new CharacterCountTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new CharacterCountTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = new ViewContext(),
@@ -514,7 +503,8 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal(hintHtml, actualOptions?.Hint?.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(hintHtml, actualOptions.Hint?.Html);
     }
 
     [Fact]
@@ -574,11 +564,9 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        CharacterCountOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateCharacterCountAsync(It.IsAny<CharacterCountOptions>())).Callback<CharacterCountOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<CharacterCountOptions>(nameof(IComponentGenerator.GenerateCharacterCountAsync));
 
-        var tagHelper = new CharacterCountTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new CharacterCountTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = TestUtils.CreateViewContext()
@@ -589,7 +577,8 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal(errorHtml, actualOptions?.ErrorMessage?.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(errorHtml, actualOptions.ErrorMessage?.Html);
     }
 
     [Fact]
@@ -640,11 +629,9 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        CharacterCountOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateCharacterCountAsync(It.IsAny<CharacterCountOptions>())).Callback<CharacterCountOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<CharacterCountOptions>(nameof(IComponentGenerator.GenerateCharacterCountAsync));
 
-        var tagHelper = new CharacterCountTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new CharacterCountTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = new ViewContext(),
@@ -656,7 +643,8 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Null(actualOptions?.ErrorMessage);
+        var actualOptions = getActualOptions();
+        Assert.Null(actualOptions.ErrorMessage);
     }
 
     [Fact]
@@ -716,11 +704,9 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        CharacterCountOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateCharacterCountAsync(It.IsAny<CharacterCountOptions>())).Callback<CharacterCountOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<CharacterCountOptions>(nameof(IComponentGenerator.GenerateCharacterCountAsync));
 
-        var tagHelper = new CharacterCountTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new CharacterCountTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             IgnoreModelStateErrors = true,
@@ -732,7 +718,8 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal(errorHtml, actualOptions?.ErrorMessage?.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(errorHtml, actualOptions.ErrorMessage?.Html);
     }
 
     [Fact]
@@ -769,11 +756,9 @@ public class CharacterCountTagHelperTests : TagHelperTestBase<CharacterCountTagH
 
         var modelHelperMock = new Mock<IModelHelper>();
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        CharacterCountOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateCharacterCountAsync(It.IsAny<CharacterCountOptions>())).Callback<CharacterCountOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<CharacterCountOptions>(nameof(IComponentGenerator.GenerateCharacterCountAsync));
 
-        var tagHelper = new CharacterCountTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new CharacterCountTagHelper(componentGenerator, modelHelperMock.Object)
         {
             Id = id,
             Name = name,

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CharacterCountValueTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CharacterCountValueTagHelperTests.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class CharacterCountValueTagHelperTests
+public class CharacterCountValueTagHelperTests : TagHelperTestBase<CharacterCountValueTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_SetsValueOnContext()
@@ -11,18 +11,9 @@ public class CharacterCountValueTagHelperTests
         // Arrange
         var characterCountContext = new CharacterCountContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-character-count-value",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CharacterCountContext), characterCountContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: characterCountContext);
 
-        var output = new TagHelperOutput(
-            "govuk-character-count-value",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesFieldsetLegendTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesFieldsetLegendTagHelperTests.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class CheckboxesFieldsetLegendTagHelperTests
+public class CheckboxesFieldsetLegendTagHelperTests : TagHelperTestBase<CheckboxesFieldsetLegendTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_AddsLegendToContext()
@@ -13,18 +13,9 @@ public class CheckboxesFieldsetLegendTagHelperTests
         // Arrange
         var fieldsetContext = new CheckboxesFieldsetContext(describedBy: null, @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes-fieldset-legend",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CheckboxesFieldsetContext), fieldsetContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: fieldsetContext);
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes-fieldset-legend",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -57,18 +48,9 @@ public class CheckboxesFieldsetLegendTagHelperTests
             html: new HtmlString("Existing legend"),
             CheckboxesFieldsetLegendTagHelper.TagName);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes-fieldset-legend",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CheckboxesFieldsetContext), fieldsetContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: fieldsetContext);
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes-fieldset-legend",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesFieldsetTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesFieldsetTagHelperTests.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class CheckboxesFieldsetTagHelperTests
+public class CheckboxesFieldsetTagHelperTests : TagHelperTestBase<CheckboxesFieldsetTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_AddsFieldsetToContext()
@@ -13,18 +13,9 @@ public class CheckboxesFieldsetTagHelperTests
         // Arrange
         var checkboxesContext = new CheckboxesContext(name: null, @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes-fieldset",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CheckboxesContext), checkboxesContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: checkboxesContext);
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes-fieldset",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var fieldsetContext = context.GetContextItem<CheckboxesFieldsetContext>();
@@ -57,18 +48,9 @@ public class CheckboxesFieldsetTagHelperTests
         checkboxesFieldsetContext.SetLegend(isPageHeading: false, attributes: new AttributeCollection(), html: new HtmlString("Existing legend"), CheckboxesFieldsetLegendTagHelper.TagName);
         checkboxesContext.CloseFieldset();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes-fieldset",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CheckboxesContext), checkboxesContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: checkboxesContext);
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes-fieldset",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var fieldsetContext = context.GetContextItem<CheckboxesFieldsetContext>();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesItemConditionalTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesItemConditionalTagHelperTests.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class CheckboxesItemConditionalTagHelperTests
+public class CheckboxesItemConditionalTagHelperTests : TagHelperTestBase<CheckboxesItemConditionalTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_SetsConditionalOnContext()
@@ -11,18 +11,9 @@ public class CheckboxesItemConditionalTagHelperTests
         // Arrange
         var checkboxesItemContext = new CheckboxesItemContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes-item-Conditional",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CheckboxesItemContext), checkboxesItemContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: checkboxesItemContext);
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes-item-Conditional",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesItemDividerTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesItemDividerTagHelperTests.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class CheckboxesItemDividerTagHelperTests
+public class CheckboxesItemDividerTagHelperTests : TagHelperTestBase<CheckboxesItemDividerTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_AddsDividerToContextItems()
@@ -13,18 +13,9 @@ public class CheckboxesItemDividerTagHelperTests
         // Arrange
         var checkboxesContext = new CheckboxesContext(name: null, @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes-divider",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CheckboxesContext), checkboxesContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: checkboxesContext);
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes-divider",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesItemHintTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesItemHintTagHelperTests.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class CheckboxesItemHintTagHelperTests
+public class CheckboxesItemHintTagHelperTests : TagHelperTestBase<CheckboxesItemHintTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_SetsHintOnContext()
@@ -11,18 +11,9 @@ public class CheckboxesItemHintTagHelperTests
         // Arrange
         var checkboxesItemContext = new CheckboxesItemContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes-item-hint",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CheckboxesItemContext), checkboxesItemContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: checkboxesItemContext);
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes-item-hint",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesItemTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesItemTagHelperTests.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class CheckboxesItemTagHelperTests
+public class CheckboxesItemTagHelperTests : TagHelperTestBase<CheckboxesItemTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_AddsItemToContext()
@@ -15,19 +15,9 @@ public class CheckboxesItemTagHelperTests
         // Arrange
         var checkboxesContext = new CheckboxesContext(name: "test", @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CheckboxesContext), checkboxesContext },
-                { typeof(CheckboxesItemContext), new CheckboxesItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [checkboxesContext, new CheckboxesItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -66,19 +56,9 @@ public class CheckboxesItemTagHelperTests
         // Arrange
         var checkboxesContext = new CheckboxesContext(name: "test", @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CheckboxesContext), checkboxesContext },
-                { typeof(CheckboxesItemContext), new CheckboxesItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [checkboxesContext, new CheckboxesItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -101,19 +81,9 @@ public class CheckboxesItemTagHelperTests
         // Arrange
         var checkboxesContext = new CheckboxesContext(name: null, @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CheckboxesContext), checkboxesContext },
-                { typeof(CheckboxesItemContext), new CheckboxesItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [checkboxesContext, new CheckboxesItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -139,19 +109,9 @@ public class CheckboxesItemTagHelperTests
         // Arrange
         var checkboxesContext = new CheckboxesContext(name: "parent", @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CheckboxesContext), checkboxesContext },
-                { typeof(CheckboxesItemContext), new CheckboxesItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [checkboxesContext, new CheckboxesItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -188,19 +148,9 @@ public class CheckboxesItemTagHelperTests
 
         var checkboxesContext = new CheckboxesContext(name: "test", @for: new ModelExpression(modelExpression, modelExplorer));
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CheckboxesContext), checkboxesContext },
-                { typeof(CheckboxesItemContext), new CheckboxesItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [checkboxesContext, new CheckboxesItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -245,19 +195,9 @@ public class CheckboxesItemTagHelperTests
 
         var checkboxesContext = new CheckboxesContext(name: "test", @for: new ModelExpression(modelExpression, modelExplorer));
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CheckboxesContext), checkboxesContext },
-                { typeof(CheckboxesItemContext), new CheckboxesItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [checkboxesContext, new CheckboxesItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -305,19 +245,9 @@ public class CheckboxesItemTagHelperTests
 
         var checkboxesContext = new CheckboxesContext(name: "test", @for: new ModelExpression(modelExpression, modelExplorer));
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CheckboxesContext), checkboxesContext },
-                { typeof(CheckboxesItemContext), new CheckboxesItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [checkboxesContext, new CheckboxesItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -359,19 +289,9 @@ public class CheckboxesItemTagHelperTests
 
         var checkboxesContext = new CheckboxesContext(name: "test", @for: new ModelExpression(modelExpression, modelExplorer));
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CheckboxesContext), checkboxesContext },
-                { typeof(CheckboxesItemContext), new CheckboxesItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [checkboxesContext, new CheckboxesItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -403,19 +323,9 @@ public class CheckboxesItemTagHelperTests
         // Arrange
         var checkboxesContext = new CheckboxesContext(name: "test", @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CheckboxesContext), checkboxesContext },
-                { typeof(CheckboxesItemContext), new CheckboxesItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [checkboxesContext, new CheckboxesItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var itemContext = context.GetContextItem<CheckboxesItemContext>();
@@ -451,19 +361,9 @@ public class CheckboxesItemTagHelperTests
         // Arrange
         var checkboxesContext = new CheckboxesContext(name: "test", @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CheckboxesContext), checkboxesContext },
-                { typeof(CheckboxesItemContext), new CheckboxesItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [checkboxesContext, new CheckboxesItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -495,19 +395,9 @@ public class CheckboxesItemTagHelperTests
         // Arrange
         var checkboxesContext = new CheckboxesContext(name: "test", @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CheckboxesContext), checkboxesContext },
-                { typeof(CheckboxesItemContext), new CheckboxesItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [checkboxesContext, new CheckboxesItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var itemContext = context.GetContextItem<CheckboxesItemContext>();
@@ -543,19 +433,9 @@ public class CheckboxesItemTagHelperTests
         // Arrange
         var checkboxesContext = new CheckboxesContext(name: "test", @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(CheckboxesContext), checkboxesContext },
-                { typeof(CheckboxesItemContext), new CheckboxesItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [checkboxesContext, new CheckboxesItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesTagHelperTests.cs
@@ -52,12 +52,9 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
 
         output.Attributes.Add("class", className);
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        CheckboxesOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateCheckboxesAsync(It.IsAny<CheckboxesOptions>()))
-            .Callback<CheckboxesOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<CheckboxesOptions>(nameof(IComponentGenerator.GenerateCheckboxesAsync));
 
-        var tagHelper = new CheckboxesTagHelper(componentGeneratorMock.Object, new DefaultModelHelper())
+        var tagHelper = new CheckboxesTagHelper(componentGenerator, new DefaultModelHelper())
         {
             IdPrefix = idPrefix,
             Name = name,
@@ -70,7 +67,7 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(idPrefix, actualOptions.IdPrefix);
         Assert.Equal(name, actualOptions.Name);
         Assert.Equal(hintContent, actualOptions.Hint?.Html);
@@ -139,12 +136,9 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        CheckboxesOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateCheckboxesAsync(It.IsAny<CheckboxesOptions>()))
-            .Callback<CheckboxesOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<CheckboxesOptions>(nameof(IComponentGenerator.GenerateCheckboxesAsync));
 
-        var tagHelper = new CheckboxesTagHelper(componentGeneratorMock.Object, new DefaultModelHelper())
+        var tagHelper = new CheckboxesTagHelper(componentGenerator, new DefaultModelHelper())
         {
             IdPrefix = idPrefix,
             Name = name,
@@ -157,7 +151,7 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(idPrefix, actualOptions.IdPrefix);
         Assert.Equal(name, actualOptions.Name);
         Assert.Null(actualOptions.Hint);
@@ -197,12 +191,9 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        CheckboxesOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateCheckboxesAsync(It.IsAny<CheckboxesOptions>()))
-            .Callback<CheckboxesOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<CheckboxesOptions>(nameof(IComponentGenerator.GenerateCheckboxesAsync));
 
-        var tagHelper = new CheckboxesTagHelper(componentGeneratorMock.Object, new DefaultModelHelper())
+        var tagHelper = new CheckboxesTagHelper(componentGenerator, new DefaultModelHelper())
         {
             IdPrefix = idPrefix,
             Name = name,
@@ -215,7 +206,7 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(idPrefix, actualOptions.IdPrefix);
         Assert.Equal(name, actualOptions.Name);
         Assert.Single(actualOptions.Items!);
@@ -259,12 +250,9 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        CheckboxesOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateCheckboxesAsync(It.IsAny<CheckboxesOptions>()))
-            .Callback<CheckboxesOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<CheckboxesOptions>(nameof(IComponentGenerator.GenerateCheckboxesAsync));
 
-        var tagHelper = new CheckboxesTagHelper(componentGeneratorMock.Object, new DefaultModelHelper())
+        var tagHelper = new CheckboxesTagHelper(componentGenerator, new DefaultModelHelper())
         {
             IdPrefix = idPrefix,
             Name = name,
@@ -277,7 +265,7 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(idPrefix, actualOptions.IdPrefix);
         Assert.Equal(name, actualOptions.Name);
         Assert.Single(actualOptions.Items!);
@@ -323,12 +311,9 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        CheckboxesOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateCheckboxesAsync(It.IsAny<CheckboxesOptions>()))
-            .Callback<CheckboxesOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<CheckboxesOptions>(nameof(IComponentGenerator.GenerateCheckboxesAsync));
 
-        var tagHelper = new CheckboxesTagHelper(componentGeneratorMock.Object, new DefaultModelHelper())
+        var tagHelper = new CheckboxesTagHelper(componentGenerator, new DefaultModelHelper())
         {
             IdPrefix = idPrefix,
             Name = name,
@@ -341,7 +326,7 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(idPrefix, actualOptions.IdPrefix);
         Assert.Equal(name, actualOptions.Name);
         Assert.Single(actualOptions.Items!);
@@ -406,12 +391,9 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        CheckboxesOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateCheckboxesAsync(It.IsAny<CheckboxesOptions>()))
-            .Callback<CheckboxesOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<CheckboxesOptions>(nameof(IComponentGenerator.GenerateCheckboxesAsync));
 
-        var tagHelper = new CheckboxesTagHelper(componentGeneratorMock.Object, new DefaultModelHelper())
+        var tagHelper = new CheckboxesTagHelper(componentGenerator, new DefaultModelHelper())
         {
             DescribedBy = describedBy,
             IdPrefix = idPrefix,
@@ -425,7 +407,7 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(idPrefix, actualOptions.IdPrefix);
         Assert.Equal(name, actualOptions.Name);
         Assert.NotNull(actualOptions.Hint);

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesTagHelperTests.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class CheckboxesTagHelperTests
+public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_InvokesComponentGeneratorWithExpectedOptions()
@@ -16,15 +16,9 @@ public class CheckboxesTagHelperTests
         var hintContent = "The hint";
         var className = "additional-class";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var checkboxesContext = context.GetContextItem<CheckboxesContext>();
@@ -110,15 +104,9 @@ public class CheckboxesTagHelperTests
         var name = "testcheckboxes";
         var errorContent = "An error";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var checkboxesContext = context.GetContextItem<CheckboxesContext>();
@@ -187,15 +175,9 @@ public class CheckboxesTagHelperTests
         var name = "testcheckboxes";
         var itemHintContent = "First item hint";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var checkboxesContext = context.GetContextItem<CheckboxesContext>();
@@ -255,15 +237,9 @@ public class CheckboxesTagHelperTests
         var name = "testcheckboxes";
         var conditionalContent = "Item 1 conditional";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var checkboxesContext = context.GetContextItem<CheckboxesContext>();
@@ -324,15 +300,9 @@ public class CheckboxesTagHelperTests
         var name = "testcheckboxes";
         var conditionalContent = "Item 1 conditional";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var checkboxesContext = context.GetContextItem<CheckboxesContext>();
@@ -396,15 +366,9 @@ public class CheckboxesTagHelperTests
         var hintContent = "The hint";
         var legendContent = "Legend";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-checkboxes",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-checkboxes",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var checkboxesContext = context.GetContextItem<CheckboxesContext>();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/DetailsSummaryTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/DetailsSummaryTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class DetailsSummaryTagHelperTests
+public class DetailsSummaryTagHelperTests : TagHelperTestBase<DetailsSummaryTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_SetsContentOnContext()
@@ -12,18 +12,9 @@ public class DetailsSummaryTagHelperTests
         // Arrange
         var detailsContext = new DetailsContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-details-summary",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(DetailsContext), detailsContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: detailsContext);
 
-        var output = new TagHelperOutput(
-            "govuk-details-summary",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -47,18 +38,9 @@ public class DetailsSummaryTagHelperTests
         var detailsContext = new DetailsContext();
         detailsContext.SetSummary([], new HtmlString("The summary"));
 
-        var context = new TagHelperContext(
-            tagName: "govuk-details-summary",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(DetailsContext), detailsContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: detailsContext);
 
-        var output = new TagHelperOutput(
-            "govuk-details-summary",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -83,18 +65,9 @@ public class DetailsSummaryTagHelperTests
         var detailsContext = new DetailsContext();
         detailsContext.SetText([], new HtmlString("The text"));
 
-        var context = new TagHelperContext(
-            tagName: "govuk-details-summary",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(DetailsContext), detailsContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: detailsContext);
 
-        var output = new TagHelperOutput(
-            "govuk-details-summary",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/DetailsTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/DetailsTagHelperTests.cs
@@ -5,21 +5,15 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class DetailsTagHelperTests
+public class DetailsTagHelperTests : TagHelperTestBase<DetailsTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_GeneratesExpectedOutput()
     {
         // Arrange
-        var context = new TagHelperContext(
-            tagName: "govuk-details",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-details",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var detailsContext = (DetailsContext)context.Items[typeof(DetailsContext)];
@@ -56,15 +50,9 @@ public class DetailsTagHelperTests
     public async Task ProcessAsync_WithOpenSpecified_AddsOpenAttributeToOutput()
     {
         // Arrange
-        var context = new TagHelperContext(
-            tagName: "govuk-details",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-details",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var detailsContext = (DetailsContext)context.Items[typeof(DetailsContext)];
@@ -98,15 +86,9 @@ public class DetailsTagHelperTests
     public async Task ProcessAsync_MissingSummary_ThrowsInvalidOperationException()
     {
         // Arrange
-        var context = new TagHelperContext(
-            tagName: "govuk-details",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-details",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var detailsContext = (DetailsContext)context.Items[typeof(DetailsContext)];
@@ -133,15 +115,9 @@ public class DetailsTagHelperTests
     public async Task ProcessAsync_MissingText_ThrowsInvalidOperationException()
     {
         // Arrange
-        var context = new TagHelperContext(
-            tagName: "govuk-details",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-details",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var detailsContext = (DetailsContext)context.Items[typeof(DetailsContext)];
@@ -171,15 +147,9 @@ public class DetailsTagHelperTests
     public async Task ProcessAsync_WithSummaryAttributes_IncludesAttributesInOutput()
     {
         // Arrange
-        var context = new TagHelperContext(
-            tagName: "govuk-details",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-details",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var detailsContext = (DetailsContext)context.Items[typeof(DetailsContext)];
@@ -213,15 +183,9 @@ public class DetailsTagHelperTests
     public async Task ProcessAsync_WithTextAttributes_IncludesAttributesInOutput()
     {
         // Arrange
-        var context = new TagHelperContext(
-            tagName: "govuk-details",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-details",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var detailsContext = (DetailsContext)context.Items[typeof(DetailsContext)];

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/DetailsTextTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/DetailsTextTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class DetailsTextTagHelperTests
+public class DetailsTextTagHelperTests : TagHelperTestBase<DetailsTextTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_SetsContentOnContext()
@@ -13,18 +13,9 @@ public class DetailsTextTagHelperTests
         var detailsContext = new DetailsContext();
         detailsContext.SetSummary([], new HtmlString("The summary"));
 
-        var context = new TagHelperContext(
-            tagName: "govuk-details-text",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(DetailsContext), detailsContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: detailsContext);
 
-        var output = new TagHelperOutput(
-            "govuk-details-text",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -49,18 +40,9 @@ public class DetailsTextTagHelperTests
         detailsContext.SetSummary([], new HtmlString("The summary"));
         detailsContext.SetText([], new HtmlString("The text"));
 
-        var context = new TagHelperContext(
-            tagName: "govuk-details-text",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(DetailsContext), detailsContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: detailsContext);
 
-        var output = new TagHelperOutput(
-            "govuk-details-text",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ErrorMessageTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ErrorMessageTagHelperTests.cs
@@ -6,21 +6,15 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class ErrorMessageTagHelperTests
+public class ErrorMessageTagHelperTests : TagHelperTestBase<ErrorMessageTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_GeneratesExpectedOutput()
     {
         // Arrange
-        var context = new TagHelperContext(
-            tagName: "govuk-error-message",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-error-message",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -47,15 +41,9 @@ public class ErrorMessageTagHelperTests
     public async Task ProcessAsync_WithVisuallyHiddenTextSpecified_GeneratesExpectedOutput()
     {
         // Arrange
-        var context = new TagHelperContext(
-            tagName: "govuk-error-message",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-error-message",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -85,23 +73,15 @@ public class ErrorMessageTagHelperTests
     public async Task ProcessAsync_AspForSpecified_GeneratesExpectedContent()
     {
         // Arrange
-        var context = new TagHelperContext(
-            tagName: "govuk-error-message",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-error-message",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
-            })
-        {
-            TagMode = TagMode.SelfClosing
-        };
+            },
+            tagMode: TagMode.SelfClosing);
 
         var modelHelperMock = new Mock<IModelHelper>();
 
@@ -138,23 +118,15 @@ public class ErrorMessageTagHelperTests
     public async Task ProcessAsync_AspForSpecifiedButNoError_GeneratesNoOutput()
     {
         // Arrange
-        var context = new TagHelperContext(
-            tagName: "govuk-error-message",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-error-message",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
-            })
-        {
-            TagMode = TagMode.SelfClosing
-        };
+            },
+            tagMode: TagMode.SelfClosing);
 
         var modelHelperMock = new Mock<IModelHelper>();
 
@@ -185,23 +157,15 @@ public class ErrorMessageTagHelperTests
     public async Task ProcessAsync_NoAspForOrContent_ThrowsInvalidOperationException()
     {
         // Arrange
-        var context = new TagHelperContext(
-            tagName: "govuk-error-message",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-error-message",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
-            })
-        {
-            TagMode = TagMode.SelfClosing
-        };
+            },
+            tagMode: TagMode.SelfClosing);
 
         var htmlHelper = new Mock<IHtmlHelper>();
 

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ErrorSummaryDescriptionTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ErrorSummaryDescriptionTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class ErrorSummaryDescriptionTagHelperTests
+public class ErrorSummaryDescriptionTagHelperTests : TagHelperTestBase<ErrorSummaryDescriptionTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_AddsDescriptionToContext()
@@ -14,18 +14,9 @@ public class ErrorSummaryDescriptionTagHelperTests
 
         var errorSummaryContext = new ErrorSummaryContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-error-summary-description",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(ErrorSummaryContext), errorSummaryContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: errorSummaryContext);
 
-        var output = new TagHelperOutput(
-            "govuk-error-summary-description",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ErrorSummaryTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ErrorSummaryTagHelperTests.cs
@@ -47,11 +47,9 @@ public class ErrorSummaryTagHelperTests : TagHelperTestBase<ErrorSummaryTagHelpe
         var viewContext = TestUtils.CreateViewContext();
         var containerErrorContext = viewContext.HttpContext.GetPageErrorContext();
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        ErrorSummaryOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateErrorSummaryAsync(It.IsAny<ErrorSummaryOptions>())).Callback<ErrorSummaryOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<ErrorSummaryOptions>(nameof(IComponentGenerator.GenerateErrorSummaryAsync));
 
-        var tagHelper = new ErrorSummaryTagHelper(componentGeneratorMock.Object)
+        var tagHelper = new ErrorSummaryTagHelper(componentGenerator)
         {
             DisableAutoFocus = disableAutoFocus,
             ViewContext = viewContext
@@ -62,7 +60,7 @@ public class ErrorSummaryTagHelperTests : TagHelperTestBase<ErrorSummaryTagHelpe
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.NotNull(actualOptions.ErrorList);
         Assert.Collection(
             actualOptions.ErrorList,
@@ -104,11 +102,9 @@ public class ErrorSummaryTagHelperTests : TagHelperTestBase<ErrorSummaryTagHelpe
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        ErrorSummaryOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateErrorSummaryAsync(It.IsAny<ErrorSummaryOptions>())).Callback<ErrorSummaryOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<ErrorSummaryOptions>(nameof(IComponentGenerator.GenerateErrorSummaryAsync));
 
-        var tagHelper = new ErrorSummaryTagHelper(componentGeneratorMock.Object)
+        var tagHelper = new ErrorSummaryTagHelper(componentGenerator)
         {
             ViewContext = TestUtils.CreateViewContext()
         };
@@ -118,7 +114,7 @@ public class ErrorSummaryTagHelperTests : TagHelperTestBase<ErrorSummaryTagHelpe
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal("There is a problem", actualOptions?.TitleHtml);
+        Assert.Equal("There is a problem", getActualOptions().TitleHtml);
     }
 
     [Fact]
@@ -184,11 +180,9 @@ public class ErrorSummaryTagHelperTests : TagHelperTestBase<ErrorSummaryTagHelpe
         var containerErrorContext = viewContext.HttpContext.GetPageErrorContext();
         containerErrorContext.AddError(containerErrorContextErrorHtml, containerErrorContextErrorHref);
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        ErrorSummaryOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateErrorSummaryAsync(It.IsAny<ErrorSummaryOptions>())).Callback<ErrorSummaryOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<ErrorSummaryOptions>(nameof(IComponentGenerator.GenerateErrorSummaryAsync));
 
-        var tagHelper = new ErrorSummaryTagHelper(componentGeneratorMock.Object)
+        var tagHelper = new ErrorSummaryTagHelper(componentGenerator)
         {
             ViewContext = viewContext
         };
@@ -198,7 +192,7 @@ public class ErrorSummaryTagHelperTests : TagHelperTestBase<ErrorSummaryTagHelpe
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.NotNull(actualOptions.ErrorList);
         Assert.Collection(
             actualOptions.ErrorList,
@@ -236,11 +230,9 @@ public class ErrorSummaryTagHelperTests : TagHelperTestBase<ErrorSummaryTagHelpe
         var containerErrorContext = viewContext.HttpContext.GetPageErrorContext();
         containerErrorContext.AddError(containerErrorContextErrorHtml, containerErrorContextErrorHref);
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        ErrorSummaryOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateErrorSummaryAsync(It.IsAny<ErrorSummaryOptions>())).Callback<ErrorSummaryOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<ErrorSummaryOptions>(nameof(IComponentGenerator.GenerateErrorSummaryAsync));
 
-        var tagHelper = new ErrorSummaryTagHelper(componentGeneratorMock.Object)
+        var tagHelper = new ErrorSummaryTagHelper(componentGenerator)
         {
             ViewContext = viewContext
         };
@@ -250,7 +242,7 @@ public class ErrorSummaryTagHelperTests : TagHelperTestBase<ErrorSummaryTagHelpe
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.NotNull(actualOptions.ErrorList);
         Assert.Collection(
             actualOptions.ErrorList,

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ErrorSummaryTitleTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ErrorSummaryTitleTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class ErrorSummaryTitleTagHelperTests
+public class ErrorSummaryTitleTagHelperTests : TagHelperTestBase<ErrorSummaryTitleTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_AddsTitleToContext()
@@ -14,18 +14,9 @@ public class ErrorSummaryTitleTagHelperTests
 
         var errorSummaryContext = new ErrorSummaryContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-error-summary-title",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(ErrorSummaryContext), errorSummaryContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: errorSummaryContext);
 
-        var output = new TagHelperOutput(
-            "govuk-error-summary-title",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FieldsetLegendTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FieldsetLegendTagHelperTests.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class FieldsetLegendTagHelperTests
+public class FieldsetLegendTagHelperTests : TagHelperTestBase<FieldsetLegendTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_AddsLegendToContext()
@@ -13,18 +13,9 @@ public class FieldsetLegendTagHelperTests
         // Arrange
         var fieldsetContext = new FieldsetContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-fieldset-legend",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(FieldsetContext), fieldsetContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: fieldsetContext);
 
-        var output = new TagHelperOutput(
-            "govuk-fieldset-legend",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -56,18 +47,9 @@ public class FieldsetLegendTagHelperTests
             attributes: new AttributeCollection(),
             content: new HtmlString("Existing legend"));
 
-        var context = new TagHelperContext(
-            tagName: "govuk-fieldset-legend",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(FieldsetContext), fieldsetContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: fieldsetContext);
 
-        var output = new TagHelperOutput(
-            "govuk-fieldset-legend",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FieldsetTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FieldsetTagHelperTests.cs
@@ -33,11 +33,9 @@ public class FieldsetTagHelperTests : TagHelperTestBase<FieldsetTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        FieldsetOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateFieldsetAsync(It.IsAny<FieldsetOptions>())).Callback<FieldsetOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<FieldsetOptions>(nameof(IComponentGenerator.GenerateFieldsetAsync));
 
-        var tagHelper = new FieldsetTagHelper(componentGeneratorMock.Object)
+        var tagHelper = new FieldsetTagHelper(componentGenerator)
         {
             DescribedBy = describedBy,
             Role = role
@@ -49,8 +47,8 @@ public class FieldsetTagHelperTests : TagHelperTestBase<FieldsetTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
-        Assert.Equal(describedBy, actualOptions!.DescribedBy);
+        var actualOptions = getActualOptions();
+        Assert.Equal(describedBy, actualOptions.DescribedBy);
         Assert.Equal(role, actualOptions.Role);
         Assert.Equal(mainContent, actualOptions.Html);
         Assert.NotNull(actualOptions.Legend);
@@ -89,11 +87,9 @@ public class FieldsetTagHelperTests : TagHelperTestBase<FieldsetTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        FieldsetOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateFieldsetAsync(It.IsAny<FieldsetOptions>())).Callback<FieldsetOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<FieldsetOptions>(nameof(IComponentGenerator.GenerateFieldsetAsync));
 
-        var tagHelper = new FieldsetTagHelper(componentGeneratorMock.Object)
+        var tagHelper = new FieldsetTagHelper(componentGenerator)
         {
             DescribedBy = describedBy,
             Role = role
@@ -105,8 +101,8 @@ public class FieldsetTagHelperTests : TagHelperTestBase<FieldsetTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
-        Assert.Equal(describedBy, actualOptions!.DescribedBy);
+        var actualOptions = getActualOptions();
+        Assert.Equal(describedBy, actualOptions.DescribedBy);
         Assert.Equal(role, actualOptions.Role);
         Assert.Equal(mainContent, actualOptions.Html);
         Assert.NotNull(actualOptions.Legend);
@@ -132,9 +128,9 @@ public class FieldsetTagHelperTests : TagHelperTestBase<FieldsetTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
+        var (componentGenerator, _) = CreateComponentGenerator<FieldsetOptions>(nameof(IComponentGenerator.GenerateFieldsetAsync));
 
-        var tagHelper = new FieldsetTagHelper(componentGeneratorMock.Object)
+        var tagHelper = new FieldsetTagHelper(componentGenerator)
         {
             DescribedBy = "describedby",
             Role = "therole"
@@ -180,11 +176,9 @@ public class FieldsetTagHelperTests : TagHelperTestBase<FieldsetTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        FieldsetOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateFieldsetAsync(It.IsAny<FieldsetOptions>())).Callback<FieldsetOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<FieldsetOptions>(nameof(IComponentGenerator.GenerateFieldsetAsync));
 
-        var tagHelper = new FieldsetTagHelper(componentGeneratorMock.Object)
+        var tagHelper = new FieldsetTagHelper(componentGenerator)
         {
             DescribedBy = describedBy,
             Role = role
@@ -196,8 +190,8 @@ public class FieldsetTagHelperTests : TagHelperTestBase<FieldsetTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
-        Assert.Equal(describedBy, actualOptions!.DescribedBy);
+        var actualOptions = getActualOptions();
+        Assert.Equal(describedBy, actualOptions.DescribedBy);
         Assert.Equal(role, actualOptions.Role);
         Assert.Equal(mainContent, actualOptions.Html);
         Assert.NotNull(actualOptions.Legend);

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FieldsetTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FieldsetTagHelperTests.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class FieldsetTagHelperTests
+public class FieldsetTagHelperTests : TagHelperTestBase<FieldsetTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_InvokesComponentGeneratorWithExpectedOptions()
@@ -16,15 +16,9 @@ public class FieldsetTagHelperTests
         var legendText = "Legend text";
         var mainContent = "Main content";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-fieldset",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-fieldset",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var fieldsetContext = context.GetContextItem<FieldsetContext>();
@@ -78,15 +72,9 @@ public class FieldsetTagHelperTests
         var legendText = "Legend text";
         var mainContent = "Main content";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-fieldset",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-fieldset",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var fieldsetContext = context.GetContextItem<FieldsetContext>();
@@ -132,15 +120,9 @@ public class FieldsetTagHelperTests
     public async Task ProcessAsync_MissingLegend_ThrowsInvalidOperationException()
     {
         // Arrange
-        var context = new TagHelperContext(
-            tagName: "govuk-fieldset",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-fieldset",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var fieldsetContext = context.GetContextItem<FieldsetContext>();
@@ -176,22 +158,14 @@ public class FieldsetTagHelperTests
         var role = "therole";
         var legendText = "Legend text";
         var mainContent = "Main content";
-        var customClass = "custom-class";
-        var dataFooAttrValue = "bar";
+        var customClass = CreateDummyClassName();
+        var attributes = CreateDummyDataAttributes();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-fieldset",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext(className: customClass, attributes: attributes);
 
-        var output = new TagHelperOutput(
-            "govuk-fieldset",
-            attributes: new TagHelperAttributeList()
-            {
-                { "class", customClass },
-                { "data-foo", dataFooAttrValue }
-            },
+        var output = CreateTagHelperOutput(
+            className: customClass,
+            attributes: attributes,
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var fieldsetContext = context.GetContextItem<FieldsetContext>();
@@ -232,11 +206,6 @@ public class FieldsetTagHelperTests
         Assert.NotNull(actualOptions.Legend.Attributes);
         Assert.Empty(actualOptions.Legend.Attributes);
         Assert.Equal(customClass, actualOptions.Classes);
-        Assert.NotNull(actualOptions.Attributes);
-        Assert.Collection(actualOptions.Attributes, kvp =>
-        {
-            Assert.Equal("data-foo", kvp.Key);
-            Assert.Equal(dataFooAttrValue, kvp.Value);
-        });
+        AssertContainsAttributes(attributes, actualOptions.Attributes);
     }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FileUploadTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FileUploadTagHelperTests.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class FileUploadTagHelperTests
+public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_InvokesComponentGeneratorWithExpectedOptions()
@@ -26,15 +26,9 @@ public class FileUploadTagHelperTests
         var wrapperDataBarAttribute = "bar";
         var wrapperClasses = "wrapper-class";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-input",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-input",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var inputContext = context.GetContextItem<FileUploadContext>();
@@ -125,15 +119,9 @@ public class FileUploadTagHelperTests
         var errorVht = "visually hidden text";
         var errorDataFooAttribute = "bar";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-input",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-input",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var inputContext = context.GetContextItem<FileUploadContext>();
@@ -193,15 +181,9 @@ public class FileUploadTagHelperTests
         var description = "The hint";
         var modelStateError = "The error message";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-input",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-input",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -274,15 +256,9 @@ public class FileUploadTagHelperTests
         var modelStateDisplayName = "ModelState label";
         var labelHtml = "Explicit label";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-input",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-input",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var inputContext = context.GetContextItem<FileUploadContext>();
@@ -348,15 +324,9 @@ public class FileUploadTagHelperTests
         var modelStateDescription = "The hint";
         var hintHtml = "Explicit hint";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-input",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-input",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var inputContext = context.GetContextItem<FileUploadContext>();
@@ -422,15 +392,9 @@ public class FileUploadTagHelperTests
         var modelStateError = "ModelState error";
         var errorHtml = "Explicit error";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-input",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-input",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var inputContext = context.GetContextItem<FileUploadContext>();
@@ -502,15 +466,9 @@ public class FileUploadTagHelperTests
         var displayName = "The label";
         var modelStateError = "ModelState error";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-input",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-input",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -576,15 +534,9 @@ public class FileUploadTagHelperTests
         var modelStateError = "ModelState error";
         var errorHtml = "Explicit error";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-input",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-input",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var inputContext = context.GetContextItem<FileUploadContext>();
@@ -658,15 +610,9 @@ public class FileUploadTagHelperTests
         var labelHtml = "The label";
         var errorHtml = "The error message";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-input",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-input",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var inputContext = context.GetContextItem<FileUploadContext>();
@@ -727,15 +673,9 @@ public class FileUploadTagHelperTests
         var multipleFilesChosenTextOther = "{count} files chosen";
         var noFileChosenText = "No file chosen";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-input",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-input",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var inputContext = context.GetContextItem<FileUploadContext>();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FileUploadTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FileUploadTagHelperTests.cs
@@ -50,11 +50,9 @@ public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
 
         var modelHelperMock = new Mock<IModelHelper>();
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        FileUploadOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateFileUploadAsync(It.IsAny<FileUploadOptions>())).Callback<FileUploadOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<FileUploadOptions>(nameof(IComponentGenerator.GenerateFileUploadAsync));
 
-        var tagHelper = new FileUploadTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new FileUploadTagHelper(componentGenerator, modelHelperMock.Object)
         {
             Id = id,
             DescribedBy = describedBy,
@@ -80,7 +78,7 @@ public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(id, actualOptions.Id);
         Assert.Equal(name, actualOptions.Name);
         Assert.Equal(multiple, actualOptions.Multiple);
@@ -145,11 +143,9 @@ public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
 
         var modelHelperMock = new Mock<IModelHelper>();
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        FileUploadOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateFileUploadAsync(It.IsAny<FileUploadOptions>())).Callback<FileUploadOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<FileUploadOptions>(nameof(IComponentGenerator.GenerateFileUploadAsync));
 
-        var tagHelper = new FileUploadTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new FileUploadTagHelper(componentGenerator, modelHelperMock.Object)
         {
             Id = id,
             Name = name,
@@ -161,7 +157,8 @@ public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions?.ErrorMessage);
+        var actualOptions = getActualOptions();
+        Assert.NotNull(actualOptions.ErrorMessage);
         Assert.Equal(errorHtml, actualOptions.ErrorMessage.Html);
         Assert.Equal(errorVht, actualOptions.ErrorMessage.VisuallyHiddenText);
         Assert.NotNull(actualOptions.ErrorMessage.Attributes);
@@ -225,11 +222,9 @@ public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        FileUploadOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateFileUploadAsync(It.IsAny<FileUploadOptions>())).Callback<FileUploadOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<FileUploadOptions>(nameof(IComponentGenerator.GenerateFileUploadAsync));
 
-        var tagHelper = new FileUploadTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new FileUploadTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = TestUtils.CreateViewContext()
@@ -240,7 +235,7 @@ public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.NotNull(actualOptions.Id);
         Assert.NotNull(actualOptions.Name);
         Assert.Equal(displayName, actualOptions.Label?.Html);
@@ -297,11 +292,9 @@ public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        FileUploadOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateFileUploadAsync(It.IsAny<FileUploadOptions>())).Callback<FileUploadOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<FileUploadOptions>(nameof(IComponentGenerator.GenerateFileUploadAsync));
 
-        var tagHelper = new FileUploadTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new FileUploadTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = new ViewContext(),
@@ -312,7 +305,8 @@ public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal(labelHtml, actualOptions?.Label?.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(labelHtml, actualOptions.Label?.Html);
     }
 
     [Fact]
@@ -365,11 +359,9 @@ public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        FileUploadOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateFileUploadAsync(It.IsAny<FileUploadOptions>())).Callback<FileUploadOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<FileUploadOptions>(nameof(IComponentGenerator.GenerateFileUploadAsync));
 
-        var tagHelper = new FileUploadTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new FileUploadTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = new ViewContext(),
@@ -380,7 +372,8 @@ public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal(hintHtml, actualOptions?.Hint?.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(hintHtml, actualOptions.Hint?.Html);
     }
 
     [Fact]
@@ -440,11 +433,9 @@ public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        FileUploadOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateFileUploadAsync(It.IsAny<FileUploadOptions>())).Callback<FileUploadOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<FileUploadOptions>(nameof(IComponentGenerator.GenerateFileUploadAsync));
 
-        var tagHelper = new FileUploadTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new FileUploadTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = TestUtils.CreateViewContext()
@@ -455,7 +446,8 @@ public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal(errorHtml, actualOptions?.ErrorMessage?.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(errorHtml, actualOptions.ErrorMessage?.Html);
     }
 
     [Fact]
@@ -506,11 +498,9 @@ public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        FileUploadOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateFileUploadAsync(It.IsAny<FileUploadOptions>())).Callback<FileUploadOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<FileUploadOptions>(nameof(IComponentGenerator.GenerateFileUploadAsync));
 
-        var tagHelper = new FileUploadTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new FileUploadTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = new ViewContext(),
@@ -522,7 +512,8 @@ public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Null(actualOptions?.ErrorMessage);
+        var actualOptions = getActualOptions();
+        Assert.Null(actualOptions.ErrorMessage);
     }
 
     [Fact]
@@ -582,11 +573,9 @@ public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        FileUploadOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateFileUploadAsync(It.IsAny<FileUploadOptions>())).Callback<FileUploadOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<FileUploadOptions>(nameof(IComponentGenerator.GenerateFileUploadAsync));
 
-        var tagHelper = new FileUploadTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new FileUploadTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             IgnoreModelStateErrors = true,
@@ -598,7 +587,8 @@ public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal(errorHtml, actualOptions?.ErrorMessage?.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(errorHtml, actualOptions.ErrorMessage?.Html);
     }
 
     [Fact]
@@ -635,9 +625,9 @@ public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
 
         var modelHelperMock = new Mock<IModelHelper>();
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
+        var (componentGenerator, _) = CreateComponentGenerator<FileUploadOptions>(nameof(IComponentGenerator.GenerateFileUploadAsync));
 
-        var tagHelper = new FileUploadTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new FileUploadTagHelper(componentGenerator, modelHelperMock.Object)
         {
             Id = id,
             Name = name,
@@ -692,11 +682,9 @@ public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
 
         var modelHelperMock = new Mock<IModelHelper>();
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        FileUploadOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateFileUploadAsync(It.IsAny<FileUploadOptions>())).Callback<FileUploadOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<FileUploadOptions>(nameof(IComponentGenerator.GenerateFileUploadAsync));
 
-        var tagHelper = new FileUploadTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new FileUploadTagHelper(componentGenerator, modelHelperMock.Object)
         {
             Id = id,
             Name = name,
@@ -715,7 +703,7 @@ public class FileUploadTagHelperTests : TagHelperTestBase<FileUploadTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(chooseFilesButtonText, actualOptions.ChooseFilesButtonText);
         Assert.Equal(dropInstructionText, actualOptions.DropInstructionText);
         Assert.Equal(enteredDropZoneText, actualOptions.EnteredDropZoneText);

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/GeneratedErrorSummaryTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/GeneratedErrorSummaryTagHelperTests.cs
@@ -5,9 +5,9 @@ using Microsoft.Extensions.Options;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class GeneratedErrorSummaryTagHelperTests
+public class GeneratedErrorSummaryTagHelperTests : TagHelperTestBase<GeneratedErrorSummaryTagHelper>
 {
-    [Theory]
+    [Xunit.Theory]
     [InlineData(null, false)]
     [InlineData(false, false)]
     [InlineData(true, true)]
@@ -21,15 +21,9 @@ public class GeneratedErrorSummaryTagHelperTests
         var errorHtml = "Error message";
         var errorHref = "#Field";
 
-        var context = new TagHelperContext(
-            tagName: "form",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext(tagName: "form");
 
-        var output = new TagHelperOutput(
-            "form",
-            attributes: [],
+        var output = CreateTagHelperOutput(tagName: "form",
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/GeneratedErrorSummaryTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/GeneratedErrorSummaryTagHelperTests.cs
@@ -30,15 +30,13 @@ public class GeneratedErrorSummaryTagHelperTests : TagHelperTestBase<GeneratedEr
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        ErrorSummaryOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateErrorSummaryAsync(It.IsAny<ErrorSummaryOptions>())).Callback<ErrorSummaryOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<ErrorSummaryOptions>(nameof(IComponentGenerator.GenerateErrorSummaryAsync));
 
         var viewContext = TestUtils.CreateViewContext();
         var containerErrorContext = viewContext.HttpContext.GetPageErrorContext();
         containerErrorContext.AddError(errorHtml, errorHref);
 
-        var tagHelper = new GeneratedErrorSummaryTagHelper(componentGeneratorMock.Object, options)
+        var tagHelper = new GeneratedErrorSummaryTagHelper(componentGenerator, options)
         {
             PrependErrorSummary = prependErrorSummary,
             ViewContext = viewContext
@@ -53,7 +51,7 @@ public class GeneratedErrorSummaryTagHelperTests : TagHelperTestBase<GeneratedEr
 
         if (expectErrorSummary)
         {
-            Assert.NotNull(actualOptions);
+            var actualOptions = getActualOptions();
             Assert.NotNull(actualOptions.ErrorList);
             Assert.True(containerErrorContext.ErrorSummaryHasBeenRendered);
 

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/InsetTextTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/InsetTextTagHelperTests.cs
@@ -23,11 +23,9 @@ public class InsetTextTagHelperTests : TagHelperTestBase<InsetTextTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        InsetTextOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateInsetTextAsync(It.IsAny<InsetTextOptions>())).Callback<InsetTextOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<InsetTextOptions>(nameof(IComponentGenerator.GenerateInsetTextAsync));
 
-        var tagHelper = new InsetTextTagHelper(componentGeneratorMock.Object)
+        var tagHelper = new InsetTextTagHelper(componentGenerator)
         {
             Id = id
         };
@@ -36,8 +34,8 @@ public class InsetTextTagHelperTests : TagHelperTestBase<InsetTextTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
-        Assert.Equal(content, actualOptions!.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(content, actualOptions.Html);
         Assert.Null(actualOptions.Text);
         Assert.Equal(id, actualOptions.Id);
     }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/InsetTextTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/InsetTextTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class InsetTextTagHelperTests
+public class InsetTextTagHelperTests : TagHelperTestBase<InsetTextTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_InvokesComponentGeneratorWithExpectedOptions()
@@ -13,15 +13,9 @@ public class InsetTextTagHelperTests
         var content = "Inset text";
         var id = "id";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-inset-text",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-inset-text",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/NotificationBannerTitleTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/NotificationBannerTitleTagHelperTests.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class NotificationBannerTitleTagHelperTests
+public class NotificationBannerTitleTagHelperTests : TagHelperTestBase<NotificationBannerTitleTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_SetsTitleOnContext()
@@ -11,18 +11,9 @@ public class NotificationBannerTitleTagHelperTests
         // Arrange
         var notificationBannerContext = new NotificationBannerContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-notification-banner-title",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(NotificationBannerContext), notificationBannerContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: notificationBannerContext);
 
-        var output = new TagHelperOutput(
-            "govuk-notification-banner-title",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PaginationEllipsisItemTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PaginationEllipsisItemTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class PaginationEllipsisItemTagHelperTests
+public class PaginationEllipsisItemTagHelperTests : TagHelperTestBase<PaginationEllipsisItemTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_AddsItemToContextItems()
@@ -12,18 +12,9 @@ public class PaginationEllipsisItemTagHelperTests
         // Arrange
         var paginationContext = new PaginationContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-pagination-ellipsis",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(PaginationContext), paginationContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: paginationContext);
 
-        var output = new TagHelperOutput(
-            "govuk-pagination-ellipsis",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PaginationItemTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PaginationItemTagHelperTests.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class PaginationItemTagHelperTests
+public class PaginationItemTagHelperTests : TagHelperTestBase<PaginationItemTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_AddsItemToContextItems()
@@ -13,18 +13,9 @@ public class PaginationItemTagHelperTests
         // Arrange
         var paginationContext = new PaginationContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-pagination-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(PaginationContext), paginationContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: paginationContext);
 
-        var output = new TagHelperOutput(
-            "govuk-pagination-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PaginationNextTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PaginationNextTagHelperTests.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class PaginationNextTagHelperTests
+public class PaginationNextTagHelperTests : TagHelperTestBase<PaginationNextTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_SetsNextOnContext()
@@ -11,18 +11,9 @@ public class PaginationNextTagHelperTests
         // Arrange
         var paginationContext = new PaginationContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-pagination-next",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(PaginationContext), paginationContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: paginationContext);
 
-        var output = new TagHelperOutput(
-            "govuk-pagination-next",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PaginationPreviousTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PaginationPreviousTagHelperTests.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class PaginationPreviousTagHelperTests
+public class PaginationPreviousTagHelperTests : TagHelperTestBase<PaginationPreviousTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_SetsPreviousOnContext()
@@ -11,18 +11,9 @@ public class PaginationPreviousTagHelperTests
         // Arrange
         var paginationContext = new PaginationContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-pagination-previous",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(PaginationContext), paginationContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: paginationContext);
 
-        var output = new TagHelperOutput(
-            "govuk-pagination-previous",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PaginationTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PaginationTagHelperTests.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class PaginationTagHelperTests
+public class PaginationTagHelperTests : TagHelperTestBase<PaginationTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_InvokesComponentGeneratorWithExpectedOptions()
@@ -25,15 +25,9 @@ public class PaginationTagHelperTests
         var nextLabelText = "6 of 9";
         var nextText = "Next page";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-pagination",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-pagination",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var paginationContext = context.GetContextItem<PaginationContext>();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PaginationTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PaginationTagHelperTests.cs
@@ -65,11 +65,9 @@ public class PaginationTagHelperTests : TagHelperTestBase<PaginationTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        PaginationOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GeneratePaginationAsync(It.IsAny<PaginationOptions>())).Callback<PaginationOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<PaginationOptions>(nameof(IComponentGenerator.GeneratePaginationAsync));
 
-        var tagHelper = new PaginationTagHelper(componentGeneratorMock.Object)
+        var tagHelper = new PaginationTagHelper(componentGenerator)
         {
             LandmarkLabel = landmarkLabel
         };
@@ -79,7 +77,7 @@ public class PaginationTagHelperTests : TagHelperTestBase<PaginationTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(landmarkLabel, actualOptions.LandmarkLabel?.ToHtmlString(HtmlEncoder.Default));
         Assert.NotNull(actualOptions.Items);
         Assert.NotNull(actualOptions.Previous);

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PanelBodyTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PanelBodyTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class PanelBodyTagHelperTests
+public class PanelBodyTagHelperTests : TagHelperTestBase<PanelBodyTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_SetsBodyOnContext()
@@ -12,18 +12,9 @@ public class PanelBodyTagHelperTests
         // Arrange
         var panelContext = new PanelContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-panel-body",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(PanelContext), panelContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: panelContext);
 
-        var output = new TagHelperOutput(
-            "govuk-panel-body",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -48,18 +39,9 @@ public class PanelBodyTagHelperTests
         var panelContext = new PanelContext();
         panelContext.SetBody(TemplateString.FromEncoded("The body"), null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-panel-body",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(PanelContext), panelContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: panelContext);
 
-        var output = new TagHelperOutput(
-            "govuk-panel-body",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PanelTitleTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PanelTitleTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class PanelTitleTagHelperTests
+public class PanelTitleTagHelperTests : TagHelperTestBase<PanelTitleTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_SetsTitleOnContext()
@@ -12,18 +12,9 @@ public class PanelTitleTagHelperTests
         // Arrange
         var panelContext = new PanelContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-panel-title",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(PanelContext), panelContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: panelContext);
 
-        var output = new TagHelperOutput(
-            "govuk-panel-title",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -48,18 +39,9 @@ public class PanelTitleTagHelperTests
         var panelContext = new PanelContext();
         panelContext.SetTitle(TemplateString.FromEncoded("The title"), null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-panel-title",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(PanelContext), panelContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: panelContext);
 
-        var output = new TagHelperOutput(
-            "govuk-panel-title",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -84,18 +66,9 @@ public class PanelTitleTagHelperTests
         var panelContext = new PanelContext();
         panelContext.SetBody(TemplateString.FromEncoded("The body"), null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-panel-title",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(PanelContext), panelContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: panelContext);
 
-        var output = new TagHelperOutput(
-            "govuk-panel-title",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PasswordInputTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PasswordInputTagHelperTests.cs
@@ -62,11 +62,9 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
 
         var modelHelperMock = new Mock<IModelHelper>();
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        PasswordInputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GeneratePasswordInputAsync(It.IsAny<PasswordInputOptions>())).Callback<PasswordInputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<PasswordInputOptions>(nameof(IComponentGenerator.GeneratePasswordInputAsync));
 
-        var tagHelper = new PasswordInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object, HtmlEncoder.Default)
+        var tagHelper = new PasswordInputTagHelper(componentGenerator, modelHelperMock.Object, HtmlEncoder.Default)
         {
             Id = id,
             DescribedBy = describedBy,
@@ -97,7 +95,7 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(id, actualOptions.Id);
         Assert.Equal(name, actualOptions.Name);
         Assert.Equal(buttonClass, actualOptions.Button?.Classes);
@@ -171,11 +169,9 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
 
         var modelHelperMock = new Mock<IModelHelper>();
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        PasswordInputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GeneratePasswordInputAsync(It.IsAny<PasswordInputOptions>())).Callback<PasswordInputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<PasswordInputOptions>(nameof(IComponentGenerator.GeneratePasswordInputAsync));
 
-        var tagHelper = new PasswordInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object, HtmlEncoder.Default)
+        var tagHelper = new PasswordInputTagHelper(componentGenerator, modelHelperMock.Object, HtmlEncoder.Default)
         {
             Id = id,
             Name = name,
@@ -188,7 +184,8 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions?.ErrorMessage);
+        var actualOptions = getActualOptions();
+        Assert.NotNull(actualOptions.ErrorMessage);
         Assert.Equal(errorHtml, actualOptions.ErrorMessage.Html);
         Assert.Equal(errorVht, actualOptions.ErrorMessage.VisuallyHiddenText);
         Assert.NotNull(actualOptions.ErrorMessage.Attributes);
@@ -258,11 +255,9 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        PasswordInputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GeneratePasswordInputAsync(It.IsAny<PasswordInputOptions>())).Callback<PasswordInputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<PasswordInputOptions>(nameof(IComponentGenerator.GeneratePasswordInputAsync));
 
-        var tagHelper = new PasswordInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object, HtmlEncoder.Default)
+        var tagHelper = new PasswordInputTagHelper(componentGenerator, modelHelperMock.Object, HtmlEncoder.Default)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = TestUtils.CreateViewContext()
@@ -274,7 +269,7 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.NotNull(actualOptions.Id);
         Assert.NotNull(actualOptions.Name);
         Assert.Equal(modelStateValue, actualOptions.Value);
@@ -330,11 +325,9 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        PasswordInputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GeneratePasswordInputAsync(It.IsAny<PasswordInputOptions>())).Callback<PasswordInputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<PasswordInputOptions>(nameof(IComponentGenerator.GeneratePasswordInputAsync));
 
-        var tagHelper = new PasswordInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object, HtmlEncoder.Default)
+        var tagHelper = new PasswordInputTagHelper(componentGenerator, modelHelperMock.Object, HtmlEncoder.Default)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = new ViewContext(),
@@ -347,7 +340,8 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal(value, actualOptions?.Value);
+        var actualOptions = getActualOptions();
+        Assert.Equal(value, actualOptions.Value);
     }
 
     [Fact]
@@ -405,11 +399,9 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        PasswordInputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GeneratePasswordInputAsync(It.IsAny<PasswordInputOptions>())).Callback<PasswordInputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<PasswordInputOptions>(nameof(IComponentGenerator.GeneratePasswordInputAsync));
 
-        var tagHelper = new PasswordInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object, HtmlEncoder.Default)
+        var tagHelper = new PasswordInputTagHelper(componentGenerator, modelHelperMock.Object, HtmlEncoder.Default)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = new ViewContext(),
@@ -421,7 +413,8 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal(labelHtml, actualOptions?.Label?.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(labelHtml, actualOptions.Label?.Html);
     }
 
     [Fact]
@@ -480,11 +473,9 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        PasswordInputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GeneratePasswordInputAsync(It.IsAny<PasswordInputOptions>())).Callback<PasswordInputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<PasswordInputOptions>(nameof(IComponentGenerator.GeneratePasswordInputAsync));
 
-        var tagHelper = new PasswordInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object, HtmlEncoder.Default)
+        var tagHelper = new PasswordInputTagHelper(componentGenerator, modelHelperMock.Object, HtmlEncoder.Default)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = new ViewContext(),
@@ -496,7 +487,8 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal(hintHtml, actualOptions?.Hint?.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(hintHtml, actualOptions.Hint?.Html);
     }
 
     [Fact]
@@ -562,11 +554,9 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        PasswordInputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GeneratePasswordInputAsync(It.IsAny<PasswordInputOptions>())).Callback<PasswordInputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<PasswordInputOptions>(nameof(IComponentGenerator.GeneratePasswordInputAsync));
 
-        var tagHelper = new PasswordInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object, HtmlEncoder.Default)
+        var tagHelper = new PasswordInputTagHelper(componentGenerator, modelHelperMock.Object, HtmlEncoder.Default)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = TestUtils.CreateViewContext()
@@ -578,7 +568,8 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal(errorHtml, actualOptions?.ErrorMessage?.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(errorHtml, actualOptions.ErrorMessage?.Html);
     }
 
     [Fact]
@@ -635,11 +626,9 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        PasswordInputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GeneratePasswordInputAsync(It.IsAny<PasswordInputOptions>())).Callback<PasswordInputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<PasswordInputOptions>(nameof(IComponentGenerator.GeneratePasswordInputAsync));
 
-        var tagHelper = new PasswordInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object, HtmlEncoder.Default)
+        var tagHelper = new PasswordInputTagHelper(componentGenerator, modelHelperMock.Object, HtmlEncoder.Default)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = new ViewContext(),
@@ -652,7 +641,8 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Null(actualOptions?.ErrorMessage);
+        var actualOptions = getActualOptions();
+        Assert.Null(actualOptions.ErrorMessage);
     }
 
     [Fact]
@@ -718,11 +708,9 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        PasswordInputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GeneratePasswordInputAsync(It.IsAny<PasswordInputOptions>())).Callback<PasswordInputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<PasswordInputOptions>(nameof(IComponentGenerator.GeneratePasswordInputAsync));
 
-        var tagHelper = new PasswordInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object, HtmlEncoder.Default)
+        var tagHelper = new PasswordInputTagHelper(componentGenerator, modelHelperMock.Object, HtmlEncoder.Default)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             IgnoreModelStateErrors = true,
@@ -735,7 +723,8 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal(errorHtml, actualOptions?.ErrorMessage?.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(errorHtml, actualOptions.ErrorMessage?.Html);
     }
 
     [Fact]
@@ -778,9 +767,9 @@ public class PasswordInputTagHelperTests : TagHelperTestBase<PasswordInputTagHel
 
         var modelHelperMock = new Mock<IModelHelper>();
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
+        var (componentGenerator, _) = CreateComponentGenerator<PasswordInputOptions>(nameof(IComponentGenerator.GeneratePasswordInputAsync));
 
-        var tagHelper = new PasswordInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object, HtmlEncoder.Default)
+        var tagHelper = new PasswordInputTagHelper(componentGenerator, modelHelperMock.Object, HtmlEncoder.Default)
         {
             Id = id,
             Name = name,

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosFieldsetLegendTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosFieldsetLegendTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class RadiosFieldsetLegendTagHelperTests
+public class RadiosFieldsetLegendTagHelperTests : TagHelperTestBase<RadiosFieldsetLegendTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_AddsLegendToContext()
@@ -12,18 +12,9 @@ public class RadiosFieldsetLegendTagHelperTests
         // Arrange
         var fieldsetContext = new RadiosFieldsetContext(describedBy: null, @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios-fieldset-legend",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(RadiosFieldsetContext), fieldsetContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: fieldsetContext);
 
-        var output = new TagHelperOutput(
-            "govuk-radios-fieldset-legend",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -56,18 +47,9 @@ public class RadiosFieldsetLegendTagHelperTests
             html: new TemplateString("Existing legend"),
             RadiosFieldsetLegendTagHelper.TagName);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios-fieldset-legend",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(RadiosFieldsetContext), fieldsetContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: fieldsetContext);
 
-        var output = new TagHelperOutput(
-            "govuk-radios-fieldset-legend",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosFieldsetTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosFieldsetTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class RadiosFieldsetTagHelperTests
+public class RadiosFieldsetTagHelperTests : TagHelperTestBase<RadiosFieldsetTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_AddsFieldsetToContext()
@@ -12,18 +12,9 @@ public class RadiosFieldsetTagHelperTests
         // Arrange
         var radiosContext = new RadiosContext(name: null, @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios-fieldset",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(RadiosContext), radiosContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: radiosContext);
 
-        var output = new TagHelperOutput(
-            "govuk-radios-fieldset",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var fieldsetContext = context.GetContextItem<RadiosFieldsetContext>();
@@ -56,18 +47,9 @@ public class RadiosFieldsetTagHelperTests
         radiosFieldsetContext.SetLegend(isPageHeading: false, attributes: new AttributeCollection(), html: new TemplateString("Existing legend"), RadiosFieldsetLegendTagHelper.TagName);
         radiosContext.CloseFieldset();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios-fieldset",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(RadiosContext), radiosContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: radiosContext);
 
-        var output = new TagHelperOutput(
-            "govuk-radios-fieldset",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var fieldsetContext = context.GetContextItem<RadiosFieldsetContext>();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosItemConditionalTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosItemConditionalTagHelperTests.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class RadiosItemConditionalTagHelperTests
+public class RadiosItemConditionalTagHelperTests : TagHelperTestBase<RadiosItemConditionalTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_SetsConditionalOnContext()
@@ -11,18 +11,9 @@ public class RadiosItemConditionalTagHelperTests
         // Arrange
         var radiosItemContext = new RadiosItemContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios-item-conditional",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(RadiosItemContext), radiosItemContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: radiosItemContext);
 
-        var output = new TagHelperOutput(
-            "govuk-radios-item-conditional",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosItemDividerTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosItemDividerTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class RadiosItemDividerTagHelperTests
+public class RadiosItemDividerTagHelperTests : TagHelperTestBase<RadiosItemDividerTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_AddsDividerToContextItems()
@@ -12,18 +12,9 @@ public class RadiosItemDividerTagHelperTests
         // Arrange
         var radiosContext = new RadiosContext(name: null, @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios-divider",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(RadiosContext), radiosContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: radiosContext);
 
-        var output = new TagHelperOutput(
-            "govuk-radios-divider",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosItemHintTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosItemHintTagHelperTests.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class RadiosItemHintTagHelperTests
+public class RadiosItemHintTagHelperTests : TagHelperTestBase<RadiosItemHintTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_SetsHintOnContext()
@@ -11,18 +11,9 @@ public class RadiosItemHintTagHelperTests
         // Arrange
         var radiosItemContext = new RadiosItemContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios-item-hint",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(RadiosItemContext), radiosItemContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: radiosItemContext);
 
-        var output = new TagHelperOutput(
-            "govuk-radios-item-hint",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosItemTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosItemTagHelperTests.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class RadiosItemTagHelperTests
+public class RadiosItemTagHelperTests : TagHelperTestBase<RadiosItemTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_AddsItemToContext()
@@ -15,19 +15,9 @@ public class RadiosItemTagHelperTests
         // Arrange
         var radiosContext = new RadiosContext(name: "test", @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(RadiosContext), radiosContext },
-                { typeof(RadiosItemContext), new RadiosItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [radiosContext, new RadiosItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-radios-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -64,19 +54,9 @@ public class RadiosItemTagHelperTests
         // Arrange
         var radiosContext = new RadiosContext(name: "test", @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(RadiosContext), radiosContext },
-                { typeof(RadiosItemContext), new RadiosItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [radiosContext, new RadiosItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-radios-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -99,19 +79,9 @@ public class RadiosItemTagHelperTests
         // Arrange
         var radiosContext = new RadiosContext(name: "parent", @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(RadiosContext), radiosContext },
-                { typeof(RadiosItemContext), new RadiosItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [radiosContext, new RadiosItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-radios-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -148,19 +118,9 @@ public class RadiosItemTagHelperTests
 
         var radiosContext = new RadiosContext(name: "test", @for: new ModelExpression(modelExpression, modelExplorer));
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(RadiosContext), radiosContext },
-                { typeof(RadiosItemContext), new RadiosItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [radiosContext, new RadiosItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-radios-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -203,19 +163,9 @@ public class RadiosItemTagHelperTests
 
         var radiosContext = new RadiosContext(name: "test", @for: new ModelExpression(modelExpression, modelExplorer));
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(RadiosContext), radiosContext },
-                { typeof(RadiosItemContext), new RadiosItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [radiosContext, new RadiosItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-radios-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -257,19 +207,9 @@ public class RadiosItemTagHelperTests
 
         var radiosContext = new RadiosContext(name: "test", @for: new ModelExpression(modelExpression, modelExplorer));
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(RadiosContext), radiosContext },
-                { typeof(RadiosItemContext), new RadiosItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [radiosContext, new RadiosItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-radios-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -302,19 +242,9 @@ public class RadiosItemTagHelperTests
         // Arrange
         var radiosContext = new RadiosContext(name: "test", @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(RadiosContext), radiosContext },
-                { typeof(RadiosItemContext), new RadiosItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [radiosContext, new RadiosItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-radios-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var itemContext = context.GetContextItem<RadiosItemContext>();
@@ -349,19 +279,9 @@ public class RadiosItemTagHelperTests
         // Arrange
         var radiosContext = new RadiosContext(name: "test", @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(RadiosContext), radiosContext },
-                { typeof(RadiosItemContext), new RadiosItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [radiosContext, new RadiosItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-radios-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -392,19 +312,9 @@ public class RadiosItemTagHelperTests
         // Arrange
         var radiosContext = new RadiosContext(name: "test", @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(RadiosContext), radiosContext },
-                { typeof(RadiosItemContext), new RadiosItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [radiosContext, new RadiosItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-radios-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var itemContext = context.GetContextItem<RadiosItemContext>();
@@ -439,19 +349,9 @@ public class RadiosItemTagHelperTests
         // Arrange
         var radiosContext = new RadiosContext(name: "test", @for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(RadiosContext), radiosContext },
-                { typeof(RadiosItemContext), new RadiosItemContext() }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: [radiosContext, new RadiosItemContext()]);
 
-        var output = new TagHelperOutput(
-            "govuk-radios-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class RadiosTagHelperTests
+public class RadiosTagHelperTests : TagHelperTestBase<RadiosTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_InvokesComponentGeneratorWithExpectedOptions()
@@ -15,15 +15,9 @@ public class RadiosTagHelperTests
         var hintContent = "The hint";
         var className = "additional-class";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-radios",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var radiosContext = context.GetContextItem<RadiosContext>();
@@ -109,15 +103,9 @@ public class RadiosTagHelperTests
         var name = "testradios";
         var errorContent = "An error";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-radios",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var radiosContext = context.GetContextItem<RadiosContext>();
@@ -200,15 +188,9 @@ public class RadiosTagHelperTests
         var name = "testradios";
         var itemHintContent = "First item hint";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-radios",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var radiosContext = context.GetContextItem<RadiosContext>();
@@ -268,15 +250,9 @@ public class RadiosTagHelperTests
         var name = "testradios";
         var conditionalContent = "Item 1 conditional";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-radios",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var radiosContext = context.GetContextItem<RadiosContext>();
@@ -337,15 +313,9 @@ public class RadiosTagHelperTests
         var name = "testradios";
         var conditionalContent = "Item 1 conditional";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-radios",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var radiosContext = context.GetContextItem<RadiosContext>();
@@ -409,15 +379,9 @@ public class RadiosTagHelperTests
         var legendContent = "Legend";
         var describedBy = "described-by-value";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-radios",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var radiosContext = context.GetContextItem<RadiosContext>();
@@ -509,15 +473,9 @@ public class RadiosTagHelperTests
         var name = "testradios";
         var itemAttributeValue = "custom-value";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-radios",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var radiosContext = context.GetContextItem<RadiosContext>();
@@ -573,15 +531,9 @@ public class RadiosTagHelperTests
         var conditionalContent = "Item conditional";
         var conditionalAttributeValue = "custom-conditional-value";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-radios",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-radios",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var radiosContext = context.GetContextItem<RadiosContext>();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosTagHelperTests.cs
@@ -51,12 +51,9 @@ public class RadiosTagHelperTests : TagHelperTestBase<RadiosTagHelper>
 
         output.Attributes.Add("class", className);
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        RadiosOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateRadiosAsync(It.IsAny<RadiosOptions>()))
-            .Callback<RadiosOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<RadiosOptions>(nameof(IComponentGenerator.GenerateRadiosAsync));
 
-        var tagHelper = new RadiosTagHelper(componentGeneratorMock.Object, new DefaultModelHelper())
+        var tagHelper = new RadiosTagHelper(componentGenerator, new DefaultModelHelper())
         {
             IdPrefix = idPrefix,
             Name = name,
@@ -69,7 +66,7 @@ public class RadiosTagHelperTests : TagHelperTestBase<RadiosTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(idPrefix, actualOptions.IdPrefix);
         Assert.Equal(name, actualOptions.Name);
         Assert.Equal(hintContent, actualOptions.Hint?.Html);
@@ -138,12 +135,9 @@ public class RadiosTagHelperTests : TagHelperTestBase<RadiosTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        RadiosOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateRadiosAsync(It.IsAny<RadiosOptions>()))
-            .Callback<RadiosOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<RadiosOptions>(nameof(IComponentGenerator.GenerateRadiosAsync));
 
-        var tagHelper = new RadiosTagHelper(componentGeneratorMock.Object, new DefaultModelHelper())
+        var tagHelper = new RadiosTagHelper(componentGenerator, new DefaultModelHelper())
         {
             IdPrefix = idPrefix,
             Name = name,
@@ -156,7 +150,7 @@ public class RadiosTagHelperTests : TagHelperTestBase<RadiosTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(idPrefix, actualOptions.IdPrefix);
         Assert.Equal(name, actualOptions.Name);
         Assert.NotNull(actualOptions.ErrorMessage);
@@ -210,12 +204,9 @@ public class RadiosTagHelperTests : TagHelperTestBase<RadiosTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        RadiosOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateRadiosAsync(It.IsAny<RadiosOptions>()))
-            .Callback<RadiosOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<RadiosOptions>(nameof(IComponentGenerator.GenerateRadiosAsync));
 
-        var tagHelper = new RadiosTagHelper(componentGeneratorMock.Object, new DefaultModelHelper())
+        var tagHelper = new RadiosTagHelper(componentGenerator, new DefaultModelHelper())
         {
             IdPrefix = idPrefix,
             Name = name,
@@ -228,7 +219,7 @@ public class RadiosTagHelperTests : TagHelperTestBase<RadiosTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(idPrefix, actualOptions.IdPrefix);
         Assert.Equal(name, actualOptions.Name);
         Assert.Single(actualOptions.Items!);
@@ -272,12 +263,9 @@ public class RadiosTagHelperTests : TagHelperTestBase<RadiosTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        RadiosOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateRadiosAsync(It.IsAny<RadiosOptions>()))
-            .Callback<RadiosOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<RadiosOptions>(nameof(IComponentGenerator.GenerateRadiosAsync));
 
-        var tagHelper = new RadiosTagHelper(componentGeneratorMock.Object, new DefaultModelHelper())
+        var tagHelper = new RadiosTagHelper(componentGenerator, new DefaultModelHelper())
         {
             IdPrefix = idPrefix,
             Name = name,
@@ -290,7 +278,7 @@ public class RadiosTagHelperTests : TagHelperTestBase<RadiosTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(idPrefix, actualOptions.IdPrefix);
         Assert.Equal(name, actualOptions.Name);
         Assert.Single(actualOptions.Items!);
@@ -336,12 +324,9 @@ public class RadiosTagHelperTests : TagHelperTestBase<RadiosTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        RadiosOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateRadiosAsync(It.IsAny<RadiosOptions>()))
-            .Callback<RadiosOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<RadiosOptions>(nameof(IComponentGenerator.GenerateRadiosAsync));
 
-        var tagHelper = new RadiosTagHelper(componentGeneratorMock.Object, new DefaultModelHelper())
+        var tagHelper = new RadiosTagHelper(componentGenerator, new DefaultModelHelper())
         {
             IdPrefix = idPrefix,
             Name = name,
@@ -354,7 +339,7 @@ public class RadiosTagHelperTests : TagHelperTestBase<RadiosTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(idPrefix, actualOptions.IdPrefix);
         Assert.Equal(name, actualOptions.Name);
         Assert.Single(actualOptions.Items!);
@@ -419,12 +404,9 @@ public class RadiosTagHelperTests : TagHelperTestBase<RadiosTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        RadiosOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateRadiosAsync(It.IsAny<RadiosOptions>()))
-            .Callback<RadiosOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<RadiosOptions>(nameof(IComponentGenerator.GenerateRadiosAsync));
 
-        var tagHelper = new RadiosTagHelper(componentGeneratorMock.Object, new DefaultModelHelper())
+        var tagHelper = new RadiosTagHelper(componentGenerator, new DefaultModelHelper())
         {
             IdPrefix = idPrefix,
             Name = name,
@@ -437,7 +419,7 @@ public class RadiosTagHelperTests : TagHelperTestBase<RadiosTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(idPrefix, actualOptions.IdPrefix);
         Assert.Equal(name, actualOptions.Name);
         Assert.NotNull(actualOptions.Hint);
@@ -495,12 +477,9 @@ public class RadiosTagHelperTests : TagHelperTestBase<RadiosTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        RadiosOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateRadiosAsync(It.IsAny<RadiosOptions>()))
-            .Callback<RadiosOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<RadiosOptions>(nameof(IComponentGenerator.GenerateRadiosAsync));
 
-        var tagHelper = new RadiosTagHelper(componentGeneratorMock.Object, new DefaultModelHelper())
+        var tagHelper = new RadiosTagHelper(componentGenerator, new DefaultModelHelper())
         {
             IdPrefix = idPrefix,
             Name = name,
@@ -513,7 +492,7 @@ public class RadiosTagHelperTests : TagHelperTestBase<RadiosTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Single(actualOptions.Items!);
 
         var item = actualOptions.Items!.ElementAt(0);
@@ -557,12 +536,9 @@ public class RadiosTagHelperTests : TagHelperTestBase<RadiosTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        RadiosOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateRadiosAsync(It.IsAny<RadiosOptions>()))
-            .Callback<RadiosOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<RadiosOptions>(nameof(IComponentGenerator.GenerateRadiosAsync));
 
-        var tagHelper = new RadiosTagHelper(componentGeneratorMock.Object, new DefaultModelHelper())
+        var tagHelper = new RadiosTagHelper(componentGenerator, new DefaultModelHelper())
         {
             IdPrefix = idPrefix,
             Name = name,
@@ -575,7 +551,7 @@ public class RadiosTagHelperTests : TagHelperTestBase<RadiosTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Single(actualOptions.Items!);
 
         var item = actualOptions.Items!.ElementAt(0);

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SelectErrorMessageTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SelectErrorMessageTagHelperTests.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class SelectErrorMessageTagHelperTests
+public class SelectErrorMessageTagHelperTests : TagHelperTestBase<SelectErrorMessageTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_SetsErrorMessageOnContext()
@@ -11,17 +11,10 @@ public class SelectErrorMessageTagHelperTests
         // Arrange
         var selectContext = new SelectContext(@for: null);
 
-        var context = new TagHelperContext(
-            tagName: SelectErrorMessageTagHelper.TagName,
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
-
+        var context = CreateTagHelperContext();
         context.SetContextItem(typeof(FormGroupContext3), selectContext);
 
-        var output = new TagHelperOutput(
-            SelectErrorMessageTagHelper.TagName,
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SelectHintTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SelectHintTagHelperTests.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class SelectHintTagHelperTests
+public class SelectHintTagHelperTests : TagHelperTestBase<SelectHintTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_SetsHintOnContext()
@@ -11,17 +11,10 @@ public class SelectHintTagHelperTests
         // Arrange
         var selectContext = new SelectContext(@for: null);
 
-        var context = new TagHelperContext(
-            tagName: SelectHintTagHelper.TagName,
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
-
+        var context = CreateTagHelperContext();
         context.SetContextItem(typeof(FormGroupContext3), selectContext);
 
-        var output = new TagHelperOutput(
-            SelectHintTagHelper.TagName,
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SelectItemTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SelectItemTagHelperTests.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class SelectItemTagHelperTests
+public class SelectItemTagHelperTests : TagHelperTestBase<SelectItemTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_AddItemsToContext()
@@ -15,18 +15,9 @@ public class SelectItemTagHelperTests
         // Arrange
         var selectContext = new SelectContext(@for: null);
 
-        var context = new TagHelperContext(
-            tagName: "govuk-select-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(SelectContext), selectContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: selectContext);
 
-        var output = new TagHelperOutput(
-            "govuk-select-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -72,18 +63,9 @@ public class SelectItemTagHelperTests
 
         var selectContext = new SelectContext(@for: new ModelExpression(modelExpression, modelExplorer));
 
-        var context = new TagHelperContext(
-            tagName: "govuk-select-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(SelectContext), selectContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: selectContext);
 
-        var output = new TagHelperOutput(
-            "govuk-select-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -124,18 +106,9 @@ public class SelectItemTagHelperTests
 
         var selectContext = new SelectContext(@for: new ModelExpression(modelExpression, modelExplorer));
 
-        var context = new TagHelperContext(
-            tagName: "govuk-select-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(SelectContext), selectContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: selectContext);
 
-        var output = new TagHelperOutput(
-            "govuk-select-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -178,18 +151,9 @@ public class SelectItemTagHelperTests
 
         var selectContext = new SelectContext(@for: new ModelExpression(modelExpression, modelExplorer));
 
-        var context = new TagHelperContext(
-            tagName: "govuk-select-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(SelectContext), selectContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: selectContext);
 
-        var output = new TagHelperOutput(
-            "govuk-select-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SelectLabelTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SelectLabelTagHelperTests.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class SelectLabelTagHelperTests
+public class SelectLabelTagHelperTests : TagHelperTestBase<SelectLabelTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_SetsLabelOnContext()
@@ -11,17 +11,10 @@ public class SelectLabelTagHelperTests
         // Arrange
         var selectContext = new SelectContext(@for: null);
 
-        var context = new TagHelperContext(
-            tagName: SelectLabelTagHelper.TagName,
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
-
+        var context = CreateTagHelperContext();
         context.SetContextItem(typeof(FormGroupContext3), selectContext);
 
-        var output = new TagHelperOutput(
-            SelectLabelTagHelper.TagName,
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SelectTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SelectTagHelperTests.cs
@@ -63,11 +63,9 @@ public class SelectTagHelperTests : TagHelperTestBase<SelectTagHelper>
 
         var modelHelperMock = new Mock<IModelHelper>();
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        SelectOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateSelectInputAsync(It.IsAny<SelectOptions>())).Callback<SelectOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<SelectOptions>(nameof(IComponentGenerator.GenerateSelectInputAsync));
 
-        var tagHelper = new SelectTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new SelectTagHelper(componentGenerator, modelHelperMock.Object)
         {
             Id = id,
             DescribedBy = describedBy,
@@ -88,7 +86,7 @@ public class SelectTagHelperTests : TagHelperTestBase<SelectTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(id, actualOptions.Id?.ToHtmlString());
         Assert.Equal(name, actualOptions.Name?.ToHtmlString());
         Assert.Equal(describedBy, actualOptions.DescribedBy?.ToHtmlString());
@@ -176,11 +174,9 @@ public class SelectTagHelperTests : TagHelperTestBase<SelectTagHelper>
 
         var modelHelperMock = new Mock<IModelHelper>();
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        SelectOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateSelectInputAsync(It.IsAny<SelectOptions>())).Callback<SelectOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<SelectOptions>(nameof(IComponentGenerator.GenerateSelectInputAsync));
 
-        var tagHelper = new SelectTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new SelectTagHelper(componentGenerator, modelHelperMock.Object)
         {
             Id = id,
             Name = name,
@@ -193,7 +189,8 @@ public class SelectTagHelperTests : TagHelperTestBase<SelectTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions?.ErrorMessage);
+        var actualOptions = getActualOptions();
+        Assert.NotNull(actualOptions.ErrorMessage);
         Assert.Equal(errorHtml, actualOptions.ErrorMessage.Html?.ToHtmlString());
         Assert.Equal(errorVht, actualOptions.ErrorMessage.VisuallyHiddenText?.ToHtmlString());
         Assert.NotNull(actualOptions.ErrorMessage.Attributes);
@@ -277,11 +274,9 @@ public class SelectTagHelperTests : TagHelperTestBase<SelectTagHelper>
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        SelectOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateSelectInputAsync(It.IsAny<SelectOptions>())).Callback<SelectOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<SelectOptions>(nameof(IComponentGenerator.GenerateSelectInputAsync));
 
-        var tagHelper = new SelectTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new SelectTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = TestUtils.CreateViewContext()
@@ -293,7 +288,7 @@ public class SelectTagHelperTests : TagHelperTestBase<SelectTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.NotNull(actualOptions.Id);
         Assert.NotNull(actualOptions.Name);
         Assert.Equal(displayName, actualOptions.Label?.Html?.ToHtmlString());

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SkipLinkTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SkipLinkTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class SkipLinkTagHelperTests
+public class SkipLinkTagHelperTests : TagHelperTestBase<SkipLinkTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_InvokesComponentGeneratorWithExpectedOptions()
@@ -13,15 +13,9 @@ public class SkipLinkTagHelperTests
         var content = "Link content";
         var href = "#";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-skip-link",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-skip-link",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SkipLinkTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SkipLinkTagHelperTests.cs
@@ -23,11 +23,9 @@ public class SkipLinkTagHelperTests : TagHelperTestBase<SkipLinkTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        SkipLinkOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateSkipLinkAsync(It.IsAny<SkipLinkOptions>())).Callback<SkipLinkOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<SkipLinkOptions>(nameof(IComponentGenerator.GenerateSkipLinkAsync));
 
-        var tagHelper = new SkipLinkTagHelper(componentGeneratorMock.Object)
+        var tagHelper = new SkipLinkTagHelper(componentGenerator)
         {
             Href = href
         };
@@ -36,8 +34,8 @@ public class SkipLinkTagHelperTests : TagHelperTestBase<SkipLinkTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
-        Assert.Equal(content, actualOptions!.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(content, actualOptions.Html);
         Assert.Null(actualOptions.Text);
         Assert.Equal(href, actualOptions.Href);
     }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TabsItemTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TabsItemTagHelperTests.cs
@@ -3,17 +3,13 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class TabsItemTagHelperTests
+public class TabsItemTagHelperTests : TagHelperTestBase<TabsItemTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_WithIdSpecified_AddsItemToContext()
     {
         // Arrange
-        var context = new TagHelperContext(
-            tagName: "govuk-tabs-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
         var tabsContext = new TabsContext(haveIdPrefix: false);
         context.Items.Add(typeof(TabsContext), tabsContext);
@@ -21,9 +17,7 @@ public class TabsItemTagHelperTests
         var panelContent = new DefaultTagHelperContent();
         panelContent.SetContent("Panel");
 
-        var output = new TagHelperOutput(
-            "govuk-tabs-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 return Task.FromResult<TagHelperContent>(panelContent);
@@ -53,11 +47,7 @@ public class TabsItemTagHelperTests
     public async Task ProcessAsync_WithoutIdSpecified_AddsItemToContext()
     {
         // Arrange
-        var context = new TagHelperContext(
-            tagName: "govuk-tabs-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
         var tabsContext = new TabsContext(haveIdPrefix: true);
         context.Items.Add(typeof(TabsContext), tabsContext);
@@ -65,9 +55,7 @@ public class TabsItemTagHelperTests
         var panelContent = new DefaultTagHelperContent();
         panelContent.SetContent("Panel");
 
-        var output = new TagHelperOutput(
-            "govuk-tabs-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 return Task.FromResult<TagHelperContent>(panelContent);
@@ -96,18 +84,12 @@ public class TabsItemTagHelperTests
     public async Task ProcessAsync_WithoutIdAndNoIdPrefix_ThrowsInvalidOperationException()
     {
         // Arrange
-        var context = new TagHelperContext(
-            tagName: "govuk-tabs-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
         var tabsContext = new TabsContext(haveIdPrefix: false);
         context.Items.Add(typeof(TabsContext), tabsContext);
 
-        var output = new TagHelperOutput(
-            "govuk-tabs-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
@@ -131,18 +113,12 @@ public class TabsItemTagHelperTests
     public async Task ProcessAsync_LabelNotSpecified_ThrowsInvalidOperationException()
     {
         // Arrange
-        var context = new TagHelperContext(
-            tagName: "govuk-tabs-item",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
         var tabsContext = new TabsContext(haveIdPrefix: false);
         context.Items.Add(typeof(TabsContext), tabsContext);
 
-        var output = new TagHelperOutput(
-            "govuk-tabs-item",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TabsTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TabsTagHelperTests.cs
@@ -50,11 +50,9 @@ public class TabsTagHelperTests : TagHelperTestBase<TabsTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        TabsOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateTabsAsync(It.IsAny<TabsOptions>())).Callback<TabsOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<TabsOptions>(nameof(IComponentGenerator.GenerateTabsAsync));
 
-        var tagHelper = new TabsTagHelper(componentGeneratorMock.Object)
+        var tagHelper = new TabsTagHelper(componentGenerator)
         {
             Id = id,
             Title = title
@@ -65,7 +63,7 @@ public class TabsTagHelperTests : TagHelperTestBase<TabsTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(id, actualOptions.Id);
         Assert.Equal(title, actualOptions.Title);
         Assert.NotNull(actualOptions.Items);

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TabsTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TabsTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class TabsTagHelperTests
+public class TabsTagHelperTests : TagHelperTestBase<TabsTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_InvokesComponentGeneratorWithExpectedOptions()
@@ -19,15 +19,9 @@ public class TabsTagHelperTests
         var secondItemLabel = "Second";
         var secondItemContent = "second content";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-tabs",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-tabs",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tabsContext = context.GetContextItem<TabsContext>();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TagTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TagTagHelperTests.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class TagTagHelperTests
+public class TagTagHelperTests : TagHelperTestBase<TagTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_InvokesComponentGeneratorWithExpectedOptions()
@@ -13,15 +13,9 @@ public class TagTagHelperTests
         // Arrange
         var content = "A tag";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-tag",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-tag",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TagTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TagTagHelperTests.cs
@@ -23,17 +23,15 @@ public class TagTagHelperTests : TagHelperTestBase<TagTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        TagOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateTagAsync(It.IsAny<TagOptions>())).Callback<TagOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<TagOptions>(nameof(IComponentGenerator.GenerateTagAsync));
 
-        var tagHelper = new TagTagHelper(componentGeneratorMock.Object);
+        var tagHelper = new TagTagHelper(componentGenerator);
 
         // Act
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
-        Assert.Equal(HtmlEncoder.Default.Encode(content), actualOptions!.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(HtmlEncoder.Default.Encode(content), actualOptions.Html);
     }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TextAreaTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TextAreaTagHelperTests.cs
@@ -56,11 +56,9 @@ public class TextAreaTagHelperTests : TagHelperTestBase<TextAreaTagHelper>
 
         var modelHelperMock = new Mock<IModelHelper>();
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        TextareaOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateTextareaAsync(It.IsAny<TextareaOptions>())).Callback<TextareaOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<TextareaOptions>(nameof(IComponentGenerator.GenerateTextareaAsync));
 
-        var tagHelper = new TextAreaTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new TextAreaTagHelper(componentGenerator, modelHelperMock.Object)
         {
             Id = id,
             DescribedBy = describedBy,
@@ -85,7 +83,7 @@ public class TextAreaTagHelperTests : TagHelperTestBase<TextAreaTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(id, actualOptions.Id);
         Assert.Equal(name, actualOptions.Name);
         Assert.Equal(rows, actualOptions.Rows);
@@ -151,11 +149,9 @@ public class TextAreaTagHelperTests : TagHelperTestBase<TextAreaTagHelper>
 
         var modelHelperMock = new Mock<IModelHelper>();
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        TextareaOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateTextareaAsync(It.IsAny<TextareaOptions>())).Callback<TextareaOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<TextareaOptions>(nameof(IComponentGenerator.GenerateTextareaAsync));
 
-        var tagHelper = new TextAreaTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new TextAreaTagHelper(componentGenerator, modelHelperMock.Object)
         {
             Id = id,
             Name = name,
@@ -168,7 +164,7 @@ public class TextAreaTagHelperTests : TagHelperTestBase<TextAreaTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.NotNull(actualOptions.ErrorMessage);
         Assert.Equal(errorVht, actualOptions.ErrorMessage.VisuallyHiddenText);
         Assert.Equal(errorHtml, actualOptions.ErrorMessage.Html);

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TextAreaValueTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TextAreaValueTagHelperTests.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class TextAreaValueTagHelperTests
+public class TextAreaValueTagHelperTests : TagHelperTestBase<TextAreaValueTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_SetsValueOnContext()
@@ -11,18 +11,9 @@ public class TextAreaValueTagHelperTests
         // Arrange
         var textAreaContext = new TextAreaContext();
 
-        var context = new TagHelperContext(
-            tagName: "govuk-textarea-value",
-            allAttributes: [],
-            items: new Dictionary<object, object>()
-            {
-                { typeof(TextAreaContext), textAreaContext }
-            },
-            uniqueId: "test");
+        var context = CreateTagHelperContext(contexts: textAreaContext);
 
-        var output = new TagHelperOutput(
-            "govuk-textarea-value",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TextInputTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TextInputTagHelperTests.cs
@@ -58,11 +58,9 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
 
         var modelHelperMock = new Mock<IModelHelper>();
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        InputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateInputAsync(It.IsAny<InputOptions>())).Callback<InputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<InputOptions>(nameof(IComponentGenerator.GenerateInputAsync));
 
-        var tagHelper = new TextInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new TextInputTagHelper(componentGenerator, modelHelperMock.Object)
         {
             Id = id,
             DescribedBy = describedBy,
@@ -90,7 +88,7 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(id, actualOptions.Id);
         Assert.Equal(name, actualOptions.Name);
         Assert.Equal(type, actualOptions.Type);
@@ -161,11 +159,9 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
 
         var modelHelperMock = new Mock<IModelHelper>();
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        InputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateInputAsync(It.IsAny<InputOptions>())).Callback<InputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<InputOptions>(nameof(IComponentGenerator.GenerateInputAsync));
 
-        var tagHelper = new TextInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new TextInputTagHelper(componentGenerator, modelHelperMock.Object)
         {
             Id = id,
             Name = name,
@@ -178,7 +174,8 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions?.ErrorMessage);
+        var actualOptions = getActualOptions();
+        Assert.NotNull(actualOptions.ErrorMessage);
         Assert.Equal(errorHtml, actualOptions.ErrorMessage.Html);
         Assert.Equal(errorVht, actualOptions.ErrorMessage.VisuallyHiddenText);
         Assert.NotNull(actualOptions.ErrorMessage.Attributes);
@@ -248,11 +245,9 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        InputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateInputAsync(It.IsAny<InputOptions>())).Callback<InputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<InputOptions>(nameof(IComponentGenerator.GenerateInputAsync));
 
-        var tagHelper = new TextInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new TextInputTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = TestUtils.CreateViewContext()
@@ -264,7 +259,7 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.NotNull(actualOptions.Id);
         Assert.NotNull(actualOptions.Name);
         Assert.Equal(modelStateValue, actualOptions.Value);
@@ -320,11 +315,9 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        InputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateInputAsync(It.IsAny<InputOptions>())).Callback<InputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<InputOptions>(nameof(IComponentGenerator.GenerateInputAsync));
 
-        var tagHelper = new TextInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new TextInputTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = new ViewContext(),
@@ -337,7 +330,8 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal(value, actualOptions?.Value);
+        var actualOptions = getActualOptions();
+        Assert.Equal(value, actualOptions.Value);
     }
 
     [Fact]
@@ -395,11 +389,9 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        InputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateInputAsync(It.IsAny<InputOptions>())).Callback<InputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<InputOptions>(nameof(IComponentGenerator.GenerateInputAsync));
 
-        var tagHelper = new TextInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new TextInputTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = new ViewContext(),
@@ -411,7 +403,8 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal(labelHtml, actualOptions?.Label?.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(labelHtml, actualOptions.Label?.Html);
     }
 
     [Fact]
@@ -470,11 +463,9 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        InputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateInputAsync(It.IsAny<InputOptions>())).Callback<InputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<InputOptions>(nameof(IComponentGenerator.GenerateInputAsync));
 
-        var tagHelper = new TextInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new TextInputTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = new ViewContext(),
@@ -486,7 +477,8 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal(hintHtml, actualOptions?.Hint?.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(hintHtml, actualOptions.Hint?.Html);
     }
 
     [Fact]
@@ -552,11 +544,9 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        InputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateInputAsync(It.IsAny<InputOptions>())).Callback<InputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<InputOptions>(nameof(IComponentGenerator.GenerateInputAsync));
 
-        var tagHelper = new TextInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new TextInputTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = TestUtils.CreateViewContext()
@@ -568,7 +558,8 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal(errorHtml, actualOptions?.ErrorMessage?.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(errorHtml, actualOptions.ErrorMessage?.Html);
     }
 
     [Fact]
@@ -625,11 +616,9 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        InputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateInputAsync(It.IsAny<InputOptions>())).Callback<InputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<InputOptions>(nameof(IComponentGenerator.GenerateInputAsync));
 
-        var tagHelper = new TextInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new TextInputTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             ViewContext = new ViewContext(),
@@ -642,7 +631,8 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Null(actualOptions?.ErrorMessage);
+        var actualOptions = getActualOptions();
+        Assert.Null(actualOptions.ErrorMessage);
     }
 
     [Fact]
@@ -708,11 +698,9 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         var modelExplorer = new EmptyModelMetadataProvider().GetModelExplorerForType(typeof(Model), new Model())
             .GetExplorerForProperty(nameof(Model.SimpleProperty));
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        InputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateInputAsync(It.IsAny<InputOptions>())).Callback<InputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<InputOptions>(nameof(IComponentGenerator.GenerateInputAsync));
 
-        var tagHelper = new TextInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new TextInputTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression(nameof(Model.SimpleProperty), modelExplorer),
             IgnoreModelStateErrors = true,
@@ -725,7 +713,8 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal(errorHtml, actualOptions?.ErrorMessage?.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(errorHtml, actualOptions.ErrorMessage?.Html);
     }
 
     [Fact]
@@ -768,9 +757,9 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
 
         var modelHelperMock = new Mock<IModelHelper>();
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
+        var (componentGenerator, _) = CreateComponentGenerator<InputOptions>(nameof(IComponentGenerator.GenerateInputAsync));
 
-        var tagHelper = new TextInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new TextInputTagHelper(componentGenerator, modelHelperMock.Object)
         {
             Id = id,
             Name = name,
@@ -838,12 +827,9 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
             metadata,
             null);
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        InputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateInputAsync(It.IsAny<InputOptions>()))
-            .Callback<InputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<InputOptions>(nameof(IComponentGenerator.GenerateInputAsync));
 
-        var tagHelper = new TextInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new TextInputTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression("TestProperty", modelExplorer),
             ViewContext = TestUtils.CreateViewContext()
@@ -855,7 +841,7 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(expectedType, actualOptions.Type);
     }
 
@@ -908,12 +894,9 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
             metadata,
             null);
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        InputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateInputAsync(It.IsAny<InputOptions>()))
-            .Callback<InputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<InputOptions>(nameof(IComponentGenerator.GenerateInputAsync));
 
-        var tagHelper = new TextInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new TextInputTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression("TestProperty", modelExplorer),
             ViewContext = TestUtils.CreateViewContext()
@@ -925,7 +908,7 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(expectedType, actualOptions.Type);
     }
 
@@ -970,12 +953,9 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
             metadata,
             null);
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        InputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateInputAsync(It.IsAny<InputOptions>()))
-            .Callback<InputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<InputOptions>(nameof(IComponentGenerator.GenerateInputAsync));
 
-        var tagHelper = new TextInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new TextInputTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression("TestProperty", modelExplorer),
             ViewContext = TestUtils.CreateViewContext()
@@ -987,7 +967,7 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal("text", actualOptions.Type);
     }
 
@@ -1035,12 +1015,9 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
             metadata,
             null);
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        InputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateInputAsync(It.IsAny<InputOptions>()))
-            .Callback<InputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<InputOptions>(nameof(IComponentGenerator.GenerateInputAsync));
 
-        var tagHelper = new TextInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new TextInputTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression("TestProperty", modelExplorer),
             ViewContext = TestUtils.CreateViewContext(),
@@ -1053,7 +1030,7 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(explicitType, actualOptions.Type);
     }
 
@@ -1102,12 +1079,9 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
             metadata,
             null);
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        InputOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateInputAsync(It.IsAny<InputOptions>()))
-            .Callback<InputOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<InputOptions>(nameof(IComponentGenerator.GenerateInputAsync));
 
-        var tagHelper = new TextInputTagHelper(componentGeneratorMock.Object, modelHelperMock.Object)
+        var tagHelper = new TextInputTagHelper(componentGenerator, modelHelperMock.Object)
         {
             For = new ModelExpression("TestProperty", modelExplorer),
             ViewContext = TestUtils.CreateViewContext()
@@ -1119,7 +1093,7 @@ public class TextInputTagHelperTests : TagHelperTestBase<TextInputTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
+        var actualOptions = getActualOptions();
         Assert.Equal(expectedType, actualOptions.Type);
     }
 

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TitleTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TitleTagHelperTests.cs
@@ -4,9 +4,9 @@ using Microsoft.Extensions.Options;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class TitleTagHelperTests
+public class TitleTagHelperTests : TagHelperTestBase<TitleTagHelper>
 {
-    [Theory]
+    [Xunit.Theory]
     [InlineData(false, false, false)]
     [InlineData(true, false, false)]
     [InlineData(false, true, false)]
@@ -22,15 +22,9 @@ public class TitleTagHelperTests
             PrependErrorToTitle = prependErrorToTitleOption
         });
 
-        var context = new TagHelperContext(
-            tagName: "form",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext(tagName: "title");
 
-        var output = new TagHelperOutput(
-            "form",
-            attributes: [],
+        var output = CreateTagHelperOutput(tagName: "title",
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/WarningTextTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/WarningTextTagHelperTests.cs
@@ -24,11 +24,9 @@ public class WarningTextTagHelperTests : TagHelperTestBase<WarningTextTagHelper>
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var componentGeneratorMock = TestUtils.CreateComponentGeneratorMock();
-        WarningTextOptions? actualOptions = null;
-        componentGeneratorMock.Setup(mock => mock.GenerateWarningTextAsync(It.IsAny<WarningTextOptions>())).Callback<WarningTextOptions>(o => actualOptions = o);
+        var (componentGenerator, getActualOptions) = CreateComponentGenerator<WarningTextOptions>(nameof(IComponentGenerator.GenerateWarningTextAsync));
 
-        var tagHelper = new WarningTextTagHelper(componentGeneratorMock.Object, HtmlEncoder.Default)
+        var tagHelper = new WarningTextTagHelper(componentGenerator, HtmlEncoder.Default)
         {
             IconFallbackText = iconFallbackText
         };
@@ -37,8 +35,8 @@ public class WarningTextTagHelperTests : TagHelperTestBase<WarningTextTagHelper>
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.NotNull(actualOptions);
-        Assert.Equal(content, actualOptions!.Html);
+        var actualOptions = getActualOptions();
+        Assert.Equal(content, actualOptions.Html);
         Assert.Null(actualOptions.Text);
         Assert.Equal(iconFallbackText, actualOptions.IconFallbackText);
     }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/WarningTextTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/WarningTextTagHelperTests.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class WarningTextTagHelperTests
+public class WarningTextTagHelperTests : TagHelperTestBase<WarningTextTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_InvokesComponentGeneratorWithExpectedOptions()
@@ -14,15 +14,9 @@ public class WarningTextTagHelperTests
         var iconFallbackText = "Danger";
         var content = "Warning message";
 
-        var context = new TagHelperContext(
-            tagName: "govuk-warning-text",
-            allAttributes: [],
-            items: new Dictionary<object, object>(),
-            uniqueId: "test");
+        var context = CreateTagHelperContext();
 
-        var output = new TagHelperOutput(
-            "govuk-warning-text",
-            attributes: [],
+        var output = CreateTagHelperOutput(
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();


### PR DESCRIPTION
## Summary

- All tag helper test classes that weren't already using `TagHelperTestBase<T>` have been migrated to inherit from it (56 files changed)
- Helper methods from the base class are used where appropriate, consistent with the tests that were already converted

## Changes

Each converted test class now:

- Inherits from `TagHelperTestBase<TTagHelper>`
- Replaces `new TagHelperContext(tagName: "...", allAttributes: [], items: new Dictionary<object, object>(), uniqueId: "test")` with `CreateTagHelperContext(...)`, passing context objects via the `contexts:` parameter
- Replaces `new TagHelperOutput(...)` with `CreateTagHelperOutput(...)`
- In the main `ProcessAsync_InvokesComponentGeneratorWithExpectedOptions` test that verifies class name and attribute passthrough:
  - Uses `CreateDummyClassName()` and `CreateDummyDataAttributes()` in place of hardcoded `"custom-class"` / `"bar"` values
  - Replaces the manual `TestUtils.CreateComponentGeneratorMock()` + `Setup`/`Callback` pattern with `CreateComponentGenerator<TOptions>(nameof(IComponentGenerator.GenerateXxxAsync))`
  - Uses `AssertContainsAttributes(attributes, actualOptions.Attributes)` instead of `Assert.Collection`/`Assert.Contains` assertions on attribute collections

Tests that don't verify attribute/class passthrough (e.g. simple helpers like `SkipLink`, `InsetText`, `WarningText`) retain the manual mock pattern, consistent with comparable already-converted tests in the suite.

The `DateInput*TagHelperTests` files that extend `DateInputItemTagHelperBaseTests<T>` / `DateInputItemLabelTagHelperBaseTests<T>` are unchanged — those base classes already inherit from `TagHelperTestBase<T>`.

## Test plan

- All 1412 tests pass (0 failures, 2 pre-existing skips)