### PR TITLE
Support the v6.4.0 date input options in the component generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Added support for the interruption variant of the panel component, including the
 
 The panel tag helpers now also support short tag names: `<panel-title>`, `<panel-body>`, `<panel-actions>`, `<action-button>` and `<action-link>`. As with the summary list component, short and long tag names cannot be mixed.
 
-The new date input options (`day`/`month`/`year`/`values` and per-item `error`) introduced in v6.4.0 are not yet supported and are deferred to a follow-up.
+Added the v6.4.0 date input options to `DateInputOptions` (`Day`/`Month`/`Year`/`Values`) and `DateInputOptionsItem` (`Error`). The date input tag helpers are unchanged.
 
 ## 4.3.0
 

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DateInputOptions.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DateInputOptions.cs
@@ -9,6 +9,10 @@ public record DateInputOptions
     public TemplateString? Id { get; set; }
     public TemplateString? NamePrefix { get; set; }
     public IReadOnlyCollection<DateInputOptionsItem>? Items { get; set; }
+    public DateInputOptionsItem? Day { get; set; }
+    public DateInputOptionsItem? Month { get; set; }
+    public DateInputOptionsItem? Year { get; set; }
+    public IReadOnlyDictionary<string, TemplateString?>? Values { get; set; }
     public HintOptions? Hint { get; set; }
     public ErrorMessageOptions? ErrorMessage { get; set; }
     public DateInputFormGroupOptions? FormGroup { get; set; }
@@ -23,6 +27,7 @@ public record DateInputOptionsItem
     public TemplateString? Name { get; set; }
     public TemplateString? Label { get; set; }
     public TemplateString? Value { get; set; }
+    public bool? Error { get; set; }
     [JsonPropertyName("autocomplete")]
     public TemplateString? AutoComplete { get; set; }
     [JsonPropertyName("inputmode")]

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.DateInput.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.DateInput.cs
@@ -9,13 +9,20 @@ internal partial class DefaultComponentGenerator
         ArgumentNullException.ThrowIfNull(options);
 
         var hasFieldset = options.Fieldset is not null;
+        var values = options.Values;
 
-        var dateInputItems = options.Items is null || options.Items.Count == 0 ?
-            [
-                new DateInputOptionsItem { Name = "day", Classes = "govuk-input--width-2" },
-                new DateInputOptionsItem { Name = "month", Classes = "govuk-input--width-2" },
-                new DateInputOptionsItem { Name = "year", Classes = "govuk-input--width-4" }
-            ] : options.Items;
+        // The day/month/year fields default to standard items whose value is taken from the
+        // `values` object, and are used only when an explicit `items` collection isn't supplied.
+        var dateInputDay = options.Day ??
+            new DateInputOptionsItem { Name = "day", Value = GetValue(values, "day"), Classes = "govuk-input--width-2" };
+        var dateInputMonth = options.Month ??
+            new DateInputOptionsItem { Name = "month", Value = GetValue(values, "month"), Classes = "govuk-input--width-2" };
+        var dateInputYear = options.Year ??
+            new DateInputOptionsItem { Name = "year", Value = GetValue(values, "year"), Classes = "govuk-input--width-4" };
+
+        var dateInputItems = options.Items is { Count: > 0 } ?
+            options.Items :
+            [dateInputDay, dateInputMonth, dateInputYear];
 
         var describedByParts = new List<TemplateString>();
         if (options.Fieldset?.DescribedBy is var describedBy && !describedBy.IsEmpty())
@@ -86,7 +93,7 @@ internal partial class DefaultComponentGenerator
                 }
             }
 
