### PR TITLE
Keep a TemplateString's encoding through composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+`TemplateString` now keeps track of whether it holds text or HTML through composition, instead of rendering eagerly.
+
+Concatenating, joining or interpolating values used to render them immediately using `HtmlEncoder.Default` and label the result as HTML. That discarded the encoder the application had configured — an app registering `HtmlEncoder.Create(UnicodeRanges.All)` got `ŵ` for a value written directly but `&#x175;` for one that had been concatenated — and meant a value built from plain text was no longer recognisable as text. Composition is now deferred until the value is written, using the encoder it is written with.
+
+Two new members go with it. `TryGetText` gets a value's plain text, for the cases that want an identifier, a key or an attribute token rather than markup; it never HTML-decodes, and reports failure for content with no unambiguous text reading. `IsHtml` reports which kind of content a value holds.
+
+Also fixed:
+
+- Reading an attribute back out of an `AttributeCollection` — through the indexer, `Remove` or enumeration — turned the already-encoded value Razor supplied into a string and treated it as text, so it was encoded again when written. An attribute written in a view as `class="a&amp;b"` came back out as `a&amp;amp;b`.
+- `GetHashCode` disagreed with `Equals`, which made `TemplateString` unsafe as a dictionary or set key.
+- `TemplateString.Empty` was not equal to `new TemplateString("")` or `TemplateString.FromEncoded("")`.
+- `Join` inserted its separator without encoding it.
+- The character count's `%{count}` substitution, the date input's field labels and lookups, and the panel's and date input's CSS class checks all operated on the encoded form of a value, which is wrong for any content outside Basic Latin.
+- The password input's toggle button text was encoded twice.
+
 Fixes content assigned to an `Html` option as a plain `string` being emitted as markup instead of being HTML-encoded.
 
 This affected validation messages: `ModelError.ErrorMessage` is a `string`, and both `<govuk-error-summary-item for="…">` and `<govuk-error-message for="…">` passed it through an `Html` option. Where a message quotes what the user submitted — as ASP.NET Core's default type-conversion message does, for example when a non-numeric value is posted to an `int` property — the submitted value was written to the page unencoded.

--- a/src/GovUk.Frontend.AspNetCore/BannedSymbols.txt
+++ b/src/GovUk.Frontend.AspNetCore/BannedSymbols.txt
@@ -1,0 +1,1 @@
+M:GovUk.Frontend.AspNetCore.HtmlContentExtensions.ToHtmlString(Microsoft.AspNetCore.Html.IHtmlContent,System.Text.Encodings.Web.HtmlEncoder);Returns encoded HTML, so passing the result somewhere that encodes gives double-encoded output. Use TemplateString.TryGetText for a value's text, TemplateString.Render to render it, or write the value itself.

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/AttributeCollection.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/AttributeCollection.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Globalization;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -64,7 +65,7 @@ public sealed class AttributeCollection : IEnumerable<KeyValuePair<string, Templ
         {
             if (_attributes.TryGetValue(name, out var attribute))
             {
-                return attribute.Value as TemplateString ?? attribute.Value?.ToString();
+                return ValueToTemplateString(attribute.Value);
             }
 
             return null;
@@ -163,7 +164,7 @@ public sealed class AttributeCollection : IEnumerable<KeyValuePair<string, Templ
     {
         if (_attributes.Remove(name, out var attribute))
         {
-            value = attribute.Value as TemplateString ?? attribute.Value?.ToString();
+            value = ValueToTemplateString(attribute.Value);
             return true;
         }
 
@@ -185,6 +186,27 @@ public sealed class AttributeCollection : IEnumerable<KeyValuePair<string, Templ
             }
         }
     }
