### PR TITLE
Stop tag helper test cases being dropped as duplicates

### DIFF
--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesFieldsetLegendTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesFieldsetLegendTagHelperTests.cs
@@ -11,7 +11,7 @@ public class CheckboxesFieldsetLegendTagHelperTests : TagHelperTestBase<Checkbox
     public async Task ProcessAsync_AddsLegendToContext()
     {
         // Arrange
-        var fieldsetContext = new FormGroupFieldsetContext2(CheckboxesFieldsetTagHelper.TagName);
+        var fieldsetContext = new FormGroupFieldsetContext2(ParentTagName!);
 
         var context = CreateTagHelperContext(contexts: fieldsetContext);
 
@@ -40,13 +40,13 @@ public class CheckboxesFieldsetLegendTagHelperTests : TagHelperTestBase<Checkbox
     public async Task ProcessAsync_ParentAlreadyHasLegend_ThrowsInvalidOperationException()
     {
         // Arrange
-        var fieldsetContext = new FormGroupFieldsetContext2(CheckboxesFieldsetTagHelper.TagName);
+        var fieldsetContext = new FormGroupFieldsetContext2(ParentTagName!);
 
         fieldsetContext.SetLegend(
             isPageHeading: false,
             attributes: new AttributeCollection(),
             html: new HtmlString("Existing legend"),
-            CheckboxesFieldsetLegendTagHelper.TagName);
+            TagName);
 
         var context = CreateTagHelperContext(contexts: fieldsetContext);
 
@@ -68,6 +68,6 @@ public class CheckboxesFieldsetLegendTagHelperTests : TagHelperTestBase<Checkbox
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal("Only one <govuk-checkboxes-fieldset-legend> element is permitted within each <govuk-checkboxes-fieldset>.", ex.Message);
+        Assert.Equal($"Only one <{TagName}> element is permitted within each <{ParentTagName}>.", ex.Message);
     }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/DateInputFieldsetLegendTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/DateInputFieldsetLegendTagHelperTests.cs
@@ -14,7 +14,7 @@ public class DateInputFieldsetLegendTagHelperTests : TagHelperTestBase<DateInput
         var isPageHeading = true;
         var attributes = CreateDummyDataAttributes();
 
