### PR TITLE
Support all six plural categories in counter text

### DIFF
--- a/docs/localization.md
+++ b/docs/localization.md
@@ -72,12 +72,29 @@ otherwise you'll get a mix of languages.
 `PasswordInput.ShowPasswordText` and `PasswordInput.ShowPasswordAriaLabelText` are used for the
 server-rendered button *and* the `data-i18n` attributes, so they always change together.
 
-### Known limitation: plural forms
+### Plural forms
 
-The govuk-frontend JavaScript selects plural forms with `Intl.PluralRules`, which has up to six
-categories. Welsh uses all six; this library currently only models `one` and `other`, matching the
-shape of the underlying options. A Welsh service therefore can't fully localize the character count
-counter or the file upload's multiple-files text through this route yet.
+The character count's counter and the file upload's multiple-files text vary by plural category. The
+govuk-frontend JavaScript picks between them with `Intl.PluralRules`, so each of these has a resource
+name per CLDR category — `Zero`, `One`, `Two`, `Few`, `Many` and `Other`:
+
+| Name                                            | Used when                        |
+| ----------------------------------------------- | -------------------------------- |
+| `CharacterCount.CharactersUnderLimitText.Other` | the `other` category applies     |
+| `CharacterCount.CharactersUnderLimitText.Few`   | the `few` category applies       |
+| …and `.Zero`, `.One`, `.Two`, `.Many`           |                                  |
+
+English needs only `one` and `other`; Welsh uses all six.
+
+> [!IMPORTANT]
+> **Supply every category your language uses, including `other`.** A category you leave out does *not*
+> fall back to your `other` — it falls back to govuk-frontend's own **English** default, because the
+> JavaScript merges your attributes over its English ones. Leaving out `other` is worse still: the
+> JavaScript throws.
+
+Only the categories you supply are written to the page, matching what govuk-frontend's own template
+does. Which categories a language needs is set by
+[CLDR's plural rules](https://cldr.unicode.org/index/cldr-spec/plural-rules).
 
 ## Implementing `IGovUkFrontendLocalizer` directly
 

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/CharacterCountOptions.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/CharacterCountOptions.cs
@@ -42,27 +42,58 @@ public record CharacterCountCountOptionsMessage
 
 public record CharacterCountOptionsCharactersUnderLimitText
 {
-    public TemplateString? Other { get; set; }
-    public TemplateString? One { get; set; }
+    public string? Other { get; set; }
+    [NonStandardParameter]
+    public string? Zero { get; set; }
+    public string? One { get; set; }
+    [NonStandardParameter]
+    public string? Two { get; set; }
+    [NonStandardParameter]
+    public string? Few { get; set; }
+    [NonStandardParameter]
+    public string? Many { get; set; }
 }
 
 public record CharacterCountOptionsCharactersOverLimitText
 {
-    public TemplateString? Other { get; set; }
-    public TemplateString? One { get; set; }
-
+    public string? Other { get; set; }
+    [NonStandardParameter]
+    public string? Zero { get; set; }
+    public string? One { get; set; }
+    [NonStandardParameter]
+    public string? Two { get; set; }
+    [NonStandardParameter]
+    public string? Few { get; set; }
+    [NonStandardParameter]
+    public string? Many { get; set; }
 }
 
 public record CharacterCountOptionsWordsUnderLimitText
 {
-    public TemplateString? Other { get; set; }
-    public TemplateString? One { get; set; }
+    public string? Other { get; set; }
+    [NonStandardParameter]
+    public string? Zero { get; set; }
+    public string? One { get; set; }
+    [NonStandardParameter]
+    public string? Two { get; set; }
+    [NonStandardParameter]
+    public string? Few { get; set; }
+    [NonStandardParameter]
+    public string? Many { get; set; }
 }
 
 public record CharacterCountOptionsWordsOverLimitText
 {
-    public TemplateString? Other { get; set; }
-    public TemplateString? One { get; set; }
+    public string? Other { get; set; }
+    [NonStandardParameter]
+    public string? Zero { get; set; }
+    public string? One { get; set; }
+    [NonStandardParameter]
+    public string? Two { get; set; }
+    [NonStandardParameter]
+    public string? Few { get; set; }
+    [NonStandardParameter]
+    public string? Many { get; set; }
 }
 
 public record CharacterCountOptionsFormGroup : FormGroupOptions

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.CharacterCount.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.CharacterCount.cs
@@ -80,39 +80,47 @@ internal partial class DefaultComponentGenerator
             formGroupAttributes.Set("data-i18n.textarea-description.other", specifiedTextareaDescriptionText);
         }
 