+
+    /// <summary>
+    /// Reads an attribute's value as a <see cref="TemplateString"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Attribute.Value"/> is <see cref="object"/> because it also carries the flag for a
+    /// minimized attribute and whatever Razor put in a <see cref="TagHelperAttribute"/> — usually an
+    /// already-encoded <see cref="IHtmlContent"/>. Calling <see cref="object.ToString"/> on that and
+    /// letting it convert back would relabel encoded HTML as text, so it would be encoded a second
+    /// time on the way out. The cases here mirror <see cref="Attribute.WriteTo"/>, so what's read back
+    /// is what gets written.
+    /// </remarks>
+    private static TemplateString? ValueToTemplateString(object? value) => value switch
+    {
+        null => null,
+        TemplateString templateString => templateString,
+        IHtmlContent htmlContent => new TemplateString(htmlContent),
+        true => new TemplateString("true"),
+        false => new TemplateString("false"),
+        _ => new TemplateString(Convert.ToString(value, CultureInfo.InvariantCulture))
+    };
 
     internal sealed record Attribute(string Name, object? Value, bool Optional) : IHtmlContent
     {
@@ -229,7 +251,7 @@ public sealed class AttributeCollection : IEnumerable<KeyValuePair<string, Templ
 
             yield return KeyValuePair.Create(
                 attribute.Name,
-                (TemplateString?)(attribute.Value as TemplateString ?? attribute.Value?.ToString()));
+                ValueToTemplateString(attribute.Value));
         }
     }
 

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.CharacterCount.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.CharacterCount.cs
@@ -19,9 +19,10 @@ internal partial class DefaultComponentGenerator
         TemplateString textareaDescriptionTextNoLimit;
         if (!hasNoLimit && textareaDescriptionLength.HasValue)
         {
-            textareaDescriptionTextNoLimit = TemplateString.FromEncoded(
-                textareaDescriptionText.ToHtmlString()
-                    .Replace("%{count}", textareaDescriptionLength.Value.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal));
+            textareaDescriptionTextNoLimit = ReplacePlaceholder(
+                textareaDescriptionText,
+                "%{count}",
+                textareaDescriptionLength.Value.ToString(CultureInfo.InvariantCulture));
         }
         else
         {

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.DateInput.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.DateInput.cs
@@ -160,7 +160,7 @@ internal partial class DefaultComponentGenerator
             var labelText = item.Label ?? Capitalize(itemName);
             var inputId = item.Id ?? new TemplateString($"{parentId}-{itemName}");
             var inputName = namePrefix.IsEmpty() ? itemName : new TemplateString($"{namePrefix}-{itemName}");
-            var inputValue = itemValue ?? GetValue(values, inputName?.ToHtmlString());
+            var inputValue = itemValue ?? GetValue(values, inputName.ToText());
 
             var inputComponent = await GenerateInputAsync(new InputOptions
             {
@@ -183,7 +183,7 @@ internal partial class DefaultComponentGenerator
     }
 
     private static bool ClassesContain(TemplateString? classes, string token) =>
-        !classes.IsEmpty() && classes!.ToHtmlString().Contains(token, StringComparison.Ordinal);
+        !classes.IsEmpty() && classes.ToText().Contains(token, StringComparison.Ordinal);
 
     private static bool NameMatches(TemplateString? name, string defaultName, TemplateString? fieldName) =>
         !name.IsEmpty() && (name == defaultName || name == fieldName);

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.PasswordInput.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.PasswordInput.cs
@@ -115,7 +115,7 @@ internal partial class DefaultComponentGenerator
             .With("aria-label", options.ShowPasswordAriaLabelText.WithEmptyFallback("Show password"))
             .WithBoolean("hidden"));
 
-        buttonElement.InnerHtml.Append(options.ShowPasswordText.WithEmptyFallback("Show").ToHtmlString());
+        buttonElement.InnerHtml.AppendHtml(options.ShowPasswordText.WithEmptyFallback("Show"));
 
         wrapperDiv.InnerHtml.AppendHtml(buttonElement);
 

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.Select.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.Select.cs
@@ -107,7 +107,7 @@ internal partial class DefaultComponentGenerator
                         else if (!options.Value.IsEmpty())
                         {
                             var compareWith = item.Value ?? item.Text;
-                            if (compareWith is not null && !compareWith.IsEmpty() && options.Value.ToHtmlString() == compareWith.ToHtmlString())
+                            if (compareWith is not null && !compareWith.IsEmpty() && options.Value == compareWith)
                             {
                                 selected = true;
                             }

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.cs
@@ -45,6 +45,8 @@ internal partial class DefaultComponentGenerator : IComponentGenerator
         public override IHtmlContent GetContent() => _content;
     }
 
+    // Casing the encoded form would upper-case the '&' of an entity rather than the character it
+    // stands for, so this works on the text.
     private static TemplateString Capitalize(TemplateString? input)
     {
         if (input.IsEmpty())
@@ -52,11 +54,28 @@ internal partial class DefaultComponentGenerator : IComponentGenerator
             return TemplateString.Empty;
         }
 
-        var encodedInput = input.ToHtmlString();
+        var text = input.ToText();
 
 #pragma warning disable CA1308
-        return TemplateString.FromEncoded(char.ToUpperInvariant(encodedInput[0]) + encodedInput[1..].ToLowerInvariant());
+        return new TemplateString(char.ToUpperInvariant(text[0]) + text[1..].ToLowerInvariant());
 #pragma warning restore CA1308
+    }
+
+    /// <summary>
+    /// Replaces every occurrence of <paramref name="placeholder"/> in <paramref name="value"/>.
+    /// </summary>
+    /// <remarks>
+    /// Substituting into the text rather than the rendered HTML keeps the result's encoding, so it's
+    /// still written with the caller's encoder.
+    /// </remarks>
+    private static TemplateString ReplacePlaceholder(TemplateString value, string placeholder, string replacement)
+    {
+        if (value.TryGetText(out var text))
+        {
+            return new TemplateString(text.Replace(placeholder, replacement, StringComparison.Ordinal));
+        }
+
+        return TemplateString.FromEncoded(value.Render().Replace(placeholder, replacement, StringComparison.Ordinal));
     }
 
     private class HtmlTagGovUkComponent : GovUkComponent

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/TemplateString.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/TemplateString.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -17,6 +18,9 @@ public sealed class TemplateString : IEquatable<TemplateString>, IHtmlContent
 {
     internal static HtmlEncoder DefaultEncoder { get; } = HtmlEncoder.Default;
 
+    // Either an unencoded string, an already-encoded IHtmlContent, or a Composite of both. Composites
+    // are kept unrendered so that composition doesn't have to pick an encoder, and so that a value
+    // built from text stays recognizable as text.
     private readonly object? _value;
 
     /// <summary>
@@ -49,8 +53,27 @@ public sealed class TemplateString : IEquatable<TemplateString>, IHtmlContent
     /// </summary>
     public TemplateString(TemplateStringInterpolatedStringHandler builder)
     {
-        _value = new HtmlString(builder.GetFormattedText());
+        // Empty parts aren't dropped here the way Join drops them: the literals between holes are
+        // content, and a literal that's only whitespace is still meaningful.
+        var parts = builder.GetParts();
+
+        _value = parts.Count switch
+        {
+            0 => string.Empty,
+            1 => parts[0]._value,
+            _ => new Composite([.. parts], Separator: string.Empty)
+        };
     }
+
+    private TemplateString(Composite composite)
+    {
+        _value = composite;
+    }
+
+    /// <summary>
+    /// A sequence of values written in order, without committing to an encoder up front.
+    /// </summary>
+    private sealed record Composite(TemplateString[] Parts, string Separator);
 
     /// <summary>
     /// Creates a new <see cref="TemplateString"/> from an encoded <see cref="string"/>.
@@ -79,27 +102,26 @@ public sealed class TemplateString : IEquatable<TemplateString>, IHtmlContent
         ArgumentNullException.ThrowIfNull(separator);
         ArgumentNullException.ThrowIfNull(content);
 
-        var builder = new StringBuilder();
-        using var writer = new StringWriter(builder);
+        var parts = content.Where(item => item is not null && !item.IsEmpty()).ToArray();
 
-        var first = true;
-        foreach (var item in content)
+        return parts.Length switch
         {
-            if (item is null || item.IsEmpty())
-            {
-                continue;
-            }
+            0 => Empty,
+            1 => parts[0]!,
+            _ => new TemplateString(new Composite(parts!, separator))
+        };
+    }
 
