### PR TITLE
Throw when panel actions are used without the interruption variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Targets GOV.UK Frontend v6.4.0.
 
 Start buttons with HTML content now wrap that content in a `<span>` to match the updated component.
 
-Added support for the interruption variant of the panel component, including the new `govuk-panel-actions`, `govuk-panel-action-button` and `govuk-panel-action-link` tag helpers. The action tag helpers take their content as the button/link text and support generated `formaction`/`href` attributes via the routing (`asp-*`) attributes.
+Added support for the interruption variant of the panel component, including the new `govuk-panel-actions`, `govuk-panel-action-button` and `govuk-panel-action-link` tag helpers. The action tag helpers take their content as the button/link text and support generated `formaction`/`href` attributes via the routing (`asp-*`) attributes. Specifying actions on a panel that isn't an interruption panel (i.e. without the `govuk-panel--interruption` class) now throws.
 
 The panel tag helpers now also support short tag names: `<panel-title>`, `<panel-body>`, `<panel-actions>`, `<action-button>` and `<action-link>`. As with the summary list component, short and long tag names cannot be mixed.
 

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/PanelActionsTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/PanelActionsTagHelper.cs
@@ -44,12 +44,14 @@ public class PanelActionsTagHelper : TagHelper
         var attributes = new AttributeCollection(output.Attributes);
         attributes.Remove("class", out var classes);
 
-        panelContext.SetActions(new PanelActionsOptions
-        {
-            Items = actionsContext.Actions,
-            Classes = classes,
-            Attributes = attributes
-        });
+        panelContext.SetActions(
+            new PanelActionsOptions
+            {
+                Items = actionsContext.Actions,
+                Classes = classes,
+                Attributes = attributes
+            },
+            context.TagName);
 
         output.SuppressOutput();
     }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/PanelContext.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/PanelContext.cs
@@ -8,9 +8,12 @@ internal class PanelContext
     public (TemplateString? Content, AttributeCollection? Attributes)? Title { get; private set; }
     public PanelActionsOptions? Actions { get; private set; }
 
-    public void SetActions(PanelActionsOptions actions)
+    public string? ActionsTagName { get; private set; }
+
+    public void SetActions(PanelActionsOptions actions, string tagName)
     {
         ArgumentNullException.ThrowIfNull(actions);
+        ArgumentNullException.ThrowIfNull(tagName);
 
         if (Actions is not null)
         {
@@ -18,6 +21,7 @@ internal class PanelContext
         }
 
         Actions = actions;
+        ActionsTagName = tagName;
     }
 
     public void SetBody(TemplateString? content, AttributeCollection? attributes)

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/PanelTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/PanelTagHelper.cs
@@ -20,6 +20,7 @@ public class PanelTagHelper : TagHelper
     internal const string TagName = "govuk-panel";
 
     private const string HeadingLevelAttributeName = "heading-level";
+    private const string InterruptionClassName = "govuk-panel--interruption";
 
     private readonly IComponentGenerator _componentGenerator;
     private int? _headingLevel;
@@ -83,6 +84,18 @@ public class PanelTagHelper : TagHelper
 
         var attributes = new AttributeCollection(output.Attributes);
         attributes.Remove("class", out var classes);