-        AddI18nPluralAttributes(
-            formGroupAttributes,
-            "characters-under-limit",
-            options.CharactersUnderLimitText?.Other ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountCharactersUnderLimitTextOther),
-            options.CharactersUnderLimitText?.One ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountCharactersUnderLimitTextOne));
+        AddI18nPluralAttributes(formGroupAttributes, "characters-under-limit", new PluralTexts(
+            Other: options.CharactersUnderLimitText?.Other ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountCharactersUnderLimitTextOther),
+            Zero: options.CharactersUnderLimitText?.Zero ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountCharactersUnderLimitTextZero),
+            One: options.CharactersUnderLimitText?.One ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountCharactersUnderLimitTextOne),
+            Two: options.CharactersUnderLimitText?.Two ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountCharactersUnderLimitTextTwo),
+            Few: options.CharactersUnderLimitText?.Few ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountCharactersUnderLimitTextFew),
+            Many: options.CharactersUnderLimitText?.Many ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountCharactersUnderLimitTextMany)));
 
         AddI18nSingularAttribute(
             formGroupAttributes,
             "characters-at-limit",
             options.CharactersAtLimitText ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountCharactersAtLimitText));
 
-        AddI18nPluralAttributes(
-            formGroupAttributes,
-            "characters-over-limit",
-            options.CharactersOverLimitText?.Other ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountCharactersOverLimitTextOther),
-            options.CharactersOverLimitText?.One ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountCharactersOverLimitTextOne));
+        AddI18nPluralAttributes(formGroupAttributes, "characters-over-limit", new PluralTexts(
+            Other: options.CharactersOverLimitText?.Other ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountCharactersOverLimitTextOther),
+            Zero: options.CharactersOverLimitText?.Zero ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountCharactersOverLimitTextZero),
+            One: options.CharactersOverLimitText?.One ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountCharactersOverLimitTextOne),
+            Two: options.CharactersOverLimitText?.Two ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountCharactersOverLimitTextTwo),
+            Few: options.CharactersOverLimitText?.Few ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountCharactersOverLimitTextFew),
+            Many: options.CharactersOverLimitText?.Many ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountCharactersOverLimitTextMany)));
 
-        AddI18nPluralAttributes(
-            formGroupAttributes,
-            "words-under-limit",
-            options.WordsUnderLimitText?.Other ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountWordsUnderLimitTextOther),
-            options.WordsUnderLimitText?.One ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountWordsUnderLimitTextOne));
+        AddI18nPluralAttributes(formGroupAttributes, "words-under-limit", new PluralTexts(
+            Other: options.WordsUnderLimitText?.Other ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountWordsUnderLimitTextOther),
+            Zero: options.WordsUnderLimitText?.Zero ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountWordsUnderLimitTextZero),
+            One: options.WordsUnderLimitText?.One ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountWordsUnderLimitTextOne),
+            Two: options.WordsUnderLimitText?.Two ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountWordsUnderLimitTextTwo),
+            Few: options.WordsUnderLimitText?.Few ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountWordsUnderLimitTextFew),
+            Many: options.WordsUnderLimitText?.Many ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountWordsUnderLimitTextMany)));
 
         AddI18nSingularAttribute(
             formGroupAttributes,
             "words-at-limit",
             options.WordsAtLimitText ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountWordsAtLimitText));
 