-            if (!first)
-            {
-                builder.Append(separator);
-            }
+    /// <summary>
+    /// Concatenates the specified values, keeping each one's encoding.
+    /// </summary>
+    /// <param name="values">The values to concatenate.</param>
+    /// <returns>A new <see cref="TemplateString"/> with the concatenated content.</returns>
+    public static TemplateString Concat(params TemplateString?[] values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
 
-            item.WriteTo(writer, DefaultEncoder);
-            first = false;
-        }
-
-        return FromEncoded(builder.ToString());
+        return Join(string.Empty, values);
     }
 
     /// <summary>
@@ -125,7 +147,7 @@ public sealed class TemplateString : IEquatable<TemplateString>, IHtmlContent
     /// <summary>
     /// A <see cref="TemplateString"/> with no content.
     /// </summary>
-    public static TemplateString Empty { get; } = new(HtmlString.Empty);
+    public static TemplateString Empty { get; } = new(string.Empty);
 
     /// <summary>
     /// Concatenates two <see cref="TemplateString"/> instances.
@@ -147,23 +169,14 @@ public sealed class TemplateString : IEquatable<TemplateString>, IHtmlContent
             return first;
         }
 
-        // Optimize concatenation for string + string case using StringBuilder to avoid intermediate allocations
+        // Text stays text: concatenating two unencoded strings gives an unencoded string, so the
+        // result still encodes at write time using whatever encoder the caller supplies.
         if (first._value is string str1 && second._value is string str2)
         {
-            // Both are strings - encode both and concatenate using StringBuilder
-            var encoded1 = DefaultEncoder.Encode(str1);
-            var encoded2 = DefaultEncoder.Encode(str2);
-            var sb = new StringBuilder(encoded1.Length + encoded2.Length);
-            sb.Append(encoded1);
-            sb.Append(encoded2);
-            return new TemplateString(new HtmlString(sb.ToString()));
+            return new TemplateString(string.Concat(str1, str2));
         }
 
-        // At least one is IHtmlContent - concatenate their HTML representations
-        using var writer = new StringWriter();
-        first.WriteTo(writer, DefaultEncoder);
-        second.WriteTo(writer, DefaultEncoder);
-        return FromEncoded(writer.ToString());
+        return new TemplateString(new Composite([first, second], Separator: string.Empty));
     }
 
     /// <summary>
@@ -212,6 +225,88 @@ public sealed class TemplateString : IEquatable<TemplateString>, IHtmlContent
     }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
