### PR TITLE
Use the `for` attribute in form field docs examples

### DIFF
--- a/docs/components/character-count.md
+++ b/docs/components/character-count.md
@@ -12,7 +12,7 @@ Check out the [max words validator](../validation/maxwords.md) for adding server
 <img alt="Character count example" src="../images/character-count-example.png" />
 
 ```razor
-<govuk-character-count name="more-detail" max-length="200">
+<govuk-character-count for="MoreDetail" max-length="200">
     <govuk-character-count-label class="govuk-label--l" is-page-heading="true">
         Can you provide more detail?
     </govuk-character-count-label>

--- a/docs/components/checkboxes.md
+++ b/docs/components/checkboxes.md
@@ -10,7 +10,7 @@
 <img alt="Checkboxes example" src="../images/checkboxes-example.png" />
 
 ```razor
-<govuk-checkboxes name="nationality">
+<govuk-checkboxes for="Nationalities">
     <govuk-checkboxes-fieldset>
         <govuk-checkboxes-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
             What is your nationality?
@@ -35,8 +35,8 @@
 <img alt="Checkboxes without fieldset example" src="../images/checkboxes-without-fieldset-example.png" />
 
 ```razor
-<govuk-checkboxes name="t-and-c">
-    <govuk-checkboxes-item value="yes">
+<govuk-checkboxes for="AcceptedTermsAndConditions">
+    <govuk-checkboxes-item value="true">
         I agree to the terms and conditions
     </govuk-checkboxes-item>
 </govuk-checkboxes>
@@ -47,7 +47,7 @@
 <img alt="Checkboxes with conditional reveal example" src="../images/checkboxes-with-conditional-example.png" />
 
 ```razor
-<govuk-checkboxes name="contact">
+<govuk-checkboxes for="ContactPreferences">
     <govuk-checkboxes-fieldset>
         <govuk-checkboxes-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
             How would you like to be contacted?
@@ -60,7 +60,7 @@
         <govuk-checkboxes-item value="email">
             Email
             <govuk-checkboxes-item-conditional>
-                <govuk-input name="contact-by-email" type="email" autocomplete="email" spellcheck="false" input-class="govuk-!-width-one-third">
+                <govuk-input for="EmailAddress" type="email" autocomplete="email" spellcheck="false" input-class="govuk-!-width-one-third">
                     <govuk-input-label>Email address</govuk-input-label>
                 </govuk-input>
             </govuk-checkboxes-item-conditional>
@@ -69,7 +69,7 @@
         <govuk-checkboxes-item value="phone">
             Phone
             <govuk-checkboxes-item-conditional>
-                <govuk-input name="contact-by-phone" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
+                <govuk-input for="PhoneNumber" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
                     <govuk-input-label>Phone number</govuk-input-label>
                 </govuk-input>
             </govuk-checkboxes-item-conditional>
@@ -78,7 +78,7 @@
         <govuk-checkboxes-item value="text message">
             Text message
             <govuk-checkboxes-item-conditional>
-                <govuk-input name="contact-by-text" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
+                <govuk-input for="MobilePhoneNumber" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
                     <govuk-input-label>Mobile phone number</govuk-input-label>
                 </govuk-input>
             </govuk-checkboxes-item-conditional>
@@ -92,7 +92,7 @@
 <img alt="Checkboxes with &#x27;none&#x27; option example" src="../images/checkboxes-with-none-example.png" />
 
 ```razor
-<govuk-checkboxes name="countries">
+<govuk-checkboxes for="CountriesTravellingTo">
     <govuk-checkboxes-fieldset>
         <govuk-checkboxes-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
             Will you be travelling to any of these countries?

--- a/docs/components/date-input.md
+++ b/docs/components/date-input.md
@@ -10,7 +10,7 @@
 <img alt="Date input example" src="../images/date-input-example.png" />
 
 ```razor