-        AddI18nPluralAttributes(
-            formGroupAttributes,
-            "words-over-limit",
-            options.WordsOverLimitText?.Other ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountWordsOverLimitTextOther),
-            options.WordsOverLimitText?.One ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountWordsOverLimitTextOne));
+        AddI18nPluralAttributes(formGroupAttributes, "words-over-limit", new PluralTexts(
+            Other: options.WordsOverLimitText?.Other ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountWordsOverLimitTextOther),
+            Zero: options.WordsOverLimitText?.Zero ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountWordsOverLimitTextZero),
+            One: options.WordsOverLimitText?.One ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountWordsOverLimitTextOne),
+            Two: options.WordsOverLimitText?.Two ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountWordsOverLimitTextTwo),
+            Few: options.WordsOverLimitText?.Few ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountWordsOverLimitTextFew),
+            Many: options.WordsOverLimitText?.Many ?? LocalizedText(GovUkFrontendResourceNames.CharacterCountWordsOverLimitTextMany)));
 
         if (options.FormGroup?.Attributes is not null)
         {
@@ -165,16 +173,44 @@ internal partial class DefaultComponentGenerator
         return await GenerateTextareaAsync(textareaOptions);
     }
 
-    private static void AddI18nPluralAttributes(AttributeCollection attributes, string key, TemplateString? other, TemplateString? one)
-    {
-        if (other is not null && !other.IsEmpty())
-        {
-            attributes.Set($"data-i18n.{key}.other", other);
-        }
+    /// <summary>
+    /// The text for a message that varies by plural category, in the order govuk-frontend writes them.
+    /// </summary>
+    /// <remarks>
+    /// The categories are CLDR's, which is what <c>Intl.PluralRules</c> selects between in the browser.
+    /// </remarks>
+    private readonly record struct PluralTexts(
+        string? Other,
+        string? Zero,
+        string? One,
+        string? Two,
+        string? Few,
+        string? Many);
 
-        if (one is not null && !one.IsEmpty())
+    /// <summary>
+    /// Writes a <c>data-i18n</c> attribute for each plural category that has content.
+    /// </summary>
+    /// <remarks>
+    /// Categories without content are left out rather than filled in from <see cref="PluralTexts.Other"/>,
+    /// matching govuk-frontend, whose macro writes exactly the categories it is given. That means a
+    /// category a translation omits falls back to govuk-frontend's own English default in the browser,
+    /// not to the translation's <c>other</c>.
+    /// </remarks>
+    private static void AddI18nPluralAttributes(AttributeCollection attributes, string key, PluralTexts texts)
+    {
+        Add("other", texts.Other);
+        Add("zero", texts.Zero);
+        Add("one", texts.One);
+        Add("two", texts.Two);
+        Add("few", texts.Few);
+        Add("many", texts.Many);
+
+        void Add(string category, string? text)
         {
-            attributes.Set($"data-i18n.{key}.one", one);
+            if (!text.IsEmpty())
+            {
+                attributes.Set($"data-i18n.{key}.{category}", text);
+            }
         }
     }
 

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.FileUpload.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.FileUpload.cs
@@ -76,19 +76,13 @@ internal partial class DefaultComponentGenerator
                     .With("data-i18n.left-drop-zone", options.LeftDropZoneText ?? LocalizedText(GovUkFrontendResourceNames.FileUploadLeftDropZoneText))
                     .With(options.WrapperAttributes));
 