+
+        // Actions are only rendered for the interruption variant, so reject them otherwise
+        // rather than silently dropping them.
+        var isInterruption = !classes.IsEmpty() &&
+            classes!.ToHtmlString().Contains(InterruptionClassName, StringComparison.Ordinal);
+
+        if (panelContext.Actions is not null && !isInterruption)
+        {
+            throw new InvalidOperationException(
+                $"The <{panelContext.ActionsTagName}> element can only be used when the " +
+                $"'{InterruptionClassName}' class is specified on the <{TagName}> element.");
+        }
 
         var options = new PanelOptions
         {

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PanelActionsTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PanelActionsTagHelperTests.cs
@@ -49,7 +49,7 @@ public class PanelActionsTagHelperTests : TagHelperTestBase<PanelActionsTagHelpe
     {
         // Arrange
         var panelContext = new PanelContext();
-        panelContext.SetActions(new PanelActionsOptions());
+        panelContext.SetActions(new PanelActionsOptions(), PanelActionsTagHelper.TagName);
 
         var context = CreateTagHelperContext(contexts: [panelContext]);
 

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PanelTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PanelTagHelperTests.cs
@@ -192,20 +192,22 @@ public class PanelTagHelperTests : TagHelperTestBase<PanelTagHelper>
     {
         // Arrange
         var titleContent = "Title";
+        var className = "govuk-panel--interruption";
         var actions = new PanelActionsOptions
         {
             Items = [new PanelActionsItemOptions { Text = "Yes", Type = "button" }],
             Classes = "actions-class"
         };
 
-        var context = CreateTagHelperContext();
+        var context = CreateTagHelperContext(className: className);
 
         var output = CreateTagHelperOutput(
+            className: className,
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var panelContext = context.GetContextItem<PanelContext>();
                 panelContext.SetTitle(TemplateString.FromEncoded(titleContent), null);
-                panelContext.SetActions(actions);
+                panelContext.SetActions(actions, PanelActionsTagHelper.TagName);
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
@@ -222,6 +224,43 @@ public class PanelTagHelperTests : TagHelperTestBase<PanelTagHelper>
         // Assert
         var actualOptions = getActualOptions();
         Assert.Same(actions, actualOptions.Actions);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithActionsButNotInterruptionVariant_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var context = CreateTagHelperContext();
+
+        var output = CreateTagHelperOutput(
+            getChildContentAsync: (useCachedResult, encoder) =>
+            {
+                var panelContext = context.GetContextItem<PanelContext>();
+                panelContext.SetTitle(TemplateString.FromEncoded("Title"), null);
+
+                // Use the short tag name to verify the actual tag name is used in the message.
+                panelContext.SetActions(
+                    new PanelActionsOptions
+                    {
+                        Items = [new PanelActionsItemOptions { Text = "Yes", Type = "button" }]
+                    },
+                    PanelActionsTagHelper.ShortTagName);
+
+                var tagHelperContent = new DefaultTagHelperContent();
+                return Task.FromResult<TagHelperContent>(tagHelperContent);
+            });
+
+        var tagHelper = new PanelTagHelper(TestUtils.CreateComponentGenerator());
+        tagHelper.Init(context);
+
+        // Act
+        var ex = await Record.ExceptionAsync(() => tagHelper.ProcessAsync(context, output));
+
+        // Assert
+        Assert.IsType<InvalidOperationException>(ex);
+        Assert.Equal(
+            "The <panel-actions> element can only be used when the 'govuk-panel--interruption' class is specified on the <govuk-panel> element.",
+            ex.Message);
     }
 
     [Fact]


### PR DESCRIPTION
Panel actions are only rendered for the interruption variant of the panel. Previously, specifying actions on a non-interruption panel silently dropped them. `PanelTagHelper` now throws an `InvalidOperationException` in that case, naming the actual tag the author used (short or long), e.g.:

> The `<panel-actions>` element can only be used when the 'govuk-panel--interruption' class is specified on the `<govuk-panel>` element.

## Notes

- The check lives in `PanelTagHelper.ProcessAsync` (mirrors the generator's interruption detection). The lower-level `GeneratePanelAsync` component-generation API is unchanged — it still ignores actions for non-interruption panels, matching the reference template.
- The exception is thrown inline in `PanelTagHelper` (not via `ExceptionHelper`). The actual tag name flows from `PanelActionsTagHelper` (`context.TagName`) through `PanelContext.SetActions`, so the message reports whichever tag was written.

## Verification

- Unit test covers the throw, using the short `<panel-actions>` tag to confirm the actual tag name appears in the message; the existing "with actions" test now sets the interruption class.
- Verified end-to-end against the running Docs app: both `<govuk-panel-actions>` (long) and `<panel-actions>` (short) without the interruption class return HTTP 500 with the expected message naming that tag; the interruption examples still render.
- Release build clean (warnings-as-errors); full unit + integration suites pass.

Rebased on top of `main` after the `-button` rename (#489) merged; the CHANGELOG _Unreleased_ entry was the only conflict and has been resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