+    /// <summary>
+    /// Gets whether this instance holds already-encoded HTML rather than plain text.
+    /// </summary>
+    /// <remarks>
+    /// A value built by concatenating or joining others is HTML if any of its parts is.
+    /// </remarks>
+    public bool IsHtml => _value switch
+    {
+        Composite composite => Array.Exists(composite.Parts, part => part.IsHtml),
+        IHtmlContent => true,
+        _ => false
+    };
+
+    /// <summary>
+    /// Gets the plain, unencoded text of this instance when it has an unambiguous text reading.
+    /// </summary>
+    /// <param name="text">
+    /// When this method returns <see langword="true"/>, the unencoded text; otherwise <see langword="null"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when this instance was created from text, or from HTML containing no
+    /// character an HTML encoder would escape — in which case its text and HTML forms are identical.
+    /// Otherwise <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    /// This never HTML-decodes: decoding isn't the inverse of encoding, so a decoded value wouldn't
+    /// re-encode to the same markup. Use this for values that are identifiers, attribute tokens or
+    /// parseable data; to write content out, write the <see cref="TemplateString"/> itself.
+    /// </remarks>
+    public bool TryGetText([NotNullWhen(true)] out string? text)
+    {
+        if (_value is null)
+        {
+            text = string.Empty;
+            return true;
+        }
+
+        if (_value is string str)
+        {
+            text = str;
+            return true;
+        }
+
+        if (_value is Composite composite)
+        {
+            var builder = new StringBuilder();
+
+            for (var i = 0; i < composite.Parts.Length; i++)
+            {
+                if (!composite.Parts[i].TryGetText(out var partText))
+                {
+                    text = null;
+                    return false;
+                }
+
+                if (i > 0)
+                {
+                    builder.Append(composite.Separator);
+                }
+
+                builder.Append(partText);
+            }
+
+            text = builder.ToString();
+            return true;
+        }
+
+        // Encoding is what tells the two readings apart, so ask it directly: content that encoding
+        // leaves alone reads identically as text and as HTML. Testing against the default encoder is
+        // the conservative choice, since it escapes the most.
+        var rendered = Render(DefaultEncoder);
+
+        if (string.Equals(DefaultEncoder.Encode(rendered), rendered, StringComparison.Ordinal))
+        {
+            text = rendered;
+            return true;
+        }
+
+        text = null;
+        return false;
+    }
+
     /// <inheritdoc cref="IHtmlContent.WriteTo"/>
     public void WriteTo(TextWriter writer, HtmlEncoder encoder)
     {
@@ -231,8 +326,38 @@ public sealed class TemplateString : IEquatable<TemplateString>, IHtmlContent
             return;
         }
 
+        if (_value is Composite composite)
+        {
+            for (var i = 0; i < composite.Parts.Length; i++)
+            {
+                if (i > 0 && composite.Separator.Length > 0)
+                {
+                    // The separator is text, so it's encoded like any other text.
+                    encoder.Encode(writer, composite.Separator);
+                }
+
+                composite.Parts[i].WriteTo(writer, encoder);
+            }
+
+            return;
+        }
+
         Debug.Assert(_value is IHtmlContent);
         ((IHtmlContent)_value).WriteTo(writer, encoder);
+    }
+
+    internal string Render(HtmlEncoder? encoder = null)
+    {
+        encoder ??= DefaultEncoder;
+
+        if (_value is IHtmlContent and HtmlString htmlString)
+        {
+            return htmlString.Value ?? string.Empty;
+        }
+
+        using var writer = new StringWriter();
+        WriteTo(writer, encoder);
+        return writer.ToString();
     }
 
     /// <inheritdoc/>
@@ -240,9 +365,16 @@ public sealed class TemplateString : IEquatable<TemplateString>, IHtmlContent
         ReferenceEquals(this, obj) || (obj is TemplateString other && Equals(other));
 
     /// <inheritdoc/>
-    public override int GetHashCode() => _value != null ? _value.GetHashCode() : 0;
+    /// <remarks>
+    /// Hashes the rendered form, so that it agrees with <see cref="Equals(TemplateString?)"/>.
+    /// </remarks>
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Render(DefaultEncoder));
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Two instances are equal when they render the same HTML, whether or not they hold the same kind
+    /// of content.
+    /// </remarks>
     public bool Equals(TemplateString? other)
     {
         if (other is null)
@@ -261,18 +393,6 @@ public sealed class TemplateString : IEquatable<TemplateString>, IHtmlContent
             return true;
         }
 
-        // Fast path: both empty
-        if (_value is "" or null && other._value is "" or null)
-        {
-            return true;
-        }
-
-        // Fast path: one is empty, the other is not
-        if (_value is "" or null || other._value is "" or null)
-        {
-            return false;
-        }
-
         // Fast path: both are strings - compare directly
         if (_value is string str1 && other._value is string str2)
         {
@@ -280,7 +400,7 @@ public sealed class TemplateString : IEquatable<TemplateString>, IHtmlContent
         }
 
         // Slow path: convert to HTML strings and compare
-        return string.Equals(this.ToHtmlString(DefaultEncoder), other.ToHtmlString(DefaultEncoder), StringComparison.Ordinal);
+        return string.Equals(Render(DefaultEncoder), other.Render(DefaultEncoder), StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -314,12 +434,10 @@ public sealed class TemplateString : IEquatable<TemplateString>, IHtmlContent
         }
 
         // Slow path: convert to HTML strings and compare
-        var thisHtml = this.ToHtmlString(DefaultEncoder);
-        var otherHtml = other.ToHtmlString(DefaultEncoder);
-        return thisHtml.Contains(otherHtml, StringComparison.Ordinal);
+        return Render(DefaultEncoder).Contains(other.Render(DefaultEncoder), StringComparison.Ordinal);
     }
 
-    private string DebuggerToString() => this.ToHtmlString(DefaultEncoder);
+    private string DebuggerToString() => Render(DefaultEncoder);
 }
 
 /// <summary>
@@ -362,6 +480,19 @@ public static class TemplateStringExtensions
 
         return !templateString.IsEmpty() ? templateString : fallback;
     }