-                var multipleFilesChosenOne = options.MultipleFilesChosenText?.One ??
-                    LocalizedText(GovUkFrontendResourceNames.FileUploadMultipleFilesChosenTextOne);
-                var multipleFilesChosenOther = options.MultipleFilesChosenText?.Other ??
-                    LocalizedText(GovUkFrontendResourceNames.FileUploadMultipleFilesChosenTextOther);
-
-                if (!multipleFilesChosenOne.IsEmpty())
-                {
-                    wrapperDiv.Attributes.Set("data-i18n.multiple-files-chosen.one", multipleFilesChosenOne);
-                }
-                if (!multipleFilesChosenOther.IsEmpty())
-                {
-                    wrapperDiv.Attributes.Set("data-i18n.multiple-files-chosen.other", multipleFilesChosenOther);
-                }
+                AddI18nPluralAttributes(wrapperDiv.Attributes, "multiple-files-chosen", new PluralTexts(
+                    Other: options.MultipleFilesChosenText?.Other ?? LocalizedText(GovUkFrontendResourceNames.FileUploadMultipleFilesChosenTextOther),
+                    Zero: options.MultipleFilesChosenText?.Zero ?? LocalizedText(GovUkFrontendResourceNames.FileUploadMultipleFilesChosenTextZero),
+                    One: options.MultipleFilesChosenText?.One ?? LocalizedText(GovUkFrontendResourceNames.FileUploadMultipleFilesChosenTextOne),
+                    Two: options.MultipleFilesChosenText?.Two ?? LocalizedText(GovUkFrontendResourceNames.FileUploadMultipleFilesChosenTextTwo),
+                    Few: options.MultipleFilesChosenText?.Few ?? LocalizedText(GovUkFrontendResourceNames.FileUploadMultipleFilesChosenTextFew),
+                    Many: options.MultipleFilesChosenText?.Many ?? LocalizedText(GovUkFrontendResourceNames.FileUploadMultipleFilesChosenTextMany)));
 
                 var inputTag = CreateFileInputTag();
                 wrapperDiv.InnerHtml.AppendHtml(inputTag);

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/FileUploadOptions.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/FileUploadOptions.cs
@@ -54,6 +54,14 @@ public record FileUploadOptionsAfterInput
 
 public record FileUploadOptionsMultipleFilesChosenText
 {
-    public TemplateString? Other { get; set; }
-    public TemplateString? One { get; set; }
+    public string? Other { get; set; }
+    [NonStandardParameter]
+    public string? Zero { get; set; }
+    public string? One { get; set; }
+    [NonStandardParameter]
+    public string? Two { get; set; }
+    [NonStandardParameter]
+    public string? Few { get; set; }
+    [NonStandardParameter]
+    public string? Many { get; set; }
 }

--- a/src/GovUk.Frontend.AspNetCore/Localization/GovUkFrontendResourceNames.cs
+++ b/src/GovUk.Frontend.AspNetCore/Localization/GovUkFrontendResourceNames.cs
@@ -224,6 +224,30 @@ public static class GovUkFrontendResourceNames
     /// </summary>
     public const string CharacterCountCharactersUnderLimitTextOne = "CharacterCount.CharactersUnderLimitText.One";
 
+    /// <summary>
+    /// The character count's description of the remaining characters when the <c>zero</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string CharacterCountCharactersUnderLimitTextZero = "CharacterCount.CharactersUnderLimitText.Zero";
+
+    /// <summary>
+    /// The character count's description of the remaining characters when the <c>two</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string CharacterCountCharactersUnderLimitTextTwo = "CharacterCount.CharactersUnderLimitText.Two";
+
+    /// <summary>
+    /// The character count's description of the remaining characters when the <c>few</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string CharacterCountCharactersUnderLimitTextFew = "CharacterCount.CharactersUnderLimitText.Few";
+
+    /// <summary>
+    /// The character count's description of the remaining characters when the <c>many</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string CharacterCountCharactersUnderLimitTextMany = "CharacterCount.CharactersUnderLimitText.Many";
+
     /// <summary>The character count's description when the character limit is reached. There is no built-in default.</summary>
     public const string CharacterCountCharactersAtLimitText = "CharacterCount.CharactersAtLimitText";
 
@@ -240,6 +264,30 @@ public static class GovUkFrontendResourceNames
     public const string CharacterCountCharactersOverLimitTextOne = "CharacterCount.CharactersOverLimitText.One";
 
     /// <summary>
