### PR TITLE
Use TemplateString for tag helper inner content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased — 5.0.0
 
+`TabsOptions.Title` is now `string?` rather than `TemplateString?`. It only ever comes from the `title` attribute, so it is always text.
+
+`SelectOptionsItem.Text` is `TemplateString?` again and its `Html` property is gone. Content written inside `<govuk-select-item>` is markup, and `TemplateString` already carries either kind, so the extra property added nothing.
+
 `Text` and `Html` options are now typed for what they hold: `Text` is a `string` and is always HTML-encoded, `Html` is an `IHtmlContent` and is always emitted as-is.
 
 Both used to be `TemplateString`, which carries either text or markup and decides which by how it was constructed. That made it possible — and, in practice, easy — to put text in an `Html` slot, and the compiler had nothing to say about it. That is how validation messages came to be rendered as markup. Now `Html = someString` doesn't compile.

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.Select.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.Select.cs
@@ -106,7 +106,7 @@ internal partial class DefaultComponentGenerator
                         }
                         else if (!options.Value.IsEmpty())
                         {
-                            var compareWith = item.Value ?? new TemplateString(item.Text);
+                            var compareWith = item.Value ?? item.Text;
                             if (compareWith is not null && !compareWith.IsEmpty() && options.Value == compareWith)
                             {
                                 selected = true;
@@ -128,9 +128,9 @@ internal partial class DefaultComponentGenerator
                         option.Attributes.AddBoolean("selected");
                     }
 
-                    if (!item.Html.IsEmpty() || !item.Text.IsEmpty())
+                    if (!item.Text.IsEmpty())
                     {
-                        option.InnerHtml.AppendHtml(HtmlOrText(item.Html, item.Text));
+                        option.InnerHtml.AppendHtml(item.Text);
                     }
 
                     select.InnerHtml.AppendHtml(option);

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.Tabs.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/DefaultComponentGenerator.Tabs.cs
@@ -17,7 +17,7 @@ internal partial class DefaultComponentGenerator
         var titleTag = new HtmlTag("h2", attrs => attrs
             .WithClasses("govuk-tabs__title"));
         titleTag.InnerHtml.AppendHtml(
-            HtmlOrText(options.Title, null, fallback: LocalizedText(GovUkFrontendResourceNames.TabsTitle) ?? "Contents"));
+            HtmlOrText(html: null, options.Title, fallback: LocalizedText(GovUkFrontendResourceNames.TabsTitle) ?? "Contents"));
         tabsTag.InnerHtml.AppendHtml(titleTag);
 
         if (options.Items is not null && options.Items.Count > 0)

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/SelectOptions.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/SelectOptions.cs
@@ -41,9 +41,7 @@ public record SelectOptionsAfterInput
 public record SelectOptionsItem
 {
     public TemplateString? Value { get; set; }
-    public string? Text { get; set; }
-    [NonStandardParameter]
-    public IHtmlContent? Html { get; set; }
+    public TemplateString? Text { get; set; }
     public bool? Selected { get; set; }
     public bool? Disabled { get; set; }
     public AttributeCollection? Attributes { get; set; }

--- a/src/GovUk.Frontend.AspNetCore/ComponentGeneration/TabsOptions.cs
+++ b/src/GovUk.Frontend.AspNetCore/ComponentGeneration/TabsOptions.cs
@@ -7,7 +7,7 @@ public record TabsOptions
 {
     public TemplateString? Id { get; set; }
     public TemplateString? IdPrefix { get; set; }
-    public TemplateString? Title { get; set; }
+    public string? Title { get; set; }
     public IReadOnlyCollection<TabsOptionsItem?>? Items { get; set; }
     public TemplateString? Classes { get; set; }
     public AttributeCollection? Attributes { get; set; }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/SelectItemTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/SelectItemTagHelper.cs
@@ -86,7 +86,7 @@ public class SelectItemTagHelper : TagHelper
         selectContext.AddItem(new SelectOptionsItem
         {
             Attributes = new AttributeCollection(output.Attributes),
-            Html = content,
+            Text = new TemplateString(content),
             Disabled = Disabled,
             Selected = selected,
             Value = Value

--- a/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/DefaultComponentGeneratorTests.NonStandardParameters.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/ComponentGeneration/DefaultComponentGeneratorTests.NonStandardParameters.cs
@@ -1155,4 +1155,19 @@ public partial class DefaultComponentGeneratorTests
             Assert.Contains($"data-i18n.multiple-files-chosen.{category}=\"{category}-text\"", html, StringComparison.Ordinal);
         }
     }
+
+    [Fact]
+    public async Task Tabs_Title_IsEncoded()
+    {
+        // Tabs' title only ever comes from a string attribute, so it has no Html sibling.
+
+        // Arrange
+        var options = new TabsOptions { Title = "Contents & more" };
+
+        // Act
+        var html = (await _componentGenerator.GenerateTabsAsync(options)).GetHtml();
+
+        // Assert
+        Assert.Contains("Contents &amp; more", html, StringComparison.Ordinal);
+    }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SelectItemTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SelectItemTagHelperTests.cs
@@ -40,7 +40,7 @@ public class SelectItemTagHelperTests : TagHelperTestBase<SelectItemTagHelper>
             selectContext.Items,
             item =>
             {
-                Assert.Equal("Item text", item.Html?.ToHtmlString());
+                Assert.Equal("Item text", item.Text?.ToHtmlString());
                 Assert.True(item.Disabled);
                 Assert.True(item.Selected);
                 Assert.Equal("value", item.Value);


### PR DESCRIPTION
A tag helper's inner content is markup, so any options property fed from it has to be able to hold markup. `TemplateString` already carries either kind — so that's all such a property needs to be. Adding a separate `[NonStandardParameter]` `Html` sibling alongside a text one buys nothing and doubles the surface.

#502 added `SelectOptionsItem.Html` for exactly this and made `SelectOptionsItem.Text` a `string`. This reverts that: `Text` is a `TemplateString?` again and `SelectItemTagHelper` writes the inner content straight into it. `Divider` on radios and checkboxes, and `Number` on pagination, keep their existing `TemplateString?` for the same reason.

## On the Nunjucks templates

Upstream renders `divider`, `number` and the select item's text with `{{ }}`, which Nunjucks autoescapes — so those parameters are text-only upstream. That isn't the deciding factor here: letting a consumer write markup inside `<govuk-select-item>` or `<govuk-radios-item-divider>` is better than matching upstream's narrower parameter, and `TemplateString` expresses it without extra properties.

## What does change

`TabsOptions.Title` becomes `string?`. It's set from the `title` attribute, which binds to a `string?` tag helper property, so inner content never reaches it and markup can't get in.

## Result

Rendered output is unchanged, and the conformance fixtures pass untouched. The net effect versus `main` is one property narrowed to `string?`, one property widened back to `TemplateString?`, and one now-unnecessary property removed.

`dotnet test` is green on net8.0, net9.0 and net10.0 — 1670 unit and 84 integration tests each — with a clean Release build and `dotnet format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)