-        var fieldsetContext = new FormGroupFieldsetContext2(DateInputFieldsetTagHelper.TagName);
+        var fieldsetContext = new FormGroupFieldsetContext2(ParentTagName!);
 
         var context = CreateTagHelperContext(
             attributes: attributes,
@@ -50,9 +50,9 @@ public class DateInputFieldsetLegendTagHelperTests : TagHelperTestBase<DateInput
     public async Task ProcessAsync_ParentAlreadyHasLegend_ThrowsInvalidOperationException()
     {
         // Arrange
-        var fieldsetContext = new FormGroupFieldsetContext2(DateInputFieldsetTagHelper.TagName);
+        var fieldsetContext = new FormGroupFieldsetContext2(ParentTagName!);
 
-        fieldsetContext.SetLegend(isPageHeading: false, attributes: [], html: new TemplateString("Existing legend"), DateInputFieldsetLegendTagHelper.TagName);
+        fieldsetContext.SetLegend(isPageHeading: false, attributes: [], html: new TemplateString("Existing legend"), TagName);
 
         var context = CreateTagHelperContext(contexts: fieldsetContext);
 

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/DateInputItemTagHelperBaseTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/DateInputItemTagHelperBaseTests.cs
@@ -89,6 +89,8 @@ public abstract class DateInputItemTagHelperBaseTests<T> : TagHelperTestBase<T>
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal($"Value cannot be specified for both <{TagName}> and the parent <{ParentTagName}>.", ex.Message);
+        // The conflicting value lives on the root date input, so that's what's named regardless
+        // of whether the item sits directly inside it or inside its fieldset.
+        Assert.Equal($"Value cannot be specified for both <{TagName}> and the parent <{DateInputTagHelper.TagName}>.", ex.Message);
     }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosFieldsetLegendTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosFieldsetLegendTagHelperTests.cs
@@ -10,7 +10,7 @@ public class RadiosFieldsetLegendTagHelperTests : TagHelperTestBase<RadiosFields
     public async Task ProcessAsync_AddsLegendToContext()
     {
         // Arrange
-        var fieldsetContext = new FormGroupFieldsetContext2(RadiosFieldsetTagHelper.TagName);
+        var fieldsetContext = new FormGroupFieldsetContext2(ParentTagName!);
 
         var context = CreateTagHelperContext(contexts: fieldsetContext);
 
@@ -39,13 +39,13 @@ public class RadiosFieldsetLegendTagHelperTests : TagHelperTestBase<RadiosFields
     public async Task ProcessAsync_ParentAlreadyHasLegend_ThrowsInvalidOperationException()
     {
         // Arrange
-        var fieldsetContext = new FormGroupFieldsetContext2(RadiosFieldsetTagHelper.TagName);
+        var fieldsetContext = new FormGroupFieldsetContext2(ParentTagName!);
 
         fieldsetContext.SetLegend(
             isPageHeading: false,
             attributes: new AttributeCollection(),
             html: new TemplateString("Existing legend"),
-            RadiosFieldsetLegendTagHelper.TagName);
+            TagName);
 
         var context = CreateTagHelperContext(contexts: fieldsetContext);
 
@@ -67,6 +67,6 @@ public class RadiosFieldsetLegendTagHelperTests : TagHelperTestBase<RadiosFields
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal("Only one <govuk-radios-fieldset-legend> element is permitted within each <govuk-radios-fieldset>.", ex.Message);
+        Assert.Equal($"Only one <{TagName}> element is permitted within each <{ParentTagName}>.", ex.Message);
     }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SummaryCardActionsTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SummaryCardActionsTagHelperTests.cs
@@ -89,17 +89,18 @@ public class SummaryCardActionsTagHelperTests : TagHelperTestBase<SummaryCardAct
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
         Assert.Equal(
-            $"Only one <{SummaryCardActionsTagHelper.ShortTagName}> or <{TagName}> element is permitted within each <{ParentTagName}>.",
+            $"Only one <{ShortTagName}> or <{PrimaryTagName}> element is permitted within each <{ParentTagName}>.",
             ex.Message);
     }
 
-    [Theory]
-    [InlineData(SummaryListTagHelper.TagName)]
-    public async Task ProcessAsync_ParentHasSummaryList_ThrowsInvalidOperationException(string summaryListTagName)
+    [Fact]
+    public async Task ProcessAsync_ParentHasSummaryList_ThrowsInvalidOperationException()
     {
         // Arrange
+        var summaryListTagName = SummaryListTagHelper.TagName;
+
         var summaryCardContext = new SummaryCardContext();
-        summaryCardContext.SetSummaryList(new(), SummaryListTagHelper.TagName);
+        summaryCardContext.SetSummaryList(new(), summaryListTagName);
 
         var context = CreateTagHelperContext(contexts: summaryCardContext);
 

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SummaryCardTitleTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SummaryCardTitleTagHelperTests.cs
@@ -78,12 +78,15 @@ public class SummaryCardTitleTagHelperTests : TagHelperTestBase<SummaryCardTitle
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
         Assert.Equal(
-            $"Only one <{SummaryCardTitleTagHelper.ShortTagName}> or <{TagName}> element is permitted within each <{ParentTagName}>.",
+            $"Only one <{ShortTagName}> or <{PrimaryTagName}> element is permitted within each <{ParentTagName}>.",
             ex.Message);
     }
 
     [Theory]
+    // Both spellings of the actions element are permitted within a <govuk-summary-card>, whichever
+    // spelling of the title is used, so each is exercised here.
     [InlineData(SummaryCardActionsTagHelper.TagName)]