+    /// The character count's description of the excess characters when the <c>zero</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string CharacterCountCharactersOverLimitTextZero = "CharacterCount.CharactersOverLimitText.Zero";
+
+    /// <summary>
+    /// The character count's description of the excess characters when the <c>two</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string CharacterCountCharactersOverLimitTextTwo = "CharacterCount.CharactersOverLimitText.Two";
+
+    /// <summary>
+    /// The character count's description of the excess characters when the <c>few</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string CharacterCountCharactersOverLimitTextFew = "CharacterCount.CharactersOverLimitText.Few";
+
+    /// <summary>
+    /// The character count's description of the excess characters when the <c>many</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string CharacterCountCharactersOverLimitTextMany = "CharacterCount.CharactersOverLimitText.Many";
+
+    /// <summary>
     /// The character count's description of the remaining words when more than one remains.
     /// Use the <c>%{count}</c> placeholder. There is no built-in default.
     /// </summary>
@@ -250,6 +298,30 @@ public static class GovUkFrontendResourceNames
     /// There is no built-in default.
     /// </summary>
     public const string CharacterCountWordsUnderLimitTextOne = "CharacterCount.WordsUnderLimitText.One";
+
+    /// <summary>
+    /// The character count's description of the remaining words when the <c>zero</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string CharacterCountWordsUnderLimitTextZero = "CharacterCount.WordsUnderLimitText.Zero";
+
+    /// <summary>
+    /// The character count's description of the remaining words when the <c>two</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string CharacterCountWordsUnderLimitTextTwo = "CharacterCount.WordsUnderLimitText.Two";
+
+    /// <summary>
+    /// The character count's description of the remaining words when the <c>few</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string CharacterCountWordsUnderLimitTextFew = "CharacterCount.WordsUnderLimitText.Few";
+
+    /// <summary>
+    /// The character count's description of the remaining words when the <c>many</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string CharacterCountWordsUnderLimitTextMany = "CharacterCount.WordsUnderLimitText.Many";
 
     /// <summary>The character count's description when the word limit is reached. There is no built-in default.</summary>
     public const string CharacterCountWordsAtLimitText = "CharacterCount.WordsAtLimitText";
@@ -265,6 +337,30 @@ public static class GovUkFrontendResourceNames
     /// There is no built-in default.
     /// </summary>
     public const string CharacterCountWordsOverLimitTextOne = "CharacterCount.WordsOverLimitText.One";
+
+    /// <summary>
+    /// The character count's description of the excess words when the <c>zero</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string CharacterCountWordsOverLimitTextZero = "CharacterCount.WordsOverLimitText.Zero";
+
+    /// <summary>
+    /// The character count's description of the excess words when the <c>two</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string CharacterCountWordsOverLimitTextTwo = "CharacterCount.WordsOverLimitText.Two";
+
+    /// <summary>
+    /// The character count's description of the excess words when the <c>few</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string CharacterCountWordsOverLimitTextFew = "CharacterCount.WordsOverLimitText.Few";
+
+    /// <summary>
+    /// The character count's description of the excess words when the <c>many</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string CharacterCountWordsOverLimitTextMany = "CharacterCount.WordsOverLimitText.Many";
 
     // Client-side content: exit this page
 
@@ -307,6 +403,30 @@ public static class GovUkFrontendResourceNames
     /// The file upload's description of the chosen files when one is chosen. There is no built-in default.
     /// </summary>
     public const string FileUploadMultipleFilesChosenTextOne = "FileUpload.MultipleFilesChosenText.One";
+
+    /// <summary>
+    /// The file upload's description of the chosen files when the <c>zero</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string FileUploadMultipleFilesChosenTextZero = "FileUpload.MultipleFilesChosenText.Zero";
+
+    /// <summary>
+    /// The file upload's description of the chosen files when the <c>two</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string FileUploadMultipleFilesChosenTextTwo = "FileUpload.MultipleFilesChosenText.Two";
+
+    /// <summary>
+    /// The file upload's description of the chosen files when the <c>few</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string FileUploadMultipleFilesChosenTextFew = "FileUpload.MultipleFilesChosenText.Few";
+
+    /// <summary>
+    /// The file upload's description of the chosen files when the <c>many</c> plural category applies.
+    /// Use the <c>%{count}</c> placeholder. There is no built-in default.
+    /// </summary>
+    public const string FileUploadMultipleFilesChosenTextMany = "FileUpload.MultipleFilesChosenText.Many";
 
     // Client-side content: password input
 

