### PR TITLE
Encode text assigned to an Html option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+Fixes content assigned to an `Html` option as a plain `string` being emitted as markup instead of being HTML-encoded.
+
+This affected validation messages: `ModelError.ErrorMessage` is a `string`, and both `<govuk-error-summary-item for="…">` and `<govuk-error-message for="…">` passed it through an `Html` option. Where a message quotes what the user submitted — as ASP.NET Core's default type-conversion message does, for example when a non-numeric value is posted to an `int` property — the submitted value was written to the page unencoded.
+
+### Breaking changes
+
+A `string` assigned to an `Html` option is now HTML-encoded rather than emitted verbatim, because a `string` is text. To supply markup, wrap it with `TemplateString.FromEncoded(...)`:
+
+```diff
+-Html = "<span class=\"govuk-visually-hidden\">Emergency</span> Exit this page"
++Html = TemplateString.FromEncoded("<span class=\"govuk-visually-hidden\">Emergency</span> Exit this page")
+```
+
+Content that already came from Razor — anything assigned from a `TagHelperContent` or an `IHtmlContent` — is unaffected and still renders as markup.
+
+The `Text` and `Html` properties on `CharacterCountOptionsBeforeInput`, `CharacterCountOptionsAfterInput`, `FileUploadOptionsBeforeInput`, `FileUploadOptionsAfterInput`, `DateInputOptionsBeforeInputs` and `DateInputOptionsAfterInputs` are now `TemplateString?` rather than `string?`, matching every other component's before- and after-input options.
+
 ## 4.4.0
 
 Targets GOV.UK Frontend v6.4.0.

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/CharacterCountOptions.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/CharacterCountOptions.cs
@@ -72,16 +72,16 @@ public record CharacterCountOptionsFormGroup : FormGroupOptions
 
 public record CharacterCountOptionsBeforeInput
 {
-    public string? Text { get; set; }
-    public string? Html { get; set; }
+    public TemplateString? Text { get; set; }
+    public TemplateString? Html { get; set; }
     [NonStandardParameter]
     public AttributeCollection? Attributes { get; set; }
 }
 
 public record CharacterCountOptionsAfterInput
 {
-    public string? Text { get; set; }
-    public string? Html { get; set; }
+    public TemplateString? Text { get; set; }
+    public TemplateString? Html { get; set; }
     [NonStandardParameter]
     public AttributeCollection? Attributes { get; set; }
 }

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DateInputOptions.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DateInputOptions.cs
@@ -45,16 +45,16 @@ public record DateInputFormGroupOptions : FormGroupOptions
 
 public record DateInputOptionsBeforeInputs
 {
-    public string? Text { get; set; }
-    public string? Html { get; set; }
+    public TemplateString? Text { get; set; }
+    public TemplateString? Html { get; set; }
     [NonStandardParameter]
     public AttributeCollection? Attributes { get; set; }
 }
 
 public record DateInputOptionsAfterInputs
 {
-    public string? Text { get; set; }
-    public string? Html { get; set; }
+    public TemplateString? Text { get; set; }
+    public TemplateString? Html { get; set; }
     [NonStandardParameter]
     public AttributeCollection? Attributes { get; set; }
 }

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.Accordion.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.Accordion.cs
@@ -77,7 +77,7 @@ internal partial class DefaultComponentGenerator
 
                 if (item.Content?.Html is { } contentHtml)
                 {
-                    contentTag.InnerHtml.AppendHtml(contentHtml.GetRawHtml());
+                    contentTag.InnerHtml.AppendHtml(contentHtml);
                 }
                 else if (item.Content?.Text is { } contentText)
                 {

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.Button.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.Button.cs
@@ -98,7 +98,7 @@ internal partial class DefaultComponentGenerator
             if (options.IsStartButton is true && !options.Html.IsEmpty())
             {
                 var span = new HtmlTag("span");
-                span.InnerHtml.AppendHtml(options.Html.GetRawHtml());
+                span.InnerHtml.AppendHtml(options.Html);
                 tag.InnerHtml.AppendHtml(span);
             }
             else

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.Checkboxes.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.Checkboxes.cs
@@ -216,7 +216,7 @@ internal partial class DefaultComponentGenerator
 
             if (hasConditional)
             {
-                var conditionalContent = conditionalHtml!.GetRawHtml();
+                var conditionalContent = conditionalHtml!;
 
                 var conditional = new HtmlTag("div", attrs => attrs
                     .WithClasses("govuk-checkboxes__conditional", !isChecked ? "govuk-checkboxes__conditional--hidden" : null)

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.GenericHeader.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.GenericHeader.cs
@@ -30,7 +30,7 @@ internal partial class DefaultComponentGenerator
 
         if (!options.LogoHtml.IsEmpty())
         {
-            logoLink.InnerHtml.AppendHtml(options.LogoHtml.GetRawHtml());
+            logoLink.InnerHtml.AppendHtml(options.LogoHtml);
         }
         else if (!options.LogoText.IsEmpty())
         {
@@ -42,7 +42,7 @@ internal partial class DefaultComponentGenerator
 
         if (!options.Html.IsEmpty())
         {
-            containerTag.InnerHtml.AppendHtml(options.Html.GetRawHtml());
+            containerTag.InnerHtml.AppendHtml(options.Html);
         }
 
         headerTag.InnerHtml.AppendHtml(containerTag);

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.NotificationBanner.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.NotificationBanner.cs
@@ -80,7 +80,7 @@ internal partial class DefaultComponentGenerator
         {
             if (!titleHtml.IsEmpty())
             {
-                return titleHtml.GetRawHtml();
+                return titleHtml;
             }
 
             if (!titleText.IsEmpty())

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.Radios.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.Radios.cs
@@ -208,7 +208,7 @@ internal partial class DefaultComponentGenerator
 
             if (hasConditional)
             {
-                var conditionalContent = conditionalHtml!.GetRawHtml();
+                var conditionalContent = conditionalHtml!;
 
                 var conditional = new HtmlTag("div", attrs => attrs
                     .WithClasses("govuk-radios__conditional", !isChecked ? "govuk-radios__conditional--hidden" : null)

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.ServiceNavigation.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.ServiceNavigation.cs
@@ -24,7 +24,7 @@ internal partial class DefaultComponentGenerator
 
             if (!(options.Slots?.Start).IsEmpty())
             {
-                widthContainerTag.InnerHtml.AppendHtml(options.Slots.Start.GetRawHtml());
+                widthContainerTag.InnerHtml.AppendHtml(options.Slots.Start);
             }
 
             var serviceNavigationContainer = new HtmlTag("div", attrs => attrs
@@ -72,7 +72,7 @@ internal partial class DefaultComponentGenerator
 
             if (!(options.Slots?.End).IsEmpty())
             {
-                widthContainerTag.InnerHtml.AppendHtml(options.Slots.End.GetRawHtml());
+                widthContainerTag.InnerHtml.AppendHtml(options.Slots.End);
             }
 
             return widthContainerTag;
@@ -116,7 +116,7 @@ internal partial class DefaultComponentGenerator
 
             if (!(options.Slots?.NavigationStart).IsEmpty())
             {
-                ulTag.InnerHtml.AppendHtml(options.Slots.NavigationStart.GetRawHtml());
+                ulTag.InnerHtml.AppendHtml(options.Slots.NavigationStart);
             }
 
             if (navigationItems is not null)
@@ -135,7 +135,7 @@ internal partial class DefaultComponentGenerator
 
             if (!(options.Slots?.NavigationEnd).IsEmpty())
             {
-                ulTag.InnerHtml.AppendHtml(options.Slots.NavigationEnd.GetRawHtml());
+                ulTag.InnerHtml.AppendHtml(options.Slots.NavigationEnd);
             }
 
             navTag.InnerHtml.AppendHtml(ulTag);

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.Tabs.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.Tabs.cs
@@ -80,7 +80,7 @@ internal partial class DefaultComponentGenerator
 
             if (!(item.Panel?.Html).IsEmpty())
             {
-                panelTag.InnerHtml.AppendHtml(item.Panel.Html.GetRawHtml());
+                panelTag.InnerHtml.AppendHtml(item.Panel.Html);
             }
             else if (!(item.Panel?.Text).IsEmpty())
             {

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.cs
@@ -9,11 +9,14 @@ internal partial class DefaultComponentGenerator : IComponentGenerator
     private ValueTask<GovUkComponent> GenerateFromHtmlTagAsync(HtmlTag tag) =>
         ValueTask.FromResult<GovUkComponent>(new HtmlTagGovUkComponent(tag));
 
+    // A TemplateString already knows whether it holds HTML or text, and writes itself accordingly.
+    // Don't reach past that to force one reading or the other: doing so is how text from a validation
+    // message ended up being emitted as markup.
     private IHtmlContent HtmlOrText(TemplateString? html, TemplateString? text, string? fallback = null)
     {
         if (!html.IsEmpty())
         {
-            return html.GetRawHtml();
+            return html;
         }
 
         if (!text.IsEmpty())

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/FileUploadOptions.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/FileUploadOptions.cs
@@ -37,16 +37,16 @@ public record FileUploadOptionsFormGroup : FormGroupOptions
 
 public record FileUploadOptionsBeforeInput
 {
-    public string? Text { get; set; }
-    public string? Html { get; set; }
+    public TemplateString? Text { get; set; }
+    public TemplateString? Html { get; set; }
     [NonStandardParameter]
     public AttributeCollection? Attributes { get; set; }
 }
 
 public record FileUploadOptionsAfterInput
 {
-    public string? Text { get; set; }
-    public string? Html { get; set; }
+    public TemplateString? Text { get; set; }
+    public TemplateString? Html { get; set; }
     [NonStandardParameter]
     public AttributeCollection? Attributes { get; set; }
 }

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/HtmlParameterAttribute.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/HtmlParameterAttribute.cs
@@ -1,0 +1,12 @@
+namespace GovUk.Frontend.AspNetCore.ComponentGeneration;
+
+/// <summary>
+/// Indicates a component parameter whose value is HTML, for parameters that aren't named for it.
+/// </summary>
+/// <remarks>
+/// Parameters whose name ends in <c>Html</c> are recognized without this attribute.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+internal sealed class HtmlParameterAttribute : Attribute
+{
+}

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/ServiceNavigationOptions.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/ServiceNavigationOptions.cs
@@ -36,8 +36,12 @@ public record ServiceNavigationOptionsNavigationItem
 
 public record ServiceNavigationOptionsSlots
 {
+    [HtmlParameter]
     public TemplateString? Start { get; set; }
+    [HtmlParameter]
     public TemplateString? End { get; set; }
+    [HtmlParameter]
     public TemplateString? NavigationStart { get; set; }
+    [HtmlParameter]
     public TemplateString? NavigationEnd { get; set; }
 }

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/TemplateString.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/TemplateString.cs
@@ -319,17 +319,6 @@ public sealed class TemplateString : IEquatable<TemplateString>, IHtmlContent
         return thisHtml.Contains(otherHtml, StringComparison.Ordinal);
     }
 
-    internal IHtmlContent GetRawHtml()
-    {
-        if (_value is string str)
-        {
-            return new HtmlString(str);
-        }
-
-        Debug.Assert(_value is IHtmlContent);
-        return (IHtmlContent)_value;
-    }
-
     private string DebuggerToString() => this.ToHtmlString(DefaultEncoder);
 }
 

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CharacterCountTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CharacterCountTagHelper.cs
@@ -287,14 +287,14 @@ public class CharacterCountTagHelper : TagHelper
                 new CharacterCountOptionsBeforeInput
                 {
                     Text = null,
-                    Html = beforeInput.ToHtmlString()
+                    Html = beforeInput
                 } :
                 null,
             AfterInput = characterCountContext.AfterInput is TemplateString afterInput ?
                 new CharacterCountOptionsAfterInput
                 {
                     Text = null,
-                    Html = afterInput.ToHtmlString()
+                    Html = afterInput
                 } :
                 null,
             Attributes = formGroupAttributes,

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputTagHelper.cs
@@ -256,14 +256,14 @@ public class DateInputTagHelper : TagHelper
                 new DateInputOptionsBeforeInputs
                 {
                     Text = null,
-                    Html = beforeInputs.ToHtmlString()
+                    Html = beforeInputs
                 } :
                 null,
             AfterInputs = dateInputContext.AfterInputs is TemplateString afterInputs ?
                 new DateInputOptionsAfterInputs
                 {
                     Text = null,
-                    Html = afterInputs.ToHtmlString()
+                    Html = afterInputs
                 } :
                 null,
             Attributes = formGroupAttributes,

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FileUploadTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FileUploadTagHelper.cs
@@ -236,13 +236,13 @@ public class FileUploadTagHelper : TagHelper
             BeforeInput = fileUploadContext.BeforeInput is TemplateString beforeInput ?
                 new FileUploadOptionsBeforeInput
                 {
-                    Html = beforeInput.ToHtmlString()
+                    Html = beforeInput
                 } :
                 null,
             AfterInput = fileUploadContext.AfterInput is TemplateString afterInput ?
                 new FileUploadOptionsAfterInput
                 {
-                    Html = afterInput.ToHtmlString()
+                    Html = afterInput
                 } :
                 null,
             Attributes = formGroupAttributes,

--- a/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/ComponentFixtureData.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/ComponentFixtureData.cs
@@ -36,14 +36,17 @@ public class ComponentFixtureData(
 
         static void UseEncodedTemplateStringForHtmlProperties(JsonTypeInfo typeInfo)
         {
-            // The *html parameters carry HTML, as does every member of a `slots` object even though
-            // none of them is named for it.
-            var typeHoldsOnlyHtml = typeInfo.Type == typeof(ServiceNavigationOptionsSlots);
-
             foreach (var property in typeInfo.Properties)
             {
-                if (property.PropertyType == typeof(TemplateString) &&
-                    (typeHoldsOnlyHtml || property.Name.EndsWith("html", StringComparison.OrdinalIgnoreCase)))
+                if (property.PropertyType != typeof(TemplateString))
+                {
+                    continue;
+                }
+
+                var isHtml = property.Name.EndsWith("html", StringComparison.OrdinalIgnoreCase) ||
+                    property.AttributeProvider?.IsDefined(typeof(HtmlParameterAttribute), inherit: false) is true;
+
+                if (isHtml)
                 {
                     property.CustomConverter = TemplateStringJsonConverter.Encoded;
                 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/ComponentFixtureData.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/ComponentFixtureData.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using GovUk.Frontend.AspNetCore.ComponentGeneration;
 using Microsoft.AspNetCore.Html;
 using Xunit.Sdk;
@@ -24,6 +25,30 @@ public class ComponentFixtureData(
         _serializerOptions.Converters.Add(new StringHtmlContentJsonConverter());
         _serializerOptions.Converters.Add(new AttributeCollectionJsonConverter());
         _serializerOptions.Converters.Add(new TemplateStringJsonConverter());
+
+        // A converter can't see which property it's deserializing, so the *html parameters are picked
+        // out here instead. Without this every fixture value is labelled as text and the suite can't
+        // tell correctly-encoded output from raw markup that merely renders.
+        _serializerOptions.TypeInfoResolver = new DefaultJsonTypeInfoResolver
+        {
+            Modifiers = { UseEncodedTemplateStringForHtmlProperties }
+        };
+
+        static void UseEncodedTemplateStringForHtmlProperties(JsonTypeInfo typeInfo)
+        {
+            // The *html parameters carry HTML, as does every member of a `slots` object even though
+            // none of them is named for it.
+            var typeHoldsOnlyHtml = typeInfo.Type == typeof(ServiceNavigationOptionsSlots);
+
+            foreach (var property in typeInfo.Properties)
+            {
+                if (property.PropertyType == typeof(TemplateString) &&
+                    (typeHoldsOnlyHtml || property.Name.EndsWith("html", StringComparison.OrdinalIgnoreCase)))
+                {
+                    property.CustomConverter = TemplateStringJsonConverter.Encoded;
+                }
+            }
+        }
     }
 
     private readonly HashSet<string> _exclude = new(exclude);

--- a/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/DefaultComponentGeneratorTests.NonStandardParameters.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/DefaultComponentGeneratorTests.NonStandardParameters.cs
@@ -329,7 +329,7 @@ public partial class DefaultComponentGeneratorTests
                 [
                     new FooterOptionsMetaItem
                     {
-                        Html = "<span data-test=\"item-html\">Custom HTML</span>",
+                        Html = TemplateString.FromEncoded("<span data-test=\"item-html\">Custom HTML</span>"),
                         Href = "#"
                     }
                 ]
@@ -471,7 +471,7 @@ public partial class DefaultComponentGeneratorTests
                     [
                         new FooterOptionsNavigationItem
                         {
-                            Html = "<span data-test=\"item-html\">Custom HTML</span>",
+                            Html = TemplateString.FromEncoded("<span data-test=\"item-html\">Custom HTML</span>"),
                             Href = "#"
                         }
                     ]
@@ -636,7 +636,7 @@ public partial class DefaultComponentGeneratorTests
         var options = new GenericHeaderOptions
         {
             LogoText = "My service",
-            Html = "<div class=\"extra-content\">Extra content</div>"
+            Html = TemplateString.FromEncoded("<div class=\"extra-content\">Extra content</div>")
         };
 
         // Act
@@ -693,7 +693,7 @@ public partial class DefaultComponentGeneratorTests
         // Arrange
         var options = new HeaderOptions
         {
-            Html = "<div class=\"extra-content\">Extra content</div>"
+            Html = TemplateString.FromEncoded("<div class=\"extra-content\">Extra content</div>")
         };
 
         // Act

--- a/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/DefaultComponentGeneratorTests.VisuallyHiddenText.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/DefaultComponentGeneratorTests.VisuallyHiddenText.cs
@@ -106,7 +106,7 @@ public partial class DefaultComponentGeneratorTests
         // Arrange
         var options = new ExitThisPageOptions
         {
-            Html = "<span class=\"govuk-visually-hidden\">Emergency</span> Leave immediately"
+            Html = TemplateString.FromEncoded("<span class=\"govuk-visually-hidden\">Emergency</span> Leave immediately")
         };
 
         // Act

--- a/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/EncodingTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/EncodingTests.cs
@@ -1,0 +1,140 @@
+using GovUk.Frontend.AspNetCore.ComponentGeneration;
+
+namespace GovUk.Frontend.AspNetCore.Tests.ComponentGeneration;
+
+/// <summary>
+/// Pins the contract that an <c>Html</c> option is emitted verbatim only when it actually holds HTML.
+/// Assertions are made against the parsed DOM rather than the HTML string: a double-encode then shows
+/// up as text that doesn't match the payload, and a raw injection as an element that shouldn't exist.
+/// </summary>
+public class EncodingTests
+{
+    private const string Payload = "Iechyd & Gofal <b>\"'";
+
+    private readonly DefaultComponentGenerator _componentGenerator = TestUtils.CreateComponentGenerator();
+
+    /// <summary>
+    /// Every component whose content reaches the output through an <c>Html</c>/<c>Text</c> pair.
+    /// </summary>
+    public static TheoryData<string> ComponentsWithContent =>
+    [
+        "back-link", "button", "details", "error-message", "error-summary", "hint", "inset-text",
+        "label", "notification-banner", "panel", "tag", "warning-text"
+    ];
+
+    [Theory]
+    [MemberData(nameof(ComponentsWithContent))]
+    public async Task TextOption_IsEncodedExactlyOnce(string component)
+    {
+        // Act
+        var html = await RenderWithContentAsync(component, text: Payload, html: null);
+
+        // Assert
+        var element = HtmlHelper.ParseHtmlElement(html);
+        Assert.Contains(Payload, element.TextContent, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [MemberData(nameof(ComponentsWithContent))]
+    public async Task HtmlOption_HoldingHtml_IsEmittedVerbatim(string component)
+    {
+        // Act
+        var html = await RenderWithContentAsync(
+            component,
+            text: null,
+            html: TemplateString.FromEncoded("<em data-probe=\"1\">Content</em>"));
+
+        // Assert
+        var element = HtmlHelper.ParseHtmlElement(html);
+        Assert.NotNull(element.QuerySelector("[data-probe]"));
+    }
+
+    [Theory]
+    [MemberData(nameof(ComponentsWithContent))]
+    public async Task HtmlOption_HoldingText_IsEncoded(string component)
+    {
+        // A bare string is text, whatever slot it's assigned to. Emitting it verbatim is how a
+        // validation message containing markup used to reach the page as markup.
+
+        // Act
+        var html = await RenderWithContentAsync(component, text: null, html: "<em data-probe=\"1\">Content</em>");
+
+        // Assert
+        var element = HtmlHelper.ParseHtmlElement(html);
+        Assert.Null(element.QuerySelector("[data-probe]"));
+        Assert.Contains("<em data-probe=\"1\">Content</em>", element.TextContent, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ErrorSummaryItem_HoldingText_IsEncoded()
+    {
+        // The path a model binding error message takes: ModelError.ErrorMessage is a string, and
+        // MVC's default type-conversion message quotes the value that was submitted.
+        var errorMessage = "The value '<img src=x onerror=alert(1)>' is not valid for Age.";
+
+        // Act
+        var component = await _componentGenerator.GenerateErrorSummaryAsync(new ErrorSummaryOptions
+        {
+            TitleText = "There is a problem",
+            ErrorList = [new ErrorSummaryOptionsErrorItem { Html = errorMessage, Href = "#age" }]
+        });
+
+        // Assert
+        var element = HtmlHelper.ParseHtmlElement(component.GetHtml());
+        Assert.Null(element.QuerySelector("img"));
+        Assert.Contains(errorMessage, element.TextContent, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ErrorMessage_HoldingText_IsEncoded()
+    {
+        var errorMessage = "The value '<img src=x onerror=alert(1)>' is not valid for Age.";
+
+        // Act
+        var component = await _componentGenerator.GenerateErrorMessageAsync(new ErrorMessageOptions
+        {
+            Html = errorMessage
+        });
+
+        // Assert
+        var element = HtmlHelper.ParseHtmlElement(component.GetHtml());
+        Assert.Null(element.QuerySelector("img"));
+        Assert.Contains(errorMessage, element.TextContent, StringComparison.Ordinal);
+    }
+
+    // Text is passed as a string because some options records type Text as string? and others as
+    // TemplateString?; both mean plain text, and string converts implicitly to either.
+    private async Task<string> RenderWithContentAsync(string component, string? text, TemplateString? html)
+    {
+        GovUkComponent generated = component switch
+        {
+            "back-link" => await _componentGenerator.GenerateBackLinkAsync(
+                new BackLinkOptions { Text = text, Html = html, Href = "#" }),
+            "button" => await _componentGenerator.GenerateButtonAsync(
+                new ButtonOptions { Text = text, Html = html }),
+            "details" => await _componentGenerator.GenerateDetailsAsync(
+                new DetailsOptions { SummaryText = "Summary", Text = text, Html = html }),
+            "error-message" => await _componentGenerator.GenerateErrorMessageAsync(
+                new ErrorMessageOptions { Text = text, Html = html }),
+            "error-summary" => await _componentGenerator.GenerateErrorSummaryAsync(
+                new ErrorSummaryOptions { TitleText = text, TitleHtml = html }),
+            "hint" => await _componentGenerator.GenerateHintAsync(
+                new HintOptions { Text = text, Html = html }),
+            "inset-text" => await _componentGenerator.GenerateInsetTextAsync(
+                new InsetTextOptions { Text = text, Html = html }),
+            "label" => await _componentGenerator.GenerateLabelAsync(
+                new LabelOptions { Text = text, Html = html }),
+            "notification-banner" => await _componentGenerator.GenerateNotificationBannerAsync(
+                new NotificationBannerOptions { Text = text, Html = html }),
+            "panel" => await _componentGenerator.GeneratePanelAsync(
+                new PanelOptions { TitleText = "Title", Text = text, Html = html }),
+            "tag" => await _componentGenerator.GenerateTagAsync(
+                new TagOptions { Text = text, Html = html }),
+            "warning-text" => await _componentGenerator.GenerateWarningTextAsync(
+                new WarningTextOptions { Text = text, Html = html }),
+            _ => throw new NotSupportedException($"Unknown component '{component}'.")
+        };
+
+        return generated.GetHtml();
+    }
+}

--- a/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/TemplateStringJsonConverter.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/TemplateStringJsonConverter.cs
@@ -4,15 +4,36 @@ using GovUk.Frontend.AspNetCore.ComponentGeneration;
 
 namespace GovUk.Frontend.AspNetCore.Tests.ComponentGeneration;
 
-public class TemplateStringJsonConverter : JsonConverter<TemplateString>
+/// <summary>
+/// Deserializes a fixture value into a <see cref="TemplateString"/>.
+/// </summary>
+/// <param name="encoded">
+/// Whether the value is already-encoded HTML. govuk-frontend's fixtures put HTML in the <c>*html</c>
+/// parameters and plain text everywhere else, so the two have to be labelled differently; deserializing
+/// everything as text would let raw markup through as content that only happens to render.
+/// </param>
+public class TemplateStringJsonConverter(bool encoded = false) : JsonConverter<TemplateString>
 {
+    /// <summary>
+    /// A converter for fixture values that are already-encoded HTML.
+    /// </summary>
+    public static TemplateStringJsonConverter Encoded { get; } = new(encoded: true);
+
     public override TemplateString? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        return reader.TokenType == JsonTokenType.Null
-            ? null
-            : reader.TokenType is JsonTokenType.Number or JsonTokenType.String or JsonTokenType.False or JsonTokenType.True
-            ? new TemplateString(JsonSerializer.Deserialize(ref reader, typeof(string), options) as string)
-            : throw new NotSupportedException($"Cannot create a {nameof(TemplateString)} from a {reader.TokenType}.");
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return null;
+        }
+
+        if (reader.TokenType is not (JsonTokenType.Number or JsonTokenType.String or JsonTokenType.False or JsonTokenType.True))
+        {
+            throw new NotSupportedException($"Cannot create a {nameof(TemplateString)} from a {reader.TokenType}.");
+        }
+
+        var value = JsonSerializer.Deserialize(ref reader, typeof(string), options) as string;
+
+        return encoded && value is not null ? TemplateString.FromEncoded(value) : new TemplateString(value);
     }
 
     public override void Write(Utf8JsonWriter writer, TemplateString value, JsonSerializerOptions options)


### PR DESCRIPTION
## The bug

`TemplateString` holds either unencoded text or already-encoded HTML, and which one it is gets decided by overload resolution on the constructor or implicit conversion. `HtmlOrText` reached past that and forced the HTML reading via `GetRawHtml()`, which for the text case wraps the string in an `HtmlString` — relabelling unencoded text as trusted markup.

`ModelError.ErrorMessage` is a `string`, and both `ErrorSummaryItemTagHelper` and `ErrorMessageTagHelper` pass it through an `Html` option. Where a validation message quotes what the user submitted — as ASP.NET Core's default type-conversion message does, e.g. when a non-numeric value is posted to an `int` property — the submitted value reached the page unencoded. `<govuk-error-summary-item for="…">` and `<govuk-error-message for="…">` are documented usage, and this is in the released v4.4.0.

Stock MVC's `asp-validation-for` encodes this; we didn't.

## The fix

`HtmlOrText` now returns the `TemplateString` and lets it write itself. HTML-backed values still render verbatim through `WriteTo`; text-backed values now encode, which is the safe failure.

`GetRawHtml()` is **deleted**, so the reading can't be forced again — that's what stops this recurring rather than just patching the four call sites that reach it today. Its other 12 call sites already passed their value straight to `AppendHtml`, so they simply lose the call.

## Two changes that are consequences, not separate cleanups

**The conformance suite was blind to this.** `TemplateStringJsonConverter` labelled *every* govuk-frontend fixture value as text — `html` parameters included — so the thousands of fixtures couldn't distinguish correctly-encoded output from raw markup that merely renders, and every `html` fixture would have gone red for the wrong reason. Fixture values now deserialize as encoded when the parameter's name ends in `Html`, or when it carries the new internal `[HtmlParameter]`. The latter exists for the `slots` parameters, which carry HTML without being named for it; annotating the property beats another branch in a test helper.

**Six sites did `Html = x.ToHtmlString()`** — putting encoded HTML into a property that is read back as text. That round-tripped correctly only because `GetRawHtml()` undid it. With the relabelling gone the round-trip is unnecessary, so those properties become `TemplateString?` like every other component's before/after-input options, and the `ToHtmlString()` calls disappear. This is the same double-encode shape as the one fixed in #499.

## Breaking change

A `string` assigned to an `Html` option is now HTML-encoded, because a `string` is text. To supply markup, wrap it:

```diff
-Html = "<span class=\"govuk-visually-hidden\">Emergency</span> Exit this page"
+Html = TemplateString.FromEncoded("<span class=\"govuk-visually-hidden\">Emergency</span> Exit this page")
```

Content that already came from Razor — anything assigned from a `TagHelperContent` or `IHtmlContent` — is unaffected and still renders as markup. Three existing tests were asserting the old behaviour by assigning raw markup as a `string`; they've been updated to `FromEncoded`, which is the same migration consumers need.

The `Text`/`Html` properties on `CharacterCountOptionsBeforeInput`, `CharacterCountOptionsAfterInput`, `FileUploadOptionsBeforeInput`, `FileUploadOptionsAfterInput`, `DateInputOptionsBeforeInputs` and `DateInputOptionsAfterInputs` change from `string?` to `TemplateString?`. Assignment from a `string` still compiles.

## Tests

New `ComponentGeneration/EncodingTests.cs` asserts against the **parsed DOM** rather than the HTML string, so a double-encode shows up as text that doesn't match the payload and a raw injection as an element that shouldn't exist. Across twelve components with `Html`/`Text` pairs: a `Text` option round-trips `& < > " '` exactly; an `Html` option holding HTML still emits verbatim; an `Html` option holding a plain `string` does not. Plus two explicit tests for the validation-message path.

**14 of these fail on `main`**, including both validation-message tests. All 38 pass here.

`dotnet test` is green on net8.0, net9.0 and net10.0 — 1532 unit and 84 integration tests each — and the Release build (warnings as errors) succeeds.

## Follow-ups, not in this PR

`TemplateString` still has related problems worth their own change: `+`/`Join`/`AppendCssClasses` eagerly render with `HtmlEncoder.Default`, discarding the app's configured encoder (an app registering `HtmlEncoder.Create(UnicodeRanges.All)` gets `&#x175;` for anything concatenated); `AttributeCollection`'s read path coerces `object?` via `ToString()`, relabelling Razor's pre-encoded attribute values as text; `GetHashCode` is inconsistent with `Equals`; and there's no way to recover plain text, so `ToHtmlString()` is being used as an identity for dictionary keys and class-token checks. A banned-API entry for `ToHtmlString` inside `src` would turn that whole family into build failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)