### PR TITLE
Don't use a custom package cache for samples

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ build-samples *ARGS: (_clear-samples-package-cache) (pack '-c Release')
 [private]
 [working-directory: 'samples']
 _clear-samples-package-cache:
-  @rm -rf package_cache/govuk.frontend.aspnetcore
+  @pwsh -f Remove-CachedPackages.ps1
 
 # Run the tests
 test *ARGS: (unit-tests ARGS) (integration-tests ARGS)

--- a/samples/.gitignore
+++ b/samples/.gitignore
@@ -1,1 +1,0 @@
-package_cache

--- a/samples/Remove-CachedPackages.ps1
+++ b/samples/Remove-CachedPackages.ps1
@@ -1,0 +1,42 @@
+#!/usr/bin/env pwsh
+
+[CmdletBinding(SupportsShouldProcess)]
+param()
+
+$ErrorActionPreference = "Stop"
+
+$packageId = "GovUk.Frontend.AspNetCore"
+
+$globalPackagesOutput = & dotnet nuget locals global-packages --list
+if ($LASTEXITCODE -ne 0) {
+    throw "'dotnet nuget locals global-packages --list' failed with exit code $LASTEXITCODE."
+}
+
+$match = $globalPackagesOutput | Select-String -Pattern '^\s*global-packages:\s*(.+?)\s*$' | Select-Object -First 1
+if (-not $match) {
+    throw "Could not determine the global packages folder."
+}
+$globalPackageCache = $match.Matches[0].Groups[1].Value
+
+Write-Verbose "Global packages folder: $globalPackageCache"
+
+$packageCache = Join-Path $globalPackageCache $packageId.ToLowerInvariant()
+if (-not (Test-Path $packageCache)) {
+    Write-Host "$packageId is not in the global packages cache."
+    return
+}
+
+# Cached versions are directory names; a hyphen means the version has a pre-release label.
+$preReleaseVersions = Get-ChildItem $packageCache -Directory | Where-Object { $_.Name -like "*-*" }
+
+if (-not $preReleaseVersions) {
+    Write-Host "No pre-release versions of $packageId found in the global packages cache."
+    return
+}
+
+foreach ($version in $preReleaseVersions) {
+    if ($PSCmdlet.ShouldProcess($version.FullName, "Remove")) {
+        Remove-Item $version.FullName -Recurse -Force
+        Write-Host "Removed $packageId $($version.Name) from the global packages cache."
+    }
+}

--- a/samples/nuget.config
+++ b/samples/nuget.config
@@ -11,7 +11,4 @@
       <package pattern="GovUk.Frontend.AspNetCore" />
     </packageSource>
   </packageSourceMapping>
-  <config>
-    <add key="globalPackagesFolder" value="./package_cache" />
-  </config>
 </configuration>


### PR DESCRIPTION
Use the user's regular package cache but delete any pre-release package versions.