-<govuk-date-input id="passport-issued" name-prefix="passport-issued" />
+<govuk-date-input for="PassportIssued" />
 ```
 
 
@@ -50,7 +50,7 @@
 <img alt="Date input with custom item labels example" src="../images/date-input-with-custom-item-labels-example.png" />
 
 ```razor
-<govuk-date-input id="passport-issued" name-prefix="passport-issued">
+<govuk-date-input for="PassportIssued">
     <govuk-date-input-day>
         <govuk-date-input-day-label>Dydd</govuk-date-input-day-label>
     </govuk-date-input-day>
@@ -68,7 +68,7 @@
 <img alt="Date input with custom item values example" src="../images/date-input-with-custom-item-values-example.png" />
 
 ```razor
-<govuk-date-input id="passport-issued" name-prefix="passport-issued" error-message-prefix="Your passport issue date">
+<govuk-date-input for="PassportIssued" error-message-prefix="Your passport issue date">
     <govuk-date-input-day value="1" />
     <govuk-date-input-month value="4" />
     <govuk-date-input-year value="2022" />
@@ -80,7 +80,7 @@
 <img alt="Date input with day and month only example" src="../images/date-input-with-day-and-month-only-example.png" />
 
 ```razor
-<govuk-date-input item-types="DateInputItemTypes.DayAndMonth" id="birthday" name-prefix="birthday" error-message-prefix="Your birthday">
+<govuk-date-input for="Birthday" item-types="DateInputItemTypes.DayAndMonth" error-message-prefix="Your birthday">
     <govuk-date-input-fieldset>
         <govuk-date-input-fieldset-legend>What is your birthday?</govuk-date-input-fieldset-legend>
     </govuk-date-input-fieldset>
@@ -92,7 +92,7 @@
 <img alt="Date input with month and year only example" src="../images/date-input-with-month-and-year-only-example.png" />
 
 ```razor
-<govuk-date-input item-types="DateInputItemTypes.MonthAndYear" id="date-moved" name-prefix="DateMoved" error-message-prefix="The date you moved into this property">
+<govuk-date-input for="DateMovedIn" item-types="DateInputItemTypes.MonthAndYear" error-message-prefix="The date you moved into this property">
     <govuk-date-input-fieldset>
         <govuk-date-input-fieldset-legend>When did you move into this property?</govuk-date-input-fieldset-legend>
     </govuk-date-input-fieldset>

--- a/docs/components/file-upload.md
+++ b/docs/components/file-upload.md
@@ -10,7 +10,7 @@
 <img alt="File upload example" src="../images/file-upload-example.png" />
 
 ```razor
-<govuk-file-upload name="FileUpload1">
+<govuk-file-upload for="Document">
     <govuk-file-upload-label>Upload a file</govuk-file-upload-label>
 </govuk-file-upload>
 ```
@@ -31,7 +31,7 @@
 <img alt="File upload with JavaScript enhancements example" src="../images/file-upload-with-javascript-enhancements-example.png" />
 
 ```razor
-<govuk-file-upload name="FileUpload1" javascript-enhancements="true">
+<govuk-file-upload for="Document" javascript-enhancements="true">
     <govuk-file-upload-label>Upload a file</govuk-file-upload-label>
 </govuk-file-upload>
 ```

--- a/docs/components/password-input.md
+++ b/docs/components/password-input.md
@@ -10,7 +10,7 @@
 <img alt="Password input example" src="../images/password-input-example.png" />
 
 ```razor
-<govuk-password-input name="Password">
+<govuk-password-input for="Password">
     <govuk-password-input-label>Password</govuk-password-input-label>
 </govuk-password-input>
 ```

--- a/docs/components/radios.md
+++ b/docs/components/radios.md
@@ -10,7 +10,7 @@
 <img alt="Radios example" src="../images/radios-example.png" />
 
 ```razor
-<govuk-radios name="where-do-you-live">
+<govuk-radios for="WhereDoYouLive">
     <govuk-radios-fieldset>
         <govuk-radios-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
             Where do you live?