+    [InlineData(SummaryCardActionsTagHelper.ShortTagName)]
     public async Task ProcessAsync_ParentHasActions_ThrowsInvalidOperationException(string actionsTagName)
     {
         // Arrange
@@ -91,7 +94,7 @@ public class SummaryCardTitleTagHelperTests : TagHelperTestBase<SummaryCardTitle
         var headingLevel = 3;
 
         var summaryCardContext = new SummaryCardContext();
-        summaryCardContext.SetActions(new(), SummaryCardActionsTagHelper.TagName);
+        summaryCardContext.SetActions(new(), actionsTagName);
 
         var context = CreateTagHelperContext(contexts: summaryCardContext);
 
@@ -118,16 +121,16 @@ public class SummaryCardTitleTagHelperTests : TagHelperTestBase<SummaryCardTitle
         Assert.Equal($"<{TagName}> must be specified before <{actionsTagName}>.", ex.Message);
     }
 
-    [Theory]
-    [InlineData(SummaryListTagHelper.TagName)]
-    public async Task ProcessAsync_ParentHasSummaryList_ThrowsInvalidOperationException(string summaryListTagName)
+    [Fact]
+    public async Task ProcessAsync_ParentHasSummaryList_ThrowsInvalidOperationException()
     {
         // Arrange
         var titleContent = "Title";
         var headingLevel = 3;
+        var summaryListTagName = SummaryListTagHelper.TagName;
 
         var summaryCardContext = new SummaryCardContext();
-        summaryCardContext.SetSummaryList(new(), SummaryListTagHelper.TagName);
+        summaryCardContext.SetSummaryList(new(), summaryListTagName);
 
         var context = CreateTagHelperContext(contexts: summaryCardContext);
 

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SummaryListRowActionsTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SummaryListRowActionsTagHelperTests.cs
@@ -13,7 +13,7 @@ public class SummaryListRowActionsTagHelperTests : TagHelperTestBase<SummaryList
 
         var summaryListContext = new SummaryListContext();
 
-        var rowContext = new SummaryListRowContext(SummaryListRowTagHelper.TagName);
+        var rowContext = new SummaryListRowContext(ParentTagName!);
 
         var context = CreateTagHelperContext(
             className: className,
@@ -43,8 +43,8 @@ public class SummaryListRowActionsTagHelperTests : TagHelperTestBase<SummaryList
         // Arrange
         var summaryListContext = new SummaryListContext();
 
-        var rowContext = new SummaryListRowContext(SummaryListRowTagHelper.TagName);
-        rowContext.SetActions(new(), SummaryListRowActionsTagHelper.TagName);
+        var rowContext = new SummaryListRowContext(ParentTagName!);
+        rowContext.SetActions(new(), TagName);
 
         var context = CreateTagHelperContext(contexts: [summaryListContext, rowContext]);
 
@@ -60,7 +60,7 @@ public class SummaryListRowActionsTagHelperTests : TagHelperTestBase<SummaryList
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
         Assert.Equal(
-            $"Only one <{SummaryListRowActionsTagHelper.ShortTagName}> or <{TagName}> element is permitted within each <{ParentTagName}>.",
+            $"Only one <{ShortTagName}> or <{PrimaryTagName}> element is permitted within each <{ParentTagName}>.",
             ex.Message);
     }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SummaryListRowKeyTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SummaryListRowKeyTagHelperTests.cs
@@ -15,7 +15,7 @@ public class SummaryListRowKeyTagHelperTests : TagHelperTestBase<SummaryListRowK
 
         var summaryListContext = new SummaryListContext();
 
-        var rowContext = new SummaryListRowContext(SummaryListRowTagHelper.TagName);
+        var rowContext = new SummaryListRowContext(ParentTagName!);
 
         var context = CreateTagHelperContext(
             className: className,
@@ -54,8 +54,8 @@ public class SummaryListRowKeyTagHelperTests : TagHelperTestBase<SummaryListRowK
 
         var summaryListContext = new SummaryListContext();
 
-        var rowContext = new SummaryListRowContext(SummaryListRowTagHelper.TagName);
-        rowContext.SetKey(new(), SummaryListRowKeyTagHelper.TagName);
+        var rowContext = new SummaryListRowContext(ParentTagName!);
+        rowContext.SetKey(new(), TagName);
 
         var context = CreateTagHelperContext(contexts: [summaryListContext, rowContext]);
 
@@ -77,21 +77,24 @@ public class SummaryListRowKeyTagHelperTests : TagHelperTestBase<SummaryListRowK
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
         Assert.Equal(
-            $"Only one <{SummaryListRowKeyTagHelper.ShortTagName}> or <{TagName}> element is permitted within each <{ParentTagName}>.",
+            $"Only one <{ShortTagName}> or <{PrimaryTagName}> element is permitted within each <{ParentTagName}>.",
             ex.Message);
     }
 
-    [Theory]
-    [InlineData(SummaryListRowValueTagHelper.TagName)]
-    public async Task ProcessAsync_ParentHasValue_ThrowsInvalidOperationException(string valueTagName)
+    [Fact]
+    public async Task ProcessAsync_ParentHasValue_ThrowsInvalidOperationException()
     {
         // Arrange
         var content = "Key";
 
+        var valueTagName = GetSiblingTagName(
+            SummaryListRowValueTagHelper.TagName,
+            SummaryListRowValueTagHelper.ShortTagName);
+
         var summaryListContext = new SummaryListContext();
 
-        var rowContext = new SummaryListRowContext(SummaryListRowTagHelper.TagName);
-        rowContext.SetValue(new(), SummaryListRowValueTagHelper.TagName);
+        var rowContext = new SummaryListRowContext(ParentTagName!);
+        rowContext.SetValue(new(), valueTagName);
 
         var context = CreateTagHelperContext(contexts: [summaryListContext, rowContext]);
 
@@ -115,17 +118,20 @@ public class SummaryListRowKeyTagHelperTests : TagHelperTestBase<SummaryListRowK
         Assert.Equal($"<{TagName}> must be specified before <{valueTagName}>.", ex.Message);
     }
 
-    [Theory]
-    [InlineData(SummaryListRowActionsTagHelper.TagName)]
-    public async Task ProcessAsync_ParentHasActions_ThrowsInvalidOperationException(string actionsTagName)
+    [Fact]
+    public async Task ProcessAsync_ParentHasActions_ThrowsInvalidOperationException()
     {
         // Arrange
         var content = "Key";
 
+        var actionsTagName = GetSiblingTagName(
+            SummaryListRowActionsTagHelper.TagName,
+            SummaryListRowActionsTagHelper.ShortTagName);
+
         var summaryListContext = new SummaryListContext();
 
-        var rowContext = new SummaryListRowContext(SummaryListRowTagHelper.TagName);
-        rowContext.SetActions(new(), SummaryListRowActionsTagHelper.TagName);
+        var rowContext = new SummaryListRowContext(ParentTagName!);
+        rowContext.SetActions(new(), actionsTagName);
 
         var context = CreateTagHelperContext(contexts: [summaryListContext, rowContext]);
 

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SummaryListRowValueTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SummaryListRowValueTagHelperTests.cs
@@ -15,7 +15,7 @@ public class SummaryListRowValueTagHelperTests : TagHelperTestBase<SummaryListRo
 
         var summaryListContext = new SummaryListContext();
 
-        var rowContext = new SummaryListRowContext(SummaryListRowTagHelper.TagName);
+        var rowContext = new SummaryListRowContext(ParentTagName!);
 
         var context = CreateTagHelperContext(
             className: className,
@@ -54,8 +54,8 @@ public class SummaryListRowValueTagHelperTests : TagHelperTestBase<SummaryListRo
 
         var summaryListContext = new SummaryListContext();
 
-        var rowContext = new SummaryListRowContext(SummaryListRowTagHelper.TagName);
-        rowContext.SetValue(new(), SummaryListRowValueTagHelper.TagName);
+        var rowContext = new SummaryListRowContext(ParentTagName!);
+        rowContext.SetValue(new(), TagName);
 
         var context = CreateTagHelperContext(contexts: [summaryListContext, rowContext]);
 
@@ -77,21 +77,24 @@ public class SummaryListRowValueTagHelperTests : TagHelperTestBase<SummaryListRo
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
         Assert.Equal(
-            $"Only one <{SummaryListRowValueTagHelper.ShortTagName}> or <{TagName}> element is permitted within each <{ParentTagName}>.",
+            $"Only one <{ShortTagName}> or <{PrimaryTagName}> element is permitted within each <{ParentTagName}>.",
             ex.Message);
     }
 
-    [Theory]
-    [InlineData(SummaryListRowActionsTagHelper.TagName)]
-    public async Task ProcessAsync_ParentHasActions_ThrowsInvalidOperationException(string actionsTagName)
+    [Fact]
+    public async Task ProcessAsync_ParentHasActions_ThrowsInvalidOperationException()
     {
         // Arrange
         var content = "Value";
 
+        var actionsTagName = GetSiblingTagName(
+            SummaryListRowActionsTagHelper.TagName,
+            SummaryListRowActionsTagHelper.ShortTagName);
+
         var summaryListContext = new SummaryListContext();
 
-        var rowContext = new SummaryListRowContext(SummaryListRowTagHelper.TagName);
-        rowContext.SetActions(new(), SummaryListRowActionsTagHelper.TagName);
+        var rowContext = new SummaryListRowContext(ParentTagName!);
+        rowContext.SetActions(new(), actionsTagName);
 
         var context = CreateTagHelperContext(contexts: [summaryListContext, rowContext]);
 

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TagHelperTestBase.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TagHelperTestBase.cs
@@ -28,6 +28,19 @@ public abstract class TagHelperTestBase<T> where T : ITagHelper
 
     public IReadOnlyCollection<string> AllParentTagNames { get; set; } = null!;
 
+    /// <summary>
+    /// Whether the tag name under test is the short alias rather than the govuk- prefixed name.
+    /// </summary>
+    protected bool UsesShortTagName => TagName == ShortTagName;
+
+    /// <summary>
+    /// Gets the spelling of a sibling element that can legally appear alongside the tag name under
+    /// test. Where a short name pairs with a short parent, only siblings of the same spelling are
+    /// permitted within that parent.
+    /// </summary>
+    protected string GetSiblingTagName(string tagName, string shortTagName) =>
+        UsesShortTagName ? shortTagName : tagName;
+
     protected TagHelperContext CreateTagHelperContext(
         string? tagName = null,
         string? className = null,

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TagHelperTestCase.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TagHelperTestCase.cs
@@ -78,11 +78,13 @@ public class TagHelperTestCase : XunitTestCase, ISelfExecutingXunitTestCase
 
     public TagHelperTestCase(
         TagHelperTestCaseInfo tagHelperTestCaseInfo,
-        XunitTestCase baseTestCase) :
+        XunitTestCase baseTestCase,
+        string testCaseDisplayName,
+        string uniqueID) :
         base(
             baseTestCase.TestMethod,
-            baseTestCase.TestCaseDisplayName,
-            baseTestCase.UniqueID,
+            testCaseDisplayName,
+            uniqueID,
             baseTestCase.Explicit,
             baseTestCase.SkipExceptions,
             baseTestCase.SkipReason,
@@ -345,7 +347,9 @@ file record TagHelperInfo((string TagName, string? ParentTagName)[] TagNames, st
         // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         var allParentTagNames = tagHelperInfo.TagNames.Select(t => t.ParentTagName!).Where(t => t is not null).Distinct().OrderByGovUkPrefixedFirst().ToArray();
 
-        return tagHelperInfo.TagNames
+        var targets = tagHelperInfo.TagNames.Distinct().ToArray();
+
+        return targets
             .SelectMany(i => baseTestCases.Select(tc =>
             {
                 var tagHelperTestCaseInfo = new TagHelperTestCaseInfo(
@@ -356,7 +360,15 @@ file record TagHelperInfo((string TagName, string? ParentTagName)[] TagNames, st
                     AllTagNames: allTagNames,
                     AllParentTagNames: allParentTagNames);
 
-                return new TagHelperTestCase(tagHelperTestCaseInfo, (XunitTestCase)tc);
+                // Each target gets its own test case so they need distinct display names and IDs;
+                // when there's only a single target keep the names the method itself declared.
+                var target = i.ParentTagName is not null ? $"{i.TagName} in {i.ParentTagName}" : i.TagName;
+
+                return new TagHelperTestCase(
+                    tagHelperTestCaseInfo,
+                    (XunitTestCase)tc,
+                    targets.Length > 1 ? $"{tc.TestCaseDisplayName} [{target}]" : tc.TestCaseDisplayName,
+                    targets.Length > 1 ? $"{tc.UniqueID}-{target}" : tc.UniqueID);
             }))
             .ToArray();
     }


### PR DESCRIPTION
Running the unit tests logs 82 `Skipping test case with duplicate ID` messages. This is what's behind them.

## The cause

`TagHelperFactDiscoverer` fans each discovered test out into one case per `[HtmlTargetElement]` on the tag helper under test, so a helper reachable as both `<govuk-panel-body>` and `<panel-body>` runs its tests against each. Every clone was constructed with the base test case's `UniqueID` and `TestCaseDisplayName` though, leaving them indistinguishable to xUnit, which dedupes by unique ID during discovery and logs the message.

Only tag helpers with more than one target were affected — 33 test classes, in two shapes:

- a short tag name alias, e.g. `PanelBodyTagHelper` targeting `govuk-panel-body` and `panel-body`
- the same tag under two parents, e.g. `DateInputMonthTagHelper` targeting both `govuk-date-input` and `govuk-date-input-fieldset`

So 82 cases were being discarded: every short tag name alias, and every alternate parent element. A `<govuk-date-input-month>` was only ever tested directly inside `<govuk-date-input>`, never inside `<govuk-date-input-fieldset>`.

## The fix

Each generated case now gets its own display name and ID, keeping the names the method declared when a helper has a single target so existing test IDs don't churn. Display names gain the target they run against, e.g. `ProcessAsync_SetsBodyOnContext [panel-body in govuk-panel]`.

## What that exposed

Nine of the cases that started running failed. All were assertions that had never been executed rather than product defects — the messages they check are fixed strings that don't echo the variant's own tag names:

- the `only one ... is permitted` messages name both accepted spellings whichever one was written, so building the expectation from the case's own `TagName` produced `<value> or <value>`
- the date input's value conflict names the component root whether the item sits directly inside it or inside its fieldset, because that's where the conflicting value lives

Those assertions now match. The parent contexts the tests arrange are also built from the tag names of the case being run, so a `<value>` sits inside a `<row>` rather than a `<govuk-summary-list-row>` that could never contain it.

The same reasoning applies to sibling elements, which a `[Theory]` with a single `[InlineData]` row pinned to the `govuk-` prefixed spelling. Only same-spelling siblings are legal within a summary list row, so those derive the sibling name from the case being run via a new `GetSiblingTagName` helper; either spelling is legal within a summary card, so the short one is exercised as its own row.

## Testing

`just unit-tests` passes on net8.0, net9.0 and net10.0 in both Debug and Release, with no duplicate ID messages: 1585 → 1669 passing (82 recovered, plus the 2 new summary card rows).

That the recovered cases genuinely exercise the short spellings was checked by temporarily replacing an assertion with a sentinel: the `[key in row]` case reports `<key> must be specified before <value>.` while the `govuk-` case reports the prefixed names.

No library changes, so nothing for the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