--- a/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/DefaultComponentGeneratorTests.NonStandardParameters.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/DefaultComponentGeneratorTests.NonStandardParameters.cs
@@ -1063,4 +1063,96 @@ public partial class DefaultComponentGeneratorTests
         // Assert
         Assert.Contains("data-test=\"item-attr\"", html);
     }
+
+    [Fact]
+    public async Task CharacterCount_PluralTexts_AllCategoriesAreIncludedInOutput()
+    {
+        // Arrange
+        var options = new CharacterCountOptions
+        {
+            Name = "my-name",
+            MaxLength = 10,
+            CharactersUnderLimitText = new CharacterCountOptionsCharactersUnderLimitText
+            {
+                Other = "other-text",
+                Zero = "zero-text",
+                One = "one-text",
+                Two = "two-text",
+                Few = "few-text",
+                Many = "many-text"
+            }
+        };
+
+        // Act
+        var result = await _componentGenerator.GenerateCharacterCountAsync(options);
+        var html = result.GetHtml();
+
+        // Assert
+        foreach (var category in new[] { "other", "zero", "one", "two", "few", "many" })
+        {
+            Assert.Contains($"data-i18n.characters-under-limit.{category}=\"{category}-text\"", html, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public async Task CharacterCount_PluralTexts_CategoriesWithoutContentAreOmitted()
+    {
+        // govuk-frontend's macro writes exactly the categories it is given, and the conformance
+        // fixtures assert that. Filling the gaps in from Other here would diverge from it.
+
+        // Arrange
+        var options = new CharacterCountOptions
+        {
+            Name = "my-name",
+            MaxLength = 10,
+            CharactersUnderLimitText = new CharacterCountOptionsCharactersUnderLimitText
+            {
+                Other = "other-text",
+                Few = "few-text"
+            }
+        };
+
+        // Act
+        var result = await _componentGenerator.GenerateCharacterCountAsync(options);
+        var html = result.GetHtml();
+
+        // Assert
+        Assert.Contains("data-i18n.characters-under-limit.other=\"other-text\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-i18n.characters-under-limit.few=\"few-text\"", html, StringComparison.Ordinal);
+
+        foreach (var category in new[] { "zero", "one", "two", "many" })
+        {
+            Assert.DoesNotContain($"data-i18n.characters-under-limit.{category}", html, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public async Task FileUpload_MultipleFilesChosenText_AllCategoriesAreIncludedInOutput()
+    {
+        // Arrange
+        var options = new FileUploadOptions
+        {
+            Name = "my-name",
+            JavaScript = true,
+            MultipleFilesChosenText = new FileUploadOptionsMultipleFilesChosenText
+            {
+                Other = "other-text",
+                Zero = "zero-text",
+                One = "one-text",
+                Two = "two-text",
+                Few = "few-text",
+                Many = "many-text"
+            }
+        };
+
+        // Act
+        var result = await _componentGenerator.GenerateFileUploadAsync(options);
+        var html = result.GetHtml();
+
+        // Assert
+        foreach (var category in new[] { "other", "zero", "one", "two", "few", "many" })
+        {
+            Assert.Contains($"data-i18n.multiple-files-chosen.{category}=\"{category}-text\"", html, StringComparison.Ordinal);
+        }
+    }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/Localization/ComponentLocalizationTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/Localization/ComponentLocalizationTests.cs
@@ -138,6 +138,18 @@ public class ComponentLocalizationTests
         [GovUkFrontendResourceNames.CharacterCountCharactersUnderLimitTextOne] =
             g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxLength = 10 }),
 
+        [GovUkFrontendResourceNames.CharacterCountCharactersUnderLimitTextZero] =
+            g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxLength = 10 }),
+
+        [GovUkFrontendResourceNames.CharacterCountCharactersUnderLimitTextTwo] =
+            g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxLength = 10 }),
+
+        [GovUkFrontendResourceNames.CharacterCountCharactersUnderLimitTextFew] =
+            g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxLength = 10 }),
+
+        [GovUkFrontendResourceNames.CharacterCountCharactersUnderLimitTextMany] =
+            g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxLength = 10 }),
+
         [GovUkFrontendResourceNames.CharacterCountCharactersAtLimitText] =
             g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxLength = 10 }),
 