@@ -35,7 +35,7 @@
 <img alt="Radios with conditional reveal example" src="../images/radios-with-conditional-example.png" />
 
 ```razor
-<govuk-radios name="how-contacted" id-prefix="contact">
+<govuk-radios for="HowContacted">
     <govuk-radios-fieldset>
         <govuk-radios-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
             How would you prefer to be contacted?
@@ -58,7 +58,7 @@
         <govuk-radios-item value="phone">
             Phone
             <govuk-radios-item-conditional>
-                <govuk-input id="contact-by-phone" name="contact-by-phone" type="tel" autocomplete="tel" class="govuk-!-width-one-third">
+                <govuk-input for="PhoneNumber" type="tel" autocomplete="tel" class="govuk-!-width-one-third">
                     <govuk-input-label>Phone number</govuk-input-label>
                 </govuk-input>
             </govuk-radios-item-conditional>
@@ -67,7 +67,7 @@
         <govuk-radios-item value="text">
             Text message
             <govuk-radios-item-conditional>
-                <govuk-input id="contact-by-text" name="contact-by-text" type="tel" autocomplete="tel" class="govuk-!-width-one-third">
+                <govuk-input for="MobilePhoneNumber" type="tel" autocomplete="tel" class="govuk-!-width-one-third">
                     <govuk-input-label>Mobile phone number</govuk-input-label>
                 </govuk-input>
             </govuk-radios-item-conditional>

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -10,10 +10,10 @@
 <img alt="Select example" src="../images/select-example.png" />
 
 ```razor
-<govuk-select name="Sort">
+<govuk-select for="SortBy">
     <govuk-select-label>Sort by</govuk-select-label>
     <govuk-select-item value="published">Recently published</govuk-select-item>
-    <govuk-select-item value="updated" selected="true">Recently updated</govuk-select-item>
+    <govuk-select-item value="updated">Recently updated</govuk-select-item>
     <govuk-select-item value="views">Most views</govuk-select-item>
     <govuk-select-item value="comments">Most comments</govuk-select-item>
 </govuk-select>

--- a/docs/components/text-input.md
+++ b/docs/components/text-input.md
@@ -10,7 +10,7 @@
 <img alt="Text input example" src="../images/text-input-example.png" />
 
 ```razor
-<govuk-input name="AccountNumber" input-class="govuk-input--width-10" inputmode="numeric" pattern="[0-9]*" spellcheck="false">
+<govuk-input for="AccountNumber" input-class="govuk-input--width-10" inputmode="numeric" pattern="[0-9]*" spellcheck="false">
     <govuk-input-label is-page-heading="true" class="govuk-label--l">What is your account number?</govuk-input-label>
     <govuk-input-hint>Must be between 6 and 8 digits long</govuk-input-hint>
 </govuk-input>
@@ -33,7 +33,7 @@
 <img alt="Text input with prefix and suffix example" src="../images/text-input-with-prefix-and-suffix-example.png" />
 
 ```razor