+
+    /// <summary>
+    /// Gets the text of <paramref name="templateString"/> for use as an identifier, key or attribute
+    /// token, falling back to its rendered HTML when it has no unambiguous text reading.
+    /// </summary>
+    /// <remarks>
+    /// The fallback only applies to values holding real markup, which none of these call sites expect;
+    /// it keeps them behaving as they did when they rendered unconditionally.
+    /// </remarks>
+    internal static string ToText(this TemplateString? templateString) =>
+        templateString is null ? string.Empty :
+        templateString.TryGetText(out var text) ? text :
+        templateString.Render();
 }
 
 /// <summary>
@@ -370,22 +501,18 @@ public static class TemplateStringExtensions
 [EditorBrowsable(EditorBrowsableState.Never)]
 [InterpolatedStringHandler]
 #pragma warning disable CA1815
-#pragma warning disable CA1815
-#pragma warning disable CA1001
 public struct TemplateStringInterpolatedStringHandler
-#pragma warning restore CA1001
-#pragma warning restore CA1815
 #pragma warning restore CA1815
 {
-    private static readonly HtmlEncoder _encoder = TemplateString.DefaultEncoder;
-
-    private readonly StringWriter _writer;
+    // Parts are collected rather than rendered, so the result is written with the caller's encoder
+    // and a value interpolated from literals and text is still recognizable as text.
+    private readonly List<TemplateString> _parts;
 
     /// <summary>Initializes a new instance of the <see cref="TemplateStringInterpolatedStringHandler"/> struct.</summary>
     // ReSharper disable UnusedParameter.Local
     public TemplateStringInterpolatedStringHandler(int literalLength, int formattedCount)
     {
-        _writer = new();
+        _parts = new List<TemplateString>(formattedCount * 2 + 1);
     }
     // ReSharper restore UnusedParameter.Local
 
@@ -394,7 +521,7 @@ public struct TemplateStringInterpolatedStringHandler
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void AppendLiteral(string value)
     {
-        _writer.Write(_encoder.Encode(value));
+        _parts.Add(new TemplateString(value));
     }
 
     /// <summary>Writes the specified value to the handler.</summary>
@@ -407,19 +534,24 @@ public struct TemplateStringInterpolatedStringHandler
             return;
         }
 
-        if (value is IHtmlContent htmlContent)
+        if (value is TemplateString templateString)
         {
-            htmlContent.WriteTo(_writer, _encoder);
+            // Added as-is; wrapping it would relabel a text hole as HTML.
+            _parts.Add(templateString);
+        }
+        else if (value is IHtmlContent htmlContent)
+        {
+            _parts.Add(new TemplateString(htmlContent));
         }
         else
         {
             var str = Convert.ToString(value, CultureInfo.InvariantCulture);
             if (str is not null)
             {
-                _writer.Write(_encoder.Encode(str));
+                _parts.Add(new TemplateString(str));
             }
         }
     }
 
-    internal string GetFormattedText() => _writer.ToString();
+    internal readonly IReadOnlyList<TemplateString> GetParts() => _parts;
 }