@@ -147,10 +159,34 @@ public class ComponentLocalizationTests
         [GovUkFrontendResourceNames.CharacterCountCharactersOverLimitTextOne] =
             g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxLength = 10 }),
 
+        [GovUkFrontendResourceNames.CharacterCountCharactersOverLimitTextZero] =
+            g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxLength = 10 }),
+
+        [GovUkFrontendResourceNames.CharacterCountCharactersOverLimitTextTwo] =
+            g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxLength = 10 }),
+
+        [GovUkFrontendResourceNames.CharacterCountCharactersOverLimitTextFew] =
+            g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxLength = 10 }),
+
+        [GovUkFrontendResourceNames.CharacterCountCharactersOverLimitTextMany] =
+            g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxLength = 10 }),
+
         [GovUkFrontendResourceNames.CharacterCountWordsUnderLimitTextOther] =
             g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxWords = 10 }),
 
         [GovUkFrontendResourceNames.CharacterCountWordsUnderLimitTextOne] =
+            g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxWords = 10 }),
+
+        [GovUkFrontendResourceNames.CharacterCountWordsUnderLimitTextZero] =
+            g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxWords = 10 }),
+
+        [GovUkFrontendResourceNames.CharacterCountWordsUnderLimitTextTwo] =
+            g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxWords = 10 }),
+
+        [GovUkFrontendResourceNames.CharacterCountWordsUnderLimitTextFew] =
+            g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxWords = 10 }),
+
+        [GovUkFrontendResourceNames.CharacterCountWordsUnderLimitTextMany] =
             g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxWords = 10 }),
 
         [GovUkFrontendResourceNames.CharacterCountWordsAtLimitText] =
@@ -160,6 +196,18 @@ public class ComponentLocalizationTests
             g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxWords = 10 }),
 
         [GovUkFrontendResourceNames.CharacterCountWordsOverLimitTextOne] =
+            g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxWords = 10 }),
+
+        [GovUkFrontendResourceNames.CharacterCountWordsOverLimitTextZero] =
+            g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxWords = 10 }),
+
+        [GovUkFrontendResourceNames.CharacterCountWordsOverLimitTextTwo] =
+            g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxWords = 10 }),
+
+        [GovUkFrontendResourceNames.CharacterCountWordsOverLimitTextFew] =
+            g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxWords = 10 }),
+
+        [GovUkFrontendResourceNames.CharacterCountWordsOverLimitTextMany] =
             g => g.GenerateCharacterCountAsync(new CharacterCountOptions { Name = "c", MaxWords = 10 }),
 
         [GovUkFrontendResourceNames.ExitThisPageActivatedText] =
@@ -193,6 +241,18 @@ public class ComponentLocalizationTests
             g => g.GenerateFileUploadAsync(new FileUploadOptions { Name = "f", JavaScript = true }),
 
         [GovUkFrontendResourceNames.FileUploadMultipleFilesChosenTextOne] =
+            g => g.GenerateFileUploadAsync(new FileUploadOptions { Name = "f", JavaScript = true }),
+
+        [GovUkFrontendResourceNames.FileUploadMultipleFilesChosenTextZero] =
+            g => g.GenerateFileUploadAsync(new FileUploadOptions { Name = "f", JavaScript = true }),
+
+        [GovUkFrontendResourceNames.FileUploadMultipleFilesChosenTextTwo] =
+            g => g.GenerateFileUploadAsync(new FileUploadOptions { Name = "f", JavaScript = true }),
+
+        [GovUkFrontendResourceNames.FileUploadMultipleFilesChosenTextFew] =
+            g => g.GenerateFileUploadAsync(new FileUploadOptions { Name = "f", JavaScript = true }),
+
+        [GovUkFrontendResourceNames.FileUploadMultipleFilesChosenTextMany] =
             g => g.GenerateFileUploadAsync(new FileUploadOptions { Name = "f", JavaScript = true })
     };
 