-<govuk-input name="AccountNumber" input-class="govuk-input--width-5" spellcheck="false">
+<govuk-input for="CostPerItem" input-class="govuk-input--width-5" spellcheck="false">
     <govuk-input-label is-page-heading="true" class="govuk-label--l">What is the cost per item, in pounds?</govuk-input-label>
     <govuk-input-prefix>&pound;</govuk-input-prefix>
     <govuk-input-suffix>per item</govuk-input-suffix>

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -10,7 +10,7 @@
 <img alt="Textarea example" src="../images/textarea-example.png" />
 
 ```razor
-<govuk-textarea name="more-detail">
+<govuk-textarea for="MoreDetail">
     <govuk-textarea-label class="govuk-label--l" is-page-heading="true">
         Can you provide more detail?
     </govuk-textarea-label>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/CharacterCount/CharacterCountExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/CharacterCount/CharacterCountExample.cshtml
@@ -1,7 +1,8 @@
 @page
+@model CharacterCountExampleModel
 
 <example>
-    <govuk-character-count name="more-detail" max-length="200">
+    <govuk-character-count for="MoreDetail" max-length="200">
         <govuk-character-count-label class="govuk-label--l" is-page-heading="true">
             Can you provide more detail?
         </govuk-character-count-label>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/CharacterCount/CharacterCountExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/CharacterCount/CharacterCountExample.cshtml.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.CharacterCount;
+
+public class CharacterCountExampleModel : PageModel
+{
+    public string? MoreDetail { get; set; }
+}

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesExample.cshtml
@@ -1,7 +1,8 @@
 @page
+@model CheckboxesExampleModel
 
 <example>
-    <govuk-checkboxes name="nationality">
+    <govuk-checkboxes for="Nationalities">
         <govuk-checkboxes-fieldset>
             <govuk-checkboxes-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
                 What is your nationality?

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesExample.cshtml.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.Checkboxes;
+
+public class CheckboxesExampleModel : PageModel
+{
+    public string[]? Nationalities { get; set; }
+}

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithConditionalExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithConditionalExample.cshtml
@@ -1,7 +1,8 @@
 @page
+@model CheckboxesWithConditionalExampleModel
 
 <example>
-    <govuk-checkboxes name="contact">
+    <govuk-checkboxes for="ContactPreferences">
         <govuk-checkboxes-fieldset>
             <govuk-checkboxes-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
                 How would you like to be contacted?
@@ -14,7 +15,7 @@
             <govuk-checkboxes-item value="email">
                 Email
                 <govuk-checkboxes-item-conditional>
-                    <govuk-input name="contact-by-email" type="email" autocomplete="email" spellcheck="false" input-class="govuk-!-width-one-third">
+                    <govuk-input for="EmailAddress" type="email" autocomplete="email" spellcheck="false" input-class="govuk-!-width-one-third">
                         <govuk-input-label>Email address</govuk-input-label>
                     </govuk-input>
                 </govuk-checkboxes-item-conditional>
@@ -23,7 +24,7 @@
             <govuk-checkboxes-item value="phone">
                 Phone
                 <govuk-checkboxes-item-conditional>
-                    <govuk-input name="contact-by-phone" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
+                    <govuk-input for="PhoneNumber" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
                         <govuk-input-label>Phone number</govuk-input-label>
                     </govuk-input>
                 </govuk-checkboxes-item-conditional>
@@ -32,7 +33,7 @@
             <govuk-checkboxes-item value="text message">
                 Text message
                 <govuk-checkboxes-item-conditional>
-                    <govuk-input name="contact-by-text" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
+                    <govuk-input for="MobilePhoneNumber" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
                         <govuk-input-label>Mobile phone number</govuk-input-label>
                     </govuk-input>
                 </govuk-checkboxes-item-conditional>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithConditionalExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithConditionalExample.cshtml.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.Checkboxes;
+
+public class CheckboxesWithConditionalExampleModel : PageModel
+{
+    public string[]? ContactPreferences { get; set; }
+
+    public string? EmailAddress { get; set; }
+
+    public string? PhoneNumber { get; set; }
+
+    public string? MobilePhoneNumber { get; set; }
+}

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithNoneExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithNoneExample.cshtml
@@ -1,7 +1,8 @@
 @page
+@model CheckboxesWithNoneExampleModel
 
 <example>
-    <govuk-checkboxes name="countries">
+    <govuk-checkboxes for="CountriesTravellingTo">
         <govuk-checkboxes-fieldset>
             <govuk-checkboxes-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
                 Will you be travelling to any of these countries?

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithNoneExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithNoneExample.cshtml.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.Checkboxes;
+
+public class CheckboxesWithNoneExampleModel : PageModel
+{
+    public string[]? CountriesTravellingTo { get; set; }
+}

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithoutFieldsetExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithoutFieldsetExample.cshtml
@@ -1,8 +1,9 @@
 @page
+@model CheckboxesWithoutFieldsetExampleModel
 
 <example>
-    <govuk-checkboxes name="t-and-c">
-        <govuk-checkboxes-item value="yes">
+    <govuk-checkboxes for="AcceptedTermsAndConditions">
+        <govuk-checkboxes-item value="true">
             I agree to the terms and conditions
         </govuk-checkboxes-item>
     </govuk-checkboxes>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithoutFieldsetExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithoutFieldsetExample.cshtml.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.Checkboxes;
+
+public class CheckboxesWithoutFieldsetExampleModel : PageModel
+{
+    public bool AcceptedTermsAndConditions { get; set; }
+}

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputExample.cshtml
@@ -1,5 +1,6 @@
 @page
+@model DateInputExampleModel
 
 <example>
-    <govuk-date-input id="passport-issued" name-prefix="passport-issued" />
+    <govuk-date-input for="PassportIssued" />
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputExample.cshtml.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.DateInput;
+
+public class DateInputExampleModel : PageModel
+{
+    public DateOnly? PassportIssued { get; set; }
+}

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithCustomItemLabelsExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithCustomItemLabelsExample.cshtml
@@ -1,7 +1,8 @@
 @page
+@model DateInputWithCustomItemLabelsExampleModel
 
 <example>
-    <govuk-date-input id="passport-issued" name-prefix="passport-issued">
+    <govuk-date-input for="PassportIssued">
         <govuk-date-input-day>
             <govuk-date-input-day-label>Dydd</govuk-date-input-day-label>
         </govuk-date-input-day>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithCustomItemLabelsExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithCustomItemLabelsExample.cshtml.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.DateInput;
+
+public class DateInputWithCustomItemLabelsExampleModel : PageModel
+{
+    public DateOnly? PassportIssued { get; set; }
+}

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithCustomItemValuesExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithCustomItemValuesExample.cshtml
@@ -1,7 +1,8 @@
 @page
+@model DateInputWithCustomItemValuesExampleModel
 
 <example>
-    <govuk-date-input id="passport-issued" name-prefix="passport-issued" error-message-prefix="Your passport issue date">
+    <govuk-date-input for="PassportIssued" error-message-prefix="Your passport issue date">
         <govuk-date-input-day value="1" />
         <govuk-date-input-month value="4" />
         <govuk-date-input-year value="2022" />

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithCustomItemValuesExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithCustomItemValuesExample.cshtml.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.DateInput;
+
+public class DateInputWithCustomItemValuesExampleModel : PageModel
+{
+    public DateOnly? PassportIssued { get; set; }
+}

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithDayAndMonthOnlyExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithDayAndMonthOnlyExample.cshtml
@@ -1,7 +1,8 @@
 @page
+@model DateInputWithDayAndMonthOnlyExampleModel
 
 <example>
-    <govuk-date-input item-types="DateInputItemTypes.DayAndMonth" id="birthday" name-prefix="birthday" error-message-prefix="Your birthday">
+    <govuk-date-input for="Birthday" item-types="DateInputItemTypes.DayAndMonth" error-message-prefix="Your birthday">
         <govuk-date-input-fieldset>
             <govuk-date-input-fieldset-legend>What is your birthday?</govuk-date-input-fieldset-legend>
         </govuk-date-input-fieldset>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithDayAndMonthOnlyExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithDayAndMonthOnlyExample.cshtml.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.DateInput;
+
+public class DateInputWithDayAndMonthOnlyExampleModel : PageModel
+{
+    public (int Day, int Month)? Birthday { get; set; }
+}

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithMonthAndYearOnlyExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithMonthAndYearOnlyExample.cshtml
@@ -1,7 +1,8 @@
 @page
+@model DateInputWithMonthAndYearOnlyExampleModel
 
 <example>
-    <govuk-date-input item-types="DateInputItemTypes.MonthAndYear" id="date-moved" name-prefix="DateMoved" error-message-prefix="The date you moved into this property">
+    <govuk-date-input for="DateMovedIn" item-types="DateInputItemTypes.MonthAndYear" error-message-prefix="The date you moved into this property">
         <govuk-date-input-fieldset>
             <govuk-date-input-fieldset-legend>When did you move into this property?</govuk-date-input-fieldset-legend>
         </govuk-date-input-fieldset>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithMonthAndYearOnlyExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithMonthAndYearOnlyExample.cshtml.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.DateInput;
+
+public class DateInputWithMonthAndYearOnlyExampleModel : PageModel
+{
+    public (int Month, int Year)? DateMovedIn { get; set; }
+}

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/FileUpload/FileUploadExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/FileUpload/FileUploadExample.cshtml
@@ -1,7 +1,8 @@
 @page
+@model FileUploadExampleModel
 
 <example>
-    <govuk-file-upload name="FileUpload1">
+    <govuk-file-upload for="Document">
         <govuk-file-upload-label>Upload a file</govuk-file-upload-label>
     </govuk-file-upload>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/FileUpload/FileUploadExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/FileUpload/FileUploadExample.cshtml.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.FileUpload;

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/FileUpload/FileUploadExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/FileUpload/FileUploadExample.cshtml.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.FileUpload;
+
+public class FileUploadExampleModel : PageModel
+{
+    public IFormFile? Document { get; set; }
+}

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/FileUpload/FileUploadWithJavascriptEnhancementsExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/FileUpload/FileUploadWithJavascriptEnhancementsExample.cshtml
@@ -1,7 +1,8 @@
 @page
+@model FileUploadWithJavascriptEnhancementsExampleModel
 
 <example>
-    <govuk-file-upload name="FileUpload1" javascript-enhancements="true">
+    <govuk-file-upload for="Document" javascript-enhancements="true">
         <govuk-file-upload-label>Upload a file</govuk-file-upload-label>
     </govuk-file-upload>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/FileUpload/FileUploadWithJavascriptEnhancementsExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/FileUpload/FileUploadWithJavascriptEnhancementsExample.cshtml.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.FileUpload;

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/FileUpload/FileUploadWithJavascriptEnhancementsExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/FileUpload/FileUploadWithJavascriptEnhancementsExample.cshtml.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.FileUpload;
+
+public class FileUploadWithJavascriptEnhancementsExampleModel : PageModel
+{
+    public IFormFile? Document { get; set; }
+}

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/PasswordInput/PasswordInputExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/PasswordInput/PasswordInputExample.cshtml
@@ -1,7 +1,8 @@
-﻿@page
+@page
+@model PasswordInputExampleModel
 
 <example>
-    <govuk-password-input name="Password">
+    <govuk-password-input for="Password">
         <govuk-password-input-label>Password</govuk-password-input-label>
     </govuk-password-input>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/PasswordInput/PasswordInputExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/PasswordInput/PasswordInputExample.cshtml.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.PasswordInput;
+
+public class PasswordInputExampleModel : PageModel
+{
+    public string? Password { get; set; }
+}

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Radios/RadiosExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Radios/RadiosExample.cshtml
@@ -1,7 +1,8 @@
 @page
+@model RadiosExampleModel
 
 <example>
-    <govuk-radios name="where-do-you-live">
+    <govuk-radios for="WhereDoYouLive">
         <govuk-radios-fieldset>
             <govuk-radios-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
                 Where do you live?

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Radios/RadiosExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Radios/RadiosExample.cshtml.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.Radios;
+
+public class RadiosExampleModel : PageModel
+{
+    public string? WhereDoYouLive { get; set; }
+}

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Radios/RadiosWithConditionalExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Radios/RadiosWithConditionalExample.cshtml
@@ -1,7 +1,8 @@
 @page
+@model RadiosWithConditionalExampleModel
 
 <example>
-    <govuk-radios name="how-contacted" id-prefix="contact">
+    <govuk-radios for="HowContacted">
         <govuk-radios-fieldset>
             <govuk-radios-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
                 How would you prefer to be contacted?
@@ -24,7 +25,7 @@
             <govuk-radios-item value="phone">
                 Phone
                 <govuk-radios-item-conditional>
-                    <govuk-input id="contact-by-phone" name="contact-by-phone" type="tel" autocomplete="tel" class="govuk-!-width-one-third">
+                    <govuk-input for="PhoneNumber" type="tel" autocomplete="tel" class="govuk-!-width-one-third">
                         <govuk-input-label>Phone number</govuk-input-label>
                     </govuk-input>
                 </govuk-radios-item-conditional>
@@ -33,7 +34,7 @@
             <govuk-radios-item value="text">
                 Text message
                 <govuk-radios-item-conditional>
-                    <govuk-input id="contact-by-text" name="contact-by-text" type="tel" autocomplete="tel" class="govuk-!-width-one-third">
+                    <govuk-input for="MobilePhoneNumber" type="tel" autocomplete="tel" class="govuk-!-width-one-third">
                         <govuk-input-label>Mobile phone number</govuk-input-label>
                     </govuk-input>
                 </govuk-radios-item-conditional>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Radios/RadiosWithConditionalExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Radios/RadiosWithConditionalExample.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.Radios;
+
+public class RadiosWithConditionalExampleModel : PageModel
+{
+    public string? HowContacted { get; set; }
+
+    public string? PhoneNumber { get; set; }
+
+    public string? MobilePhoneNumber { get; set; }
+}

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Select/SelectExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Select/SelectExample.cshtml
@@ -1,10 +1,11 @@
 @page
+@model SelectExampleModel
 
 <example>
-    <govuk-select name="Sort">
+    <govuk-select for="SortBy">
         <govuk-select-label>Sort by</govuk-select-label>
         <govuk-select-item value="published">Recently published</govuk-select-item>
-        <govuk-select-item value="updated" selected="true">Recently updated</govuk-select-item>
+        <govuk-select-item value="updated">Recently updated</govuk-select-item>
         <govuk-select-item value="views">Most views</govuk-select-item>
         <govuk-select-item value="comments">Most comments</govuk-select-item>
     </govuk-select>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Select/SelectExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Select/SelectExample.cshtml.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.Select;
+
+public class SelectExampleModel : PageModel
+{
+    public string? SortBy { get; set; }
+
+    public void OnGet()
+    {
+        SortBy = "updated";
+    }
+}

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextArea/TextAreaExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextArea/TextAreaExample.cshtml
@@ -1,7 +1,8 @@
 @page
+@model TextAreaExampleModel
 
 <example>
-    <govuk-textarea name="more-detail">
+    <govuk-textarea for="MoreDetail">
         <govuk-textarea-label class="govuk-label--l" is-page-heading="true">
             Can you provide more detail?
         </govuk-textarea-label>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextArea/TextAreaExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextArea/TextAreaExample.cshtml.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.TextArea;
+
+public class TextAreaExampleModel : PageModel
+{
+    public string? MoreDetail { get; set; }
+}

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextInput/TextInputExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextInput/TextInputExample.cshtml
@@ -1,7 +1,8 @@
 @page
+@model TextInputExampleModel
 
 <example>
-    <govuk-input name="AccountNumber" input-class="govuk-input--width-10" inputmode="numeric" pattern="[0-9]*" spellcheck="false">
+    <govuk-input for="AccountNumber" input-class="govuk-input--width-10" inputmode="numeric" pattern="[0-9]*" spellcheck="false">
         <govuk-input-label is-page-heading="true" class="govuk-label--l">What is your account number?</govuk-input-label>
         <govuk-input-hint>Must be between 6 and 8 digits long</govuk-input-hint>
     </govuk-input>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextInput/TextInputExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextInput/TextInputExample.cshtml.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.TextInput;
+
+public class TextInputExampleModel : PageModel
+{
+    public string? AccountNumber { get; set; }
+}

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextInput/TextInputWithPrefixAndSuffixExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextInput/TextInputWithPrefixAndSuffixExample.cshtml
@@ -1,7 +1,8 @@
 @page
+@model TextInputWithPrefixAndSuffixExampleModel
 
 <example>
-    <govuk-input name="AccountNumber" input-class="govuk-input--width-5" spellcheck="false">
+    <govuk-input for="CostPerItem" input-class="govuk-input--width-5" spellcheck="false">
         <govuk-input-label is-page-heading="true" class="govuk-label--l">What is the cost per item, in pounds?</govuk-input-label>
         <govuk-input-prefix>&pound;</govuk-input-prefix>
         <govuk-input-suffix>per item</govuk-input-suffix>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextInput/TextInputWithPrefixAndSuffixExample.cshtml.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextInput/TextInputWithPrefixAndSuffixExample.cshtml.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GovUk.Frontend.AspNetCore.Docs.Pages.Examples.TextInput;
+
+public class TextInputWithPrefixAndSuffixExampleModel : PageModel
+{
+    public decimal? CostPerItem { get; set; }
+}


### PR DESCRIPTION
The documentation examples for components that generate form fields (text input, select, radios, checkboxes, date input, textarea, character count, password input, file upload) bound their inputs with `name`/`id` — and `name-prefix`/`id-prefix` for date input and radios. That is not how these components are normally used in an app, where the input is bound to a model property.

Each of those examples now uses `for="<Property>"`, backed by a new `PageModel` per example page. Property names were chosen to fit the subject of the example rather than something generic: `AccountNumber`, `CostPerItem`, `MoreDetail`, `SortBy`, `Password`, `Document`, `WhereDoYouLive`, `HowContacted`, `Nationalities`, `CountriesTravellingTo`, `ContactPreferences`, `AcceptedTermsAndConditions`, `PassportIssued`, `Birthday`, `DateMovedIn`.

The generated markdown under `docs/components` was regenerated with `dotnet run --project src/GovUk.Frontend.AspNetCore.Docs -- publish`. No screenshots changed, since nothing visible about the rendered components is different.

## Examples deliberately left alone

Examples that set an explicit `error-message` still use `name`/`id`. Setting the error message explicitly is the alternative to letting `ModelState` drive it, so pairing it with `for` would be misleading. That covers text input with error message, radios with error, checkboxes with error, date input with error message, date input with fieldset, and file upload with error message.

The radios conditional-reveal example is a partial case: only the email input inside it sets an explicit error message, so that single input keeps `id`/`name` while the radios group and the other two conditional inputs use `for`.

## Notes for reviewers

A few examples needed more than a mechanical attribute swap:

- **Select** previously hard-coded `selected="true"` on "Recently updated". With `for`, the selected option follows the model, so the attribute is gone and `SortBy` is set in `OnGet`. The rendered `<option>` is still marked `selected`.
- **Checkboxes without a fieldset** bound a `"yes"` value that could not round-trip. It now binds a `bool AcceptedTermsAndConditions` with `value="true"`.
- **Partial date inputs** bind to nullable value tuples (`(int Day, int Month)?` and `(int Month, int Year)?`), which is what `TupleDateInputModelConverter` expects. The explicit `item-types` attribute stays on the tag, because the snippet extractor only emits the markup inside `<example>` — a reader of the docs never sees the page model, so dropping it in favour of `[DateInput(...)]` on the property would hide how a partial date is declared.

Verified by serving the docs site and inspecting the rendered HTML: the date inputs emit `Birthday.Day`/`Birthday.Month` and `DateMovedIn.Month`/`DateMovedIn.Year`, the radios emit `data-aria-controls` pointing at correctly derived conditional ids, and the remaining inputs get sensible names and ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)