--- a/src/GovUk.Frontend.AspNetCore/GovUk.Frontend.AspNetCore.csproj
+++ b/src/GovUk.Frontend.AspNetCore/GovUk.Frontend.AspNetCore.csproj
@@ -22,6 +22,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <WarningsAsErrors>$(WarningsAsErrors);RS0030</WarningsAsErrors>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -101,8 +102,18 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- RS0030 flags calls to the APIs in BannedSymbols.txt. An error rather than a warning so that a
+         double-encode can't reach review in the first place. -->
+    <AdditionalFiles Include="BannedSymbols.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="AspNetCore.SassCompiler" Version="1.99.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.13.61">
       <PrivateAssets>all</PrivateAssets>

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputTagHelper.cs
@@ -418,7 +418,7 @@ public class DateInputTagHelper : TagHelper
 
             TemplateString? GetValueFromModelState()
             {
-                var modelStateKey = _modelHelper.GetFullHtmlFieldName(ViewContext!, itemName.ToHtmlString());
+                var modelStateKey = _modelHelper.GetFullHtmlFieldName(ViewContext!, itemName.ToText());
 
                 return ViewContext!.ModelState.TryGetValue(modelStateKey, out var modelStateEntry) &&
                     modelStateEntry.AttemptedValue is not null

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupFieldsetHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupFieldsetHelper.cs
@@ -40,7 +40,7 @@ internal static class FormGroupFieldsetHelper
 
         if (resolvedLegendAttributes.Remove(IsPageHeadingAttributeName, out var isPageHeadingValue))
         {
-            resolvedLegendIsPageHeading = bool.TryParse(isPageHeadingValue?.ToHtmlString(), out var parsed)
+            resolvedLegendIsPageHeading = bool.TryParse(isPageHeadingValue.ToText(), out var parsed)
                 ? parsed
                 : throw new InvalidOperationException(
                     $"The '{LegendIsPageHeadingAttributeName}' attribute must be 'true' or 'false'.");

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/PanelTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/PanelTagHelper.cs
@@ -88,7 +88,7 @@ public class PanelTagHelper : TagHelper
         // Actions are only rendered for the interruption variant, so reject them otherwise
         // rather than silently dropping them.
         var isInterruption = !classes.IsEmpty() &&
-            classes!.ToHtmlString().Contains(InterruptionClassName, StringComparison.Ordinal);
+            classes.ToText().Contains(InterruptionClassName, StringComparison.Ordinal);
 
         if (panelContext.Actions is not null && !isInterruption)
         {

--- a/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/AttributeCollectionTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/AttributeCollectionTests.cs
@@ -1,3 +1,6 @@
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 using GovUk.Frontend.AspNetCore.ComponentGeneration;
 
 namespace GovUk.Frontend.AspNetCore.Tests.ComponentGeneration;
@@ -58,5 +61,35 @@ public class AttributeCollectionTests
 
         // Assert
         Assert.Equal("id1 id2", attributes["aria-describedby"]?.ToHtmlString());
+    }
+
+    [Theory]
+    [InlineData("a&b")]
+    [InlineData("a<b>c")]
+    [InlineData("say \"hi\"")]
+    public void ReadingAndWritingAnAttributeFromRazor_RoundTripsExactly(string value)
+    {
+        // Razor hands over attribute values already encoded, as an IHtmlContent. Reading one back out
+        // and putting it in again must not treat it as text, or it gets encoded a second time.
+        var encoded = HtmlEncoder.Default.Encode(value);
+
+        var attributes = new AttributeCollection(
+            [new TagHelperAttribute("data-test", new HtmlString(encoded), HtmlAttributeValueStyle.DoubleQuotes)]);
+
+        // Act
+        var viaIndexer = attributes["data-test"];
+        var viaEnumerator = attributes.Single().Value;
+        Assert.True(attributes.Remove("data-test", out var viaRemove));
+
+        // Assert
+        foreach (var read in new[] { viaIndexer, viaEnumerator, viaRemove })
+        {
+            Assert.NotNull(read);
+
+            var tag = new HtmlTag("div", attrs => attrs.With("data-test", read));
+            var element = HtmlHelper.ParseHtmlElement(tag.ToHtmlString());
+
+            Assert.Equal(value, element.GetAttribute("data-test"));
+        }
     }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/TemplateStringPropertyTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/TemplateStringPropertyTests.cs
@@ -1,0 +1,218 @@
+using System.Text.Encodings.Web;
+using System.Text.Unicode;
+using GovUk.Frontend.AspNetCore.ComponentGeneration;
+
+namespace GovUk.Frontend.AspNetCore.Tests.ComponentGeneration;
+
+/// <summary>
+/// Properties that have to hold for every <see cref="TemplateString"/>, checked exhaustively over a
+/// small alphabet rather than by example. The value space is tiny, so the whole cartesian product
+/// composed to depth two runs in milliseconds.
+/// </summary>
+public class TemplateStringPropertyTests
+{
+    private static readonly string[] Alphabet =
+        ["", "a", "&", "<b>", "\"'", "é", "AT&amp;T", "a & b"];
+
+    private static readonly HtmlEncoder DefaultEncoder = HtmlEncoder.Default;
+
+    /// <summary>
+    /// An encoder that leaves non-ASCII alone — what a Welsh service would register.
+    /// </summary>
+    private static readonly HtmlEncoder UnicodeEncoder = HtmlEncoder.Create(UnicodeRanges.All);
+
+    /// <summary>
+    /// Every way of building a <see cref="TemplateString"/> holding each alphabet value.
+    /// </summary>
+    private static IEnumerable<(string Description, TemplateString Value)> Atoms()
+    {
+        foreach (var s in Alphabet)
+        {
+            yield return ($"Text({s})", new TemplateString(s));
+            yield return ($"Html(Encode({s}))", TemplateString.FromEncoded(DefaultEncoder.Encode(s)));
+            yield return ($"Html({s})", TemplateString.FromEncoded(s));
+        }
+    }
+
+    private static IEnumerable<(string Description, TemplateString Value)> Composed()
+    {
+        foreach (var (description, value) in Atoms())
+        {
+            yield return (description, value);
+        }
+
+        foreach (var (leftDescription, left) in Atoms())
+        {
+            foreach (var (rightDescription, right) in Atoms())
+            {
+                yield return ($"{leftDescription} + {rightDescription}", left + right);
+                yield return ($"Join(' ', {leftDescription}, {rightDescription})", TemplateString.Join(" ", left, right));
+                yield return ($"$\"{{{leftDescription}}}-{{{rightDescription}}}\"", new TemplateString($"{left}-{right}"));
+            }
+        }
+    }
+
+    [Fact]
+    public void Concatenation_DistributesOverRendering()
+    {
+        // Render(a + b) == Render(a) + Render(b). If this holds, concatenation can't be quietly
+        // changing how either operand is treated.
+        foreach (var (leftDescription, left) in Atoms())
+        {
+            foreach (var (rightDescription, right) in Atoms())
+            {
+                var expected = Render(left) + Render(right);
+                var actual = Render(left + right);
+
+                Assert.True(expected == actual, $"{leftDescription} + {rightDescription}: expected '{expected}', got '{actual}'");
+            }
+        }
+    }
+
+    [Fact]
+    public void TryGetText_AgreesWithRendering()
+    {
+        // The invariant that makes TryGetText safe to build keys and tokens from: whenever it
+        // succeeds, encoding the text it returns reproduces the rendered HTML exactly.
+        foreach (var (description, value) in Composed())
+        {
+            if (!value.TryGetText(out var text))
+            {
+                continue;
+            }
+
+            Assert.True(
+                DefaultEncoder.Encode(text) == Render(value),
+                $"{description}: text '{text}' encodes to '{DefaultEncoder.Encode(text)}' but renders as '{Render(value)}'");
+        }
+    }
+
+    [Fact]
+    public void TryGetText_SucceedsForEverythingBuiltFromText()
+    {
+        foreach (var s in Alphabet)
+        {
+            Assert.True(new TemplateString(s).TryGetText(out var text));
+            Assert.Equal(s, text);
+        }
+
+        // ...including once it's been composed.
+        Assert.True((new TemplateString("a") + new TemplateString("&")).TryGetText(out var concatenated));
+        Assert.Equal("a&", concatenated);
+
+        Assert.True(TemplateString.Join("-", new TemplateString("a"), new TemplateString("&")).TryGetText(out var joined));
+        Assert.Equal("a-&", joined);
+
+        Assert.True(new TemplateString($"{new TemplateString("a")}-{new TemplateString("&")}").TryGetText(out var interpolated));
+        Assert.Equal("a-&", interpolated);
+    }
+
+    [Fact]
+    public void TryGetText_FailsForMarkup()
+    {
+        Assert.False(TemplateString.FromEncoded("<b>bold</b>").TryGetText(out _));
+        Assert.False(TemplateString.FromEncoded("&lt;b&gt;").TryGetText(out _));
+
+        // A composite is only text if all of it is.
+        Assert.False((new TemplateString("a") + TemplateString.FromEncoded("<b>")).TryGetText(out _));
+    }
+
+    [Fact]
+    public void Rendering_UsesTheSuppliedEncoder()
+    {
+        // Composition must not bake in HtmlEncoder.Default, or an app that registers a Unicode-aware
+        // encoder gets é in some places and &#xE9; in others.
+        foreach (var (description, value) in Composed())
+        {
+            if (!value.TryGetText(out var text) || !text.Contains('é', StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            Assert.True(
+                Render(value, UnicodeEncoder).Contains('é', StringComparison.Ordinal),
+                $"{description}: rendered as '{Render(value, UnicodeEncoder)}'");
+        }
+    }
+
+    [Fact]
+    public void Join_EncodesTheSeparator()
+    {
+        var joined = TemplateString.Join(" & ", new TemplateString("a"), new TemplateString("b"));
+
+        Assert.Equal("a &amp; b", Render(joined));
+    }
+
+    [Fact]
+    public void Join_MatchesStringJoinOfTheRenderedParts()
+    {
+        foreach (var (leftDescription, left) in Atoms())
+        {
+            foreach (var (rightDescription, right) in Atoms())
+            {
+                var parts = new[] { left, right }.Where(p => !p.IsEmpty()).Select(p => Render(p));
+                var expected = string.Join(DefaultEncoder.Encode("-"), parts);
+                var actual = Render(TemplateString.Join("-", left, right));
+
+                Assert.True(expected == actual, $"Join('-', {leftDescription}, {rightDescription}): expected '{expected}', got '{actual}'");
+            }
+        }
+    }
+
+    [Fact]
+    public void Equality_AndHashing_AgreeWithRendering()
+    {
+        // Rendered forms and hashes are computed once; comparing every pair otherwise means rendering
+        // each value a few thousand times.
+        var all = Composed()
+            .Select(v => (v.Description, v.Value, Rendered: Render(v.Value), Hash: v.Value.GetHashCode()))
+            .ToArray();
+
+        foreach (var left in all)
+        {
+            foreach (var right in all)
+            {
+                var rendersTheSame = left.Rendered == right.Rendered;
+                var isEqual = left.Value.Equals(right.Value);
+
+                Assert.True(
+                    isEqual == rendersTheSame,
+                    $"'{left.Description}' vs '{right.Description}': Equals returned {isEqual} but renders {(rendersTheSame ? "the same" : "differently")}");
+
+                if (isEqual)
+                {
+                    Assert.True(
+                        left.Hash == right.Hash,
+                        $"'{left.Description}' equals '{right.Description}' but hashes differently");
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void EmptyValues_AreAllEqual()
+    {
+        Assert.Equal(TemplateString.Empty, new TemplateString(""));
+        Assert.Equal(TemplateString.Empty, new TemplateString((string?)null));
+        Assert.Equal(TemplateString.Empty, TemplateString.FromEncoded(""));
+        Assert.Equal(TemplateString.Empty.GetHashCode(), new TemplateString("").GetHashCode());
+    }
+
+    [Fact]
+    public void IsHtml_IsTrueWhenAnyPartIsHtml()
+    {
+        Assert.False(new TemplateString("a").IsHtml);
+        Assert.True(TemplateString.FromEncoded("<b>").IsHtml);
+
+        Assert.False((new TemplateString("a") + new TemplateString("b")).IsHtml);
+        Assert.True((new TemplateString("a") + TemplateString.FromEncoded("<b>")).IsHtml);
+        Assert.True(TemplateString.Join(" ", new TemplateString("a"), TemplateString.FromEncoded("<b>")).IsHtml);
+    }
+
+    private static string Render(TemplateString value, HtmlEncoder? encoder = null)
+    {
+        using var writer = new StringWriter();
+        value.WriteTo(writer, encoder ?? DefaultEncoder);
+        return writer.ToString();
+    }
+}


### PR DESCRIPTION
Follow-up to #500. That fixed the symptom — text emitted as markup. This removes the conditions that made it writable.

## The problem

`operator +`, `Join`, `AppendCssClasses` and interpolation all rendered their operands immediately with `HtmlEncoder.Default` and returned the result as `FromEncoded`. Two things followed.

**The application's configured encoder was discarded.** An app registering `HtmlEncoder.Create(UnicodeRanges.All)` — the usual move for a Welsh service — got a literal `ŵ` for a value written directly and `&#x175;` for anything that had been concatenated, on the same page.

**A value built from text was no longer recognisable as text**, and there was no way to ask a `TemplateString` for its text anyway. So callers who wanted an identifier rather than markup reached for `ToHtmlString()`, which is the *encoded* form. Dictionary keys, a ModelState key, `bool.TryParse`, CSS class token tests and `Capitalize` were all operating on encoded text — wrong for anything outside Basic Latin, which is everything `HtmlEncoder.Default` escapes.

## The change

`_value` now admits a `Composite` of parts, walked at write time with the caller's encoder. That fixes the encoder loss, keeps text recognisable as text, and fixes `Join` inserting its separator unencoded.

```csharp
public bool IsHtml { get; }
public bool TryGetText([NotNullWhen(true)] out string? text);
```

`TryGetText` succeeds when the value is text-backed, or when it is HTML that encoding leaves unchanged — in which case the text and HTML readings provably coincide. **It never HTML-decodes.** Decoding isn't the inverse of encoding: `FromEncoded("<b>")` would decode to `<b>`, which as text re-encodes to `&lt;b&gt;`, a different rendering. It also isn't injective — `FromEncoded("<b>")` and `FromEncoded("&lt;b&gt;")` both decode to `<b>`, so keys derived from it would collide markup with escaped text. And it would be the deleted `GetRawHtml()` pointing the other way, handing out a `string` containing `<script>` that somebody eventually `AppendHtml`s.

## Also fixed — the same defect from other angles

- **`AttributeCollection`'s read path.** The indexer, `Remove` and enumeration each coerced `Value` via `ToString()`, relabelling Razor's already-encoded attribute value as text so it was encoded a second time on the way out. `class="a&amp;b"` in a view came back as `a&amp;amp;b`. Now normalised at the point of reading, mirroring `Attribute.WriteTo` so what's read back is what gets written. ~40 `Remove("class", …)` call sites reach this.
- **`GetHashCode` disagreed with `Equals`** (which compares rendered output), so `TemplateString` was unsafe as a dictionary or set key.
- **`Empty` was `HtmlString`-backed**, so it wasn't equal to `new TemplateString("")` and the empty fast paths never fired for it.
- **The password input's button text was still double-encoded on `main`** — that fix had only landed on the localization branch.

## The guard rail

`src` no longer calls `ToHtmlString` anywhere, so it's banned there via `BannedApiAnalyzers` with `RS0030` as an error. I verified this by reintroducing the original bug:

```
error RS0030: The symbol 'HtmlContentExtensions.ToHtmlString(IHtmlContent, HtmlEncoder?)' is banned in
this project: Returns encoded HTML, so passing the result somewhere that encodes gives double-encoded
output. Use TemplateString.TryGetText for a value's text, TemplateString.Render to render it, or write
the value itself.
```

Not banned in the test projects, where rendering to a string for assertions is the point.

## Tests

`TemplateStringPropertyTests` checks properties exhaustively over a small alphabet × the three ways of constructing a value, composed to depth two — about 1,800 values, under a second. It asserts `Render(a + b) == Render(a) + Render(b)`; that `TryGetText` succeeding implies `Encode(text) == Render(value)`; that a Unicode-aware encoder is respected however the value was built; that `Join` matches `string.Join` of the rendered parts; that `Equals` agrees with rendering and equal values hash equally; and that the three empty values are interchangeable.

**This approach earned its keep immediately** — it found two bugs in my first cut that example-based tests would have missed: interpolation was promoting text holes to HTML (because `TemplateString` is itself an `IHtmlContent`), and my rule for reading text back out of HTML was a hand-written character list standing in for the round-trip law rather than the law itself, which `é` broke.

`AttributeCollectionTests` gains a round-trip test built from a `TagHelperAttribute` carrying an `HtmlString`, exactly what Razor produces. It fails on `main` with `a&amp;b` → `a&amp;amp;b`.

`dotnet test` is green on net8.0, net9.0 and net10.0 — 1545 unit and 84 integration tests each — and the Release build succeeds.

## Not in this PR

Expressing the union in the options records (`Text` → `string?`, `Html` → `IHtmlContent?`) so that mislabelling becomes a compile error rather than a safe-but-wrong encode. That's ~80 assignment sites and a public API break, so it wants a major version — and it's much safer now the semantics underneath are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)