### PR DESCRIPTION
Removes the "Known limitation: plural forms" that #499 shipped with.

The character count's counter and the file upload's multiple-files text vary by plural category, and govuk-frontend's JavaScript picks between them with `Intl.PluralRules`. The five options records modelling them only had `One` and `Other`, so a Welsh service — which uses all six CLDR categories — couldn't fully translate either.

## The change

Each of the five records gains `Zero`, `Two`, `Few` and `Many`, marked `[NonStandardParameter]`: upstream types these parameters as an untyped `object` and only ever documents `one` and `other`, so the extra categories aren't part of its published shape.

The properties are also retyped from `TemplateString?` to `string?`, matching the singular siblings on the same records (`TextareaDescriptionText`, `CharactersAtLimitText`, `ChooseFilesButtonText`, …). #502's retype keyed off the `Text` suffix and these are named `One`/`Other`, so it missed them.

Twenty new resource names follow the existing `{Component}.{Parameter}.{Variant}` convention — `CharacterCount.CharactersUnderLimitText.Few` and so on. Adding names is non-breaking for existing `IGovUkFrontendLocalizer` implementations, since `GetString` is documented as safe to return `null` from for a name it doesn't know.

## Two findings worth calling out

**The JavaScript needed no change at all.** `extractConfigByNamespace` splits every `data-*` key on `.` into a nested object, the component schema only declares `i18n: { type: 'object' }`, and `getPluralSuffix` does `preferredForm in translation` — a plain lookup against whatever `Intl.PluralRules(locale).select(count)` returns. `data-i18n.characters-under-limit.few` already worked end to end. The limitation was entirely on the C# side.

**Categories without content are deliberately not filled in from `Other`.** `macros/i18n.njk` is `{% for pluralRule, message in params.messages %}` — a blind loop with no notion of `one`/`other` — and the conformance fixtures assert the exact attribute set: `character-count`'s "with translations" expects `.other` and `.one` and nothing else. Auto-filling would emit six attributes where upstream emits two and break conformance.

That has a consequence worth knowing, now documented: `mergeConfigs` deep-merges the supplied attributes over govuk-frontend's **English** defaults, so a category a translation omits falls back to English rather than to the translation's own `other`. Omitting `other` is worse — `getPluralSuffix` throws. The docs now say to supply every category your language uses.

## Also

Emission moves onto a private `PluralTexts` transport so the six categories are written in one place, and file upload's hand-rolled block joins it — that block duplicated the logic and emitted `.one` before `.other`, the opposite order to everything else.

Tag helper surface is unchanged: `FileUploadTagHelper` keeps its existing `multiple-files-chosen-text-one`/`-other` attributes and nothing is added. Six attributes per key would be 30 new attributes across the two components for a job the localizer already does.

## Tests

- **Conformance is the primary guard** and passes untouched — if the generator emitted a category upstream doesn't, `character-count`'s "with translations" and `file-upload`'s "translated" fixtures would fail.
- `EveryResourceName_IsCoveredByATest` forced a `Renderers` entry for each of the 20 new names, and `LocalizedContent_ReachesTheRenderedOutput` then proves each one actually reaches the HTML — that pairing is what stops a category being declared but never emitted.
- Three new tests: a full six-category set emits all six attributes for both components, and a partial set emits **only** what was supplied — pinning the no-auto-fill decision so a later change can't quietly break conformance.

`dotnet test` is green on net8.0, net9.0 and net10.0 — 1672 unit and 84 integration tests each — with a clean Release build and `dotnet format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)