-            var anyItemHasError = dateInputItems.Any(i => ClassesContain(i.Classes, "govuk-input--error"));
+            var anyItemHasError = dateInputItems.Any(i => i.Error is true || ClassesContain(i.Classes, "govuk-input--error"));
 
             foreach (var item in dateInputItems)
             {
@@ -112,21 +119,48 @@ internal partial class DefaultComponentGenerator
             var itemDiv = new HtmlTag("div", attrs => attrs
                 .WithClasses("govuk-date-input__item"));
 
-            var labelText = item.Label ?? Capitalize(item.Name);
-            var inputId = item.Id ?? new TemplateString($"{parentId}-{item.Name}");
-            var inputName = namePrefix.IsEmpty() ? item.Name : new TemplateString($"{namePrefix}-{item.Name}");
+            // Resolve the item's name, value and width. The day/month/year fields are matched by
+            // object identity (for the default items) or by their name, and the year field is wider.
+            var itemName = item.Name;
+            var itemValue = item.Value;
+            var itemWidth = 2;
 
-            // Add the error modifier when the item hasn't set one itself but the component has an
-            // error message and no item has opted into the error state via its classes.
+            if (ReferenceEquals(item, dateInputDay) || NameMatches(item.Name, "day", dateInputDay.Name))
+            {
+                itemName = item.Name ?? "day";
+                itemValue = item.Value ?? dateInputDay.Value;
+            }
+            else if (ReferenceEquals(item, dateInputMonth) || NameMatches(item.Name, "month", dateInputMonth.Name))
+            {
+                itemName = item.Name ?? "month";
+                itemValue = item.Value ?? dateInputMonth.Value;
+            }
+            else if (ReferenceEquals(item, dateInputYear) || NameMatches(item.Name, "year", dateInputYear.Name))
+            {
+                itemName = item.Name ?? "year";
+                itemValue = item.Value ?? dateInputYear.Value;
+                itemWidth = 4;
+            }
+
             var itemHasErrorClass = ClassesContain(item.Classes, "govuk-input--error");
-            var errorClass = !itemHasErrorClass && options.ErrorMessage is not null && !anyItemHasError ?
+            var itemHasError = item.Error is true || itemHasErrorClass;
+
+            // Add the error modifier when the item opts in (via `error` or its classes), or when the
+            // component has an error message and no item has opted in itself.
+            var errorClass = !itemHasErrorClass &&
+                (itemHasError || (item.Error != false && options.ErrorMessage is not null && !anyItemHasError)) ?
                 "govuk-input--error" : null;
 
-            // Default the width modifier from the field name when the item doesn't specify one.
+            // Default the width modifier from the field when the item doesn't specify one.
             var widthClass = !ClassesContain(item.Classes, "govuk-input--width-") ?
-                (item.Name == "year" ? "govuk-input--width-4" : "govuk-input--width-2") : null;
+                new TemplateString($"govuk-input--width-{itemWidth}") : null;
 
             var inputClasses = new TemplateString("govuk-date-input__input").AppendCssClasses(errorClass, widthClass, item.Classes);
+
+            var labelText = item.Label ?? Capitalize(itemName);
+            var inputId = item.Id ?? new TemplateString($"{parentId}-{itemName}");
+            var inputName = namePrefix.IsEmpty() ? itemName : new TemplateString($"{namePrefix}-{itemName}");
+            var inputValue = itemValue ?? GetValue(values, inputName?.ToHtmlString());
 
             var inputComponent = await GenerateInputAsync(new InputOptions
             {
@@ -134,7 +168,7 @@ internal partial class DefaultComponentGenerator
                 Id = inputId,
                 Classes = inputClasses,
                 Name = inputName,
-                Value = item.Value,
+                Value = inputValue,
                 Type = "text",
                 InputMode = item.InputMode ?? "numeric",
                 AutoComplete = item.AutoComplete,
@@ -150,4 +184,10 @@ internal partial class DefaultComponentGenerator
 
     private static bool ClassesContain(TemplateString? classes, string token) =>
         !classes.IsEmpty() && classes!.ToHtmlString().Contains(token, StringComparison.Ordinal);
+
+    private static bool NameMatches(TemplateString? name, string defaultName, TemplateString? fieldName) =>
+        !name.IsEmpty() && (name == defaultName || name == fieldName);
+
+    private static TemplateString? GetValue(IReadOnlyDictionary<string, TemplateString?>? values, string? key) =>
+        key is not null && values is not null && values.TryGetValue(key, out var value) ? value : null;
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/DefaultComponentGeneratorTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/DefaultComponentGeneratorTests.cs
@@ -57,37 +57,13 @@ public partial class DefaultComponentGeneratorTests
             (generator, options) => generator.GenerateCookieBannerAsync(options));
 
     [Theory]
-    // The v6.4.0 date-input options (day/month/year/values, and per-item error) are not yet
-    // exposed by the component generator; those fixtures are deferred to a follow-up.
+    // These fixtures omit a field by passing `false` for day/month/year; the typed API omits a
+    // field by leaving it out of the `items` collection instead, so they're excluded (as with the
+    // other components' falsy-value fixtures).
     [ComponentFixtureData(
         "date-input",
         typeof(DateInputOptions),
-        exclude:
-        [
-            "day and month",
-            "month and year",
-            "with error on day input",
-            "with error on day input (using items)",
-            "with error on month input",
-            "with error on month input (using items)",
-            "with error on year input",
-            "with error on year input (using items)",
-            "with error on single field",
-            "with error on single field by omission",
-            "with error on single field using classes",
-            "with error on single item",
-            "with error on single item by omission",
-            "with errors only",
-            "with errors only (using classes)",
-            "with errors only (using items)",
-            "with field value",
-            "with field value and items",
-            "with field value overriding values",
-            "with translations",
-            "with values",
-            "with values and name prefix",
-            "with values, name prefix and custom names"
-        ])]
+        exclude: ["day and month", "month and year"])]
     public Task DateInput(ComponentTestCaseData<DateInputOptions> data) =>
         CheckComponentHtmlMatchesExpectedHtml(
             data,


### PR DESCRIPTION
Finishes the last deferred piece of the v6.4.0 upgrade: the new date-input options, ported to the component-generation layer. **The date input tag helpers are unchanged** — these are additive options on the lower-level `DateInputOptions` records, so the original "don't change the tag helper API" constraint holds.

## New options

- `DateInputOptions.Day` / `Month` / `Year` (`DateInputOptionsItem`) — per-field customisation, used when an explicit `Items` collection isn't supplied.
- `DateInputOptions.Values` (`IReadOnlyDictionary<string, TemplateString?>`) — bulk values, keyed by plain name (`day`) and/or `namePrefix-name` (`dob-day`).
- `DateInputOptionsItem.Error` (`bool?`) — per-field error state.

## Generator

`GenerateDateInputAsync` now ports the 6.4.0 `_dateInputItem` macro: day/month/year matched by object identity (default items) or by name, value precedence (`item.value` → `Values[…]`), width-by-field, and error resolution honouring the per-item `Error` flag (including explicit `Error = false` to opt a field out).

## Why the tag helpers don't change

The tag helper already covers these scenarios through its child elements (per-field value via `<govuk-date-input-day value="…">`/model binding, per-field errors via `error-items`, per-field labels/names/etc). Adding the record options doesn't alter tag-helper behaviour — it never sets them.

## Excluded fixtures

`day and month` and `month and year` omit a field by passing `false` for `day`/`year`. The typed API expresses field omission by leaving the field out of the `items` collection, so these two are excluded — consistent with the other components' excluded "with falsy values" fixtures. The remaining 21 previously-excluded fixtures now pass.

## Verification

- All 48 date-input fixtures pass (21 newly enabled; 2 falsy-omission excluded).
- Date input tag-helper unit tests and integration tests unaffected.
- Release build clean (warnings-as-errors); full unit (1477) + integration (63) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)