### PR TITLE
Upgrade to govuk-frontend 6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Targets GOV.UK Frontend v6.3.0.
+
 Added `GetJavascriptFileName()` and `GetStylesheetFileName()` methods to `PageTemplateHelper`.
 
 ## 4.2.1

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <RepoRoot>$([MSBuild]::EnsureTrailingSlash('$(MSBuildThisFileDirectory)'))</RepoRoot>
     <Nullable>enable</Nullable>
     <PackageOutputPath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'packages'))</PackageOutputPath>
-    <GovUkFrontendVersion>6.2.0</GovUkFrontendVersion>
+    <GovUkFrontendVersion>6.3.0</GovUkFrontendVersion>
 
     <IsTestProject Condition="'$(IsTestProject)' == '' and $(MSBuildProjectName.EndsWith('Tests'))">true</IsTestProject>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GOV.UK Frontend for ASP.NET Core
 
-[![GOV.UK Design System version](https://img.shields.io/badge/GOV.UK%20Design%20System-6.2.0-brightgreen)](https://github.com/alphagov/govuk-frontend/releases/tag/v6.2.0)
+[![GOV.UK Design System version](https://img.shields.io/badge/GOV.UK%20Design%20System-6.3.0-brightgreen)](https://github.com/alphagov/govuk-frontend/releases/tag/v6.3.0)
 [![Build](https://github.com/x-govuk/govuk-frontend-aspnetcore/actions/workflows/build.yml/badge.svg)](https://github.com/x-govuk/govuk-frontend-aspnetcore/actions/workflows/build.yml)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/GovUk.Frontend.AspNetCore)](https://www.nuget.org/packages/GovUk.Frontend.AspNetCore)
 

--- a/src/GovUk.Frontend.AspNetCore/govuk-frontend.scss
+++ b/src/GovUk.Frontend.AspNetCore/govuk-frontend.scss
@@ -1,6 +1,6 @@
 @use "sass:meta";
 @use "Package/content/support" as support;
-@use "../../lib/govuk-frontend-6.2.0/dist/govuk" as * with (
+@use "../../lib/govuk-frontend-6.3.0/dist/govuk" as * with (
   $govuk-font-url-function: meta.get-function("versioned-font-url", $module: "support"),
   $govuk-image-url-function: meta.get-function("versioned-image-url", $module: "support")
 );


### PR DESCRIPTION
## What

Upgrades the targeted GOV.UK Frontend version from 6.2.0 to 6.3.0.

- `Directory.Build.props` — `GovUkFrontendVersion` → `6.3.0`
- `README.md` — Design System version badge → 6.3.0
- `CHANGELOG.md` — noted "Targets GOV.UK Frontend v6.3.0."
- `govuk-frontend.scss` — `@use` path auto-rewritten to the 6.3.0 lib by the build's `UpdateScssImports` target

## Why no component/generator changes were needed

[govuk-frontend 6.3.0](https://github.com/alphagov/govuk-frontend/releases/tag/v6.3.0) contains:

- **A new generic-header component** — intentionally **not** wired up here; tag helpers for it will be a separate follow-up.
- **Two CSS-only fixes** — explicit colour on input prefix/suffix, and small inline radio text no longer wrapping unnecessarily. These ride along in the recompiled stylesheet with no template or option changes.

The existing `header` component's template now delegates internally to the generic-header macro (via a private `_namespace: 'govuk'` param), but the rendered markup is identical — confirmed by the fixture-based HTML comparison tests still passing.

## Verification

- Library **Release build clean** (0 warnings, with `TreatWarningsAsErrors`)
- **Tests: 1422 passed**, 2 pre-existing skips (component fixtures auto-refresh from the restored 6.3.0 package)
- **IntegrationTests: 63 passed**
- Packed the NuGet package and **built Samples.Sass against it** to confirm SASS compilation works end-to-end on 6.3.0

## Note for reviewers

A clean checkout needs `dotnet tool restore` before the first build so the `libman` CLI is available for `InstallGovUkFrontendPackage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)