### PR TITLE
Add automated tests for the package's MSBuild targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,26 @@ jobs:
           name: GovUk.Frontend.AspNetCore.nupkg
           path: packages/*.nupkg
 
+  package_tests:
+    name: "Package tests"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # required for minver to create the right version number
+          filter: tree:0
+
+      - uses: ./.github/workflows/actions/setup-tools
+
+      - name: Restore
+        run: just restore
+
+      # These pack the library and build throwaway projects against the package, so they only need
+      # running once; nothing in the targets varies by configuration.
+      - name: Test
+        run: just package-tests --configuration Release
+
   build_samples:
     name: "Build samples"
     runs-on: ubuntu-latest
@@ -183,7 +203,7 @@ jobs:
   release:
     name: "Publish package to NuGet"
     runs-on: ubuntu-latest
-    needs: [format, build_release, build_samples, docs]
+    needs: [format, build_release, build_samples, package_tests, docs]
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       id-token: write

--- a/GovUk.Frontend.AspNetCore.sln
+++ b/GovUk.Frontend.AspNetCore.sln
@@ -24,6 +24,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{884EFCBA-B4C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Frontend.AspNetCore.Docs", "src\GovUk.Frontend.AspNetCore.Docs\GovUk.Frontend.AspNetCore.Docs.csproj", "{D89C39A5-1919-459A-B868-65507B02CEE7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Frontend.AspNetCore.PackageTests", "tests\GovUk.Frontend.AspNetCore.PackageTests\GovUk.Frontend.AspNetCore.PackageTests.csproj", "{5AA085E7-2B4B-4504-9130-04A11F9D4DCA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -94,6 +96,18 @@ Global
 		{D89C39A5-1919-459A-B868-65507B02CEE7}.Release|x64.Build.0 = Release|Any CPU
 		{D89C39A5-1919-459A-B868-65507B02CEE7}.Release|x86.ActiveCfg = Release|Any CPU
 		{D89C39A5-1919-459A-B868-65507B02CEE7}.Release|x86.Build.0 = Release|Any CPU
+		{5AA085E7-2B4B-4504-9130-04A11F9D4DCA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5AA085E7-2B4B-4504-9130-04A11F9D4DCA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5AA085E7-2B4B-4504-9130-04A11F9D4DCA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5AA085E7-2B4B-4504-9130-04A11F9D4DCA}.Debug|x64.Build.0 = Debug|Any CPU
+		{5AA085E7-2B4B-4504-9130-04A11F9D4DCA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5AA085E7-2B4B-4504-9130-04A11F9D4DCA}.Debug|x86.Build.0 = Debug|Any CPU
+		{5AA085E7-2B4B-4504-9130-04A11F9D4DCA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5AA085E7-2B4B-4504-9130-04A11F9D4DCA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5AA085E7-2B4B-4504-9130-04A11F9D4DCA}.Release|x64.ActiveCfg = Release|Any CPU
+		{5AA085E7-2B4B-4504-9130-04A11F9D4DCA}.Release|x64.Build.0 = Release|Any CPU
+		{5AA085E7-2B4B-4504-9130-04A11F9D4DCA}.Release|x86.ActiveCfg = Release|Any CPU
+		{5AA085E7-2B4B-4504-9130-04A11F9D4DCA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -104,6 +118,7 @@ Global
 		{C1A97F71-B436-4681-A611-D38C7B357897} = {F85128C9-8470-4F7A-B16F-5AEC17BC0924}
 		{AECA829F-DC59-4CA2-88C2-54218D4BD817} = {F85128C9-8470-4F7A-B16F-5AEC17BC0924}
 		{D89C39A5-1919-459A-B868-65507B02CEE7} = {884EFCBA-B4CC-4B02-9909-5AB345A6D9F2}
+		{5AA085E7-2B4B-4504-9130-04A11F9D4DCA} = {F85128C9-8470-4F7A-B16F-5AEC17BC0924}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {56670F00-D357-4E76-A289-2114015DDFE5}

--- a/justfile
+++ b/justfile
@@ -29,7 +29,7 @@ _clear-samples-package-cache:
   @pwsh -f Remove-CachedPackages.ps1
 
 # Run the tests
-test *ARGS: (unit-tests ARGS) (integration-tests ARGS)
+test *ARGS: (unit-tests ARGS) (integration-tests ARGS) (package-tests ARGS)
 
 # Run the unit tests
 unit-tests *ARGS:
@@ -38,6 +38,10 @@ unit-tests *ARGS:
 # Run the integration tests
 integration-tests *ARGS:
   @dotnet test tests/GovUk.Frontend.AspNetCore.IntegrationTests/ {{ARGS}}
+
+# Run the package tests; these pack the library and build throwaway projects against it
+package-tests *ARGS:
+  @dotnet test tests/GovUk.Frontend.AspNetCore.PackageTests/ {{ARGS}}
 
 # Format the C# code
 format *ARGS:

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/AssemblyInfo.cs
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using GovUk.Frontend.AspNetCore.PackageTests.Infrastructure;
+
+// One sandbox and one packed package for the whole run.
+[assembly: AssemblyFixture(typeof(PackageTestContext))]

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/Fixtures/ClassLib/Placeholder.cs
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/Fixtures/ClassLib/Placeholder.cs
@@ -1,0 +1,6 @@
+namespace PackageTestFixture;
+
+public static class Placeholder
+{
+    public static string Value => nameof(Value);
+}

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/Fixtures/WebApp/Pages/Index.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/Fixtures/WebApp/Pages/Index.cshtml
@@ -1,0 +1,18 @@
+@page
+@using Microsoft.AspNetCore.Http
+@using static GovUk.Frontend.AspNetCore.Views.GovUkPageTemplateConstants
+@{
+    // The library's own page template, so the URLs under test are the ones a real consumer's pages
+    // would emit: the stylesheet, the script imports and the head icons that live under the assets
+    // directory.
+    Layout = "_GovUkPageTemplate";
+    ViewData[ViewDataKeys.Title] = "Package test app";
+
+    // Lets a test point the head icons at a non-default assets directory.
+    if (Request.Query["assetPath"] is [{ } assetPath, ..])
+    {
+        ViewData[ViewDataKeys.AssetPath] = new PathString(assetPath);
+    }
+}
+
+<p class="govuk-body">Package test app</p>

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/Fixtures/WebApp/Pages/_ViewImports.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/Fixtures/WebApp/Pages/_ViewImports.cshtml
@@ -1,0 +1,4 @@
+@using GovUk.Frontend.AspNetCore
+@namespace PackageTestFixture.Pages
+@addTagHelper *, GovUk.Frontend.AspNetCore
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/Fixtures/WebApp/Program.cs
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/Fixtures/WebApp/Program.cs
@@ -1,0 +1,22 @@
+using GovUk.Frontend.AspNetCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddGovUkFrontend();
+builder.Services.AddRazorPages();
+
+var app = builder.Build();
+
+app.UseGovUkFrontend();
+
+#if NET9_0_OR_GREATER
+// MapStaticAssets only serves files that made it into the static web assets manifest, so this is
+// also how the tests check that the restored files were added to @(Content) early enough.
+app.MapStaticAssets();
+app.MapRazorPages().WithStaticAssets();
+#else
+app.UseStaticFiles();
+app.MapRazorPages();
+#endif
+
+app.Run();

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/GovUk.Frontend.AspNetCore.PackageTests.csproj
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/GovUk.Frontend.AspNetCore.PackageTests.csproj
@@ -1,0 +1,54 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- These tests drive the SDK as a child process, so the host only needs one TFM; the frameworks
+         under test are a property of the generated fixture projects. -->
+    <TargetFramework>net10.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>xUnit1051</NoWarn>
+
+    <PackageTestFeed>$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', 'obj', 'test-feed'))</PackageTestFeed>
+    <PackageTestPackages>$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', 'obj', 'test-packages'))</PackageTestPackages>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="1.5.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.1.0" />
+  </ItemGroup>
+
+  <!-- Deliberately no ProjectReference to the library: these tests must only ever see it through the
+       package, since the packed layout is half of what's under test. -->
+
+  <!-- The fixture sources are copied into generated projects at test time; they're data here, not part
+       of this assembly. -->
+  <ItemGroup>
+    <Compile Remove="Fixtures\**" />
+    <None Remove="Fixtures\**" />
+    <Content Include="Fixtures\**" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <!-- The tests build throwaway projects against a real nupkg, so one has to exist before they run.
+       MinVer gives every local pack a distinct version, hence the wipe. -->
+  <Target Name="PackLibraryUnderTest" BeforeTargets="Build" Condition="'$(SkipPackLibraryUnderTest)' != 'true'">
+    <!-- The extracted copy goes too, so a repeated version number can't leave a stale package behind for
+         the fixture projects to restore. -->
+    <RemoveDir Directories="$(PackageTestFeed);$(PackageTestPackages)govuk.frontend.aspnetcore" />
+
+    <MSBuild Projects="$(RepoRoot)src\GovUk.Frontend.AspNetCore\GovUk.Frontend.AspNetCore.csproj"
+             Targets="Pack"
+             Properties="Configuration=$(Configuration);PackageOutputPath=$(PackageTestFeed)" />
+  </Target>
+
+  <ItemGroup>
+    <AssemblyMetadata Include="PackageTestFeed" Value="$(PackageTestFeed)" />
+    <AssemblyMetadata Include="RepoRoot" Value="$(RepoRoot)" />
+  </ItemGroup>
+
+</Project>

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/HostingTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/HostingTests.cs
@@ -1,0 +1,253 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using GovUk.Frontend.AspNetCore.PackageTests.Infrastructure;
+
+namespace GovUk.Frontend.AspNetCore.PackageTests;
+
+/// <summary>
+/// Whether the files the targets restored are actually served, at the URLs the library tells you to use
+/// and with the caching the versioned asset middleware promises.
+/// </summary>
+public partial class HostingTests(DefaultConfigurationAppFixture fixture, PackageTestContext context) :
+    IClassFixture<DefaultConfigurationAppFixture>
+{
+    public static TheoryData<string> TargetFrameworks => [.. FixtureProject.AllTargetFrameworks];
+
+    /// <summary>
+    /// The strongest form of the assertion: rather than hard-coding paths, ask the page template which
+    /// URLs it emits and check those are the ones that work.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(TargetFrameworks))]
+    public async Task ThePageTemplateAdvertisesUrlsThatAreServed(string targetFramework)
+    {
+        await using var app = await fixture.StartAsync(targetFramework);
+
+        var page = await HostedPage.GetAsync(app);
+
+        await AssertServedAsync(app, page.Stylesheet, "text/css");
+        await AssertServedAsync(app, page.Script, "text/javascript");
+
+        // These live under the assets directory, so they cover the recursive copy as well.
+        await AssertServedAsync(app, page.FavIcon, expectedContentType: null);
+        await AssertServedAsync(app, page.Manifest, expectedContentType: null);
+    }
+
+    /// <summary>
+    /// On .NET 9 and later the page template resolves its URLs through the static asset collection that
+    /// <c>MapStaticAssets</c> builds from the static web assets manifest, so this is also what proves the
+    /// restored files were added to <c>@(Content)</c> early enough to be in that manifest.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(TargetFrameworks))]
+    public async Task ThePageTemplateUsesFingerprintedUrlsOnlyWhereTheFrameworkSupportsThem(string targetFramework)
+    {
+        await using var app = await fixture.StartAsync(targetFramework);
+
+        var page = await HostedPage.GetAsync(app);
+
+        if (targetFramework == "net8.0")
+        {
+            Assert.Equal($"/govuk-frontend.min.css?v={context.GovUkFrontendVersion}", page.Stylesheet);
+        }
+        else
+        {
+            Assert.Matches(@"^/govuk-frontend\.min\.[a-z0-9]+\.css$", page.Stylesheet);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(TargetFrameworks))]
+    public async Task RequestForARestoredFileWithTheCurrentVersion_IsCacheableForever(string targetFramework)
+    {
+        await using var app = await fixture.StartAsync(targetFramework);
+
+        foreach (var path in RestoredFilePaths())
+        {
+            using var response = await app.Client.GetAsync(Versioned(path, context.GovUkFrontendVersion));
+
+            AssertCacheableForever(response, path);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(TargetFrameworks))]
+    public async Task RequestForARestoredFileWithAnotherVersion_IsNotCacheableForever(string targetFramework)
+    {
+        await using var app = await fixture.StartAsync(targetFramework);
+
+        foreach (var path in RestoredFilePaths())
+        {
+            using var withWrongVersion = await app.Client.GetAsync(Versioned(path, "0.0.0"));
+            AssertNotCacheableForever(withWrongVersion, path);
+
+            using var withNoVersion = await app.Client.GetAsync(path);
+            AssertNotCacheableForever(withNoVersion, path);
+        }
+    }
+
+    /// <summary>
+    /// The middleware keys off the directories in the build info, so a versioned request for something it
+    /// didn't restore must be left alone.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(TargetFrameworks))]
+    public async Task RequestForAnUnrelatedFileWithTheCurrentVersion_IsNotCacheableForever(string targetFramework)
+    {
+        await using var app = await fixture.StartAsync(targetFramework);
+
+        var path = "/" + HostedAppFixture.UnrelatedStaticFile;
+
+        using var response = await app.Client.GetAsync(Versioned(path, context.GovUkFrontendVersion));
+
+        AssertNotCacheableForever(response, path);
+    }
+
+    /// <summary>
+    /// The stylesheet references the fonts and images itself, with the version already appended, so those
+    /// URLs have to resolve and pick up the same caching as everything else.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(TargetFrameworks))]
+    public async Task TheAssetUrlsInsideTheStylesheetAreServedAndCacheableForever(string targetFramework)
+    {
+        await using var app = await fixture.StartAsync(targetFramework);
+
+        var stylesheet = await app.Client.GetStringAsync("/govuk-frontend.min.css");
+
+        var assetUrls = AssetUrlRegex().Matches(stylesheet).Select(m => m.Value).Distinct().ToArray();
+
+        Assert.NotEmpty(assetUrls);
+        Assert.All(assetUrls, url => Assert.Contains($"?v={context.GovUkFrontendVersion}", url, StringComparison.Ordinal));
+
+        foreach (var url in assetUrls)
+        {
+            using var response = await app.Client.GetAsync(url);
+
+            AssertCacheableForever(response, url);
+        }
+    }
+
+    private static IEnumerable<string> RestoredFilePaths() =>
+    [
+        "/govuk-frontend.min.css",
+        "/govuk-frontend.min.js",
+        "/assets/images/favicon.ico",
+        "/assets/manifest.json"
+    ];
+
+    internal static string Versioned(string path, string version) => $"{path}?v={version}";
+
+    internal static async Task AssertServedAsync(FixtureApp app, string url, string? expectedContentType)
+    {
+        using var response = await app.Client.GetAsync(url);
+
+        Assert.True(
+            response.StatusCode == HttpStatusCode.OK,
+            $"GET {url} returned {(int)response.StatusCode}.");
+
+        if (expectedContentType is not null)
+        {
+            Assert.Equal(expectedContentType, response.Content.Headers.ContentType?.MediaType);
+        }
+
+        Assert.NotEmpty(await response.Content.ReadAsByteArrayAsync());
+    }
+
+    internal static void AssertCacheableForever(HttpResponseMessage response, string path)
+    {
+        Assert.True(response.StatusCode == HttpStatusCode.OK, $"GET {path} returned {(int)response.StatusCode}.");
+
+        var cacheControl = response.Headers.CacheControl;
+
+        Assert.NotNull(cacheControl);
+        Assert.True(cacheControl.Public, $"{path}: expected a public Cache-Control, got '{cacheControl}'.");
+        Assert.Equal(TimeSpan.FromDays(365), cacheControl.MaxAge);
+        Assert.Contains("immutable", cacheControl.ToString(), StringComparison.Ordinal);
+
+        // A validator would let the browser revalidate a response that never changes.
+        Assert.Null(response.Headers.ETag);
+        Assert.Null(response.Content.Headers.LastModified);
+    }
+
+    internal static void AssertNotCacheableForever(HttpResponseMessage response, string path)
+    {
+        Assert.True(response.StatusCode == HttpStatusCode.OK, $"GET {path} returned {(int)response.StatusCode}.");
+
+        var cacheControl = response.Headers.CacheControl?.ToString() ?? "";
+
+        Assert.DoesNotContain("immutable", cacheControl, StringComparison.Ordinal);
+    }
+
+    [GeneratedRegex(@"/assets/[^)""']+")]
+    private static partial Regex AssetUrlRegex();
+}
+
+/// <summary>
+/// The same, for a project that has moved everything the package restores into a subdirectory.
+/// </summary>
+public class CustomDirectoryHostingTests(CustomDirectoryAppFixture fixture, PackageTestContext context) :
+    IClassFixture<CustomDirectoryAppFixture>
+{
+    public static TheoryData<string> TargetFrameworks => [.. FixtureProject.AllTargetFrameworks];
+
+    [Theory]
+    [MemberData(nameof(TargetFrameworks))]
+    public async Task RestoredFilesAreServedFromTheCustomDirectoryAndCacheableForever(string targetFramework)
+    {
+        await using var app = await fixture.StartAsync(targetFramework);
+
+        string[] paths =
+        [
+            "/govuk/govuk-frontend.min.css",
+            "/govuk/govuk-frontend.min.js",
+            "/govuk/assets/images/favicon.ico"
+        ];
+
+        foreach (var path in paths)
+        {
+            await HostingTests.AssertServedAsync(app, path, expectedContentType: null);
+
+            using var response = await app.Client.GetAsync(HostingTests.Versioned(path, context.GovUkFrontendVersion));
+
+            HostingTests.AssertCacheableForever(response, path);
+        }
+    }
+
+    /// <summary>
+    /// Pins a known gap: <c>PageTemplateHelper</c> builds its URLs from the file names alone and never
+    /// consults the directories in the build info, so moving the stylesheet or the script leaves the page
+    /// template pointing at a URL that isn't there. Callers have to pass a <c>pathBase</c> themselves.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(TargetFrameworks))]
+    public async Task ThePageTemplateStillAdvertisesTheDefaultUrls(string targetFramework)
+    {
+        await using var app = await fixture.StartAsync(targetFramework);
+
+        var page = await HostedPage.GetAsync(app);
+
+        Assert.StartsWith("/govuk-frontend.min.css", page.Stylesheet, StringComparison.Ordinal);
+        Assert.StartsWith("/govuk-frontend.min.js", page.Script, StringComparison.Ordinal);
+
+        using var stylesheet = await app.Client.GetAsync(page.Stylesheet);
+        Assert.Equal(HttpStatusCode.NotFound, stylesheet.StatusCode);
+    }
+
+    /// <summary>
+    /// The assets path is configurable through view data, so the head icons can be pointed at the moved
+    /// directory even though the stylesheet and script can't.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(TargetFrameworks))]
+    public async Task TheHeadIconsFollowTheConfiguredAssetPath(string targetFramework)
+    {
+        await using var app = await fixture.StartAsync(targetFramework);
+
+        var page = await HostedPage.GetAsync(app, "/?assetPath=/govuk/assets");
+
+        Assert.StartsWith("/govuk/assets/", page.FavIcon, StringComparison.Ordinal);
+
+        await HostingTests.AssertServedAsync(app, page.FavIcon, expectedContentType: null);
+    }
+}

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/Infrastructure/DotnetCli.cs
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/Infrastructure/DotnetCli.cs
@@ -1,0 +1,167 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace GovUk.Frontend.AspNetCore.PackageTests.Infrastructure;
+
+/// <summary>
+/// Runs the <c>dotnet</c> CLI as a child process.
+/// </summary>
+public static class DotnetCli
+{
+    /// <summary>
+    /// The MSBuild state that the surrounding build and test run leak through the environment. A nested
+    /// build that inherits these picks up the wrong SDK or the wrong project extensions path.
+    /// </summary>
+    private static readonly string[] InheritedVariablesToClear =
+    [
+        "MSBuildExtensionsPath",
+        "MSBuildLoadMicrosoftTargetsReadOnly",
+        "MSBuildProjectFullPath",
+        "MSBuildSDKsPath",
+        "MSBuildStartupDirectory",
+        "MSBUILD_EXE_PATH",
+        "NUGET_PACKAGES",
+        "VSINSTALLDIR"
+    ];
+
+    public static string ExecutablePath =>
+        Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") is { Length: > 0 } path && File.Exists(path)
+            ? path
+            : "dotnet";
+
+    public static async Task<DotnetCliResult> RunAsync(
+        IEnumerable<string> arguments,
+        string workingDirectory,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        var startInfo = CreateStartInfo(arguments, workingDirectory);
+
+        using var process = new Process() { StartInfo = startInfo };
+
+        var output = new StringBuilder();
+
+        process.OutputDataReceived += AppendLine;
+        process.ErrorDataReceived += AppendLine;
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        using var timeoutSource = new CancellationTokenSource(timeout ?? TimeSpan.FromMinutes(10));
+        using var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(timeoutSource.Token, cancellationToken);
+
+        try
+        {
+            await process.WaitForExitAsync(linkedSource.Token);
+        }
+        catch (OperationCanceledException) when (timeoutSource.IsCancellationRequested)
+        {
+            TryKill(process);
+
+            throw new TimeoutException(
+                $"'{startInfo.FileName} {string.Join(' ', arguments)}' did not complete in time.{Environment.NewLine}{output}");
+        }
+
+        return new DotnetCliResult(process.ExitCode, output.ToString(), string.Join(' ', arguments));
+
+        void AppendLine(object sender, DataReceivedEventArgs e)
+        {
+            if (e.Data is not null)
+            {
+                lock (output)
+                {
+                    output.AppendLine(e.Data);
+                }
+            }
+        }
+    }
+
+    public static ProcessStartInfo CreateStartInfo(IEnumerable<string> arguments, string workingDirectory)
+    {
+        var startInfo = new ProcessStartInfo()
+        {
+            FileName = ExecutablePath,
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        foreach (var variable in InheritedVariablesToClear)
+        {
+            startInfo.Environment.Remove(variable);
+        }
+
+        // Nothing in the sandbox needs the first-run experience or telemetry, and both add noise to the
+        // output the tests parse.
+        startInfo.Environment["DOTNET_NOLOGO"] = "1";
+        startInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
+        startInfo.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "1";
+
+        return startInfo;
+    }
+
+    public static void TryKill(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+        }
+        catch (NotSupportedException)
+        {
+        }
+    }
+}
+
+public sealed record DotnetCliResult(int ExitCode, string Output, string Arguments)
+{
+    public bool Succeeded => ExitCode == 0;
+
+    public DotnetCliResult AssertSucceeded()
+    {
+        if (!Succeeded)
+        {
+            Assert.Fail($"'dotnet {Arguments}' failed with exit code {ExitCode}.{Environment.NewLine}{Output}");
+        }
+
+        return this;
+    }
+
+    public DotnetCliResult AssertFailed()
+    {
+        if (Succeeded)
+        {
+            Assert.Fail($"'dotnet {Arguments}' was expected to fail but succeeded.{Environment.NewLine}{Output}");
+        }
+
+        return this;
+    }
+
+    public void AssertHasWarning(string containing)
+    {
+        if (!Output.Contains(containing, StringComparison.Ordinal))
+        {
+            Assert.Fail($"Expected a warning containing '{containing}'.{Environment.NewLine}{Output}");
+        }
+    }
+
+    public void AssertHasNoWarning(string containing)
+    {
+        if (Output.Contains(containing, StringComparison.Ordinal))
+        {
+            Assert.Fail($"Expected no warning containing '{containing}'.{Environment.NewLine}{Output}");
+        }
+    }
+}

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/Infrastructure/FixtureApp.cs
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/Infrastructure/FixtureApp.cs
@@ -1,0 +1,138 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace GovUk.Frontend.AspNetCore.PackageTests.Infrastructure;
+
+/// <summary>
+/// A built fixture app, running as a child process so requests go through the real host, the real
+/// static file handling and the real middleware pipeline.
+/// </summary>
+public sealed partial class FixtureApp : IAsyncDisposable
+{
+    private static readonly TimeSpan StartupTimeout = TimeSpan.FromSeconds(90);
+
+    private readonly Process _process;
+    private readonly StringBuilder _output;
+    private bool _disposed;
+
+    private FixtureApp(Process process, StringBuilder output, Uri baseAddress)
+    {
+        _process = process;
+        _output = output;
+        BaseAddress = baseAddress;
+
+        Client = new HttpClient(new HttpClientHandler() { AllowAutoRedirect = false })
+        {
+            BaseAddress = baseAddress,
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+    }
+
+    public Uri BaseAddress { get; }
+
+    public HttpClient Client { get; }
+
+    /// <summary>Everything the app has written to stdout and stderr so far.</summary>
+    public string Output
+    {
+        get
+        {
+            lock (_output)
+            {
+                return _output.ToString();
+            }
+        }
+    }
+
+    public static async Task<FixtureApp> StartAsync(FixtureProject project, string targetFramework)
+    {
+        var assemblyPath = project.AssemblyPathFor(targetFramework);
+
+        if (!File.Exists(assemblyPath))
+        {
+            throw new InvalidOperationException($"'{assemblyPath}' does not exist; build the project first.");
+        }
+
+        // The project directory is the content root when you 'dotnet run', which is what puts wwwroot in
+        // the right place.
+        var startInfo = DotnetCli.CreateStartInfo([assemblyPath], project.Directory);
+        startInfo.Environment["ASPNETCORE_URLS"] = "http://127.0.0.1:0";
+        startInfo.Environment["ASPNETCORE_ENVIRONMENT"] = "Development";
+
+        var output = new StringBuilder();
+        var listening = new TaskCompletionSource<Uri>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var process = new Process() { StartInfo = startInfo, EnableRaisingEvents = true };
+
+        process.OutputDataReceived += OnOutput;
+        process.ErrorDataReceived += OnOutput;
+        process.Exited += (_, _) => listening.TrySetException(
+            new InvalidOperationException($"The app exited with code {process.ExitCode} before it started listening.{Environment.NewLine}{output}"));
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        try
+        {
+            var baseAddress = await listening.Task.WaitAsync(StartupTimeout);
+            return new FixtureApp(process, output, baseAddress);
+        }
+        catch (Exception ex)
+        {
+            DotnetCli.TryKill(process);
+            process.Dispose();
+
+            throw ex is TimeoutException
+                ? new TimeoutException($"The app did not start listening within {StartupTimeout}.{Environment.NewLine}{output}")
+                : ex;
+        }
+
+        void OnOutput(object sender, DataReceivedEventArgs e)
+        {
+            if (e.Data is null)
+            {
+                return;
+            }
+
+            lock (output)
+            {
+                output.AppendLine(e.Data);
+            }
+
+            // Kestrel binds an ephemeral port, so the only way to know it is to read it back.
+            if (ListeningRegex().Match(e.Data) is { Success: true } match)
+            {
+                listening.TrySetResult(new Uri(match.Groups[1].Value));
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        Client.Dispose();
+
+        DotnetCli.TryKill(_process);
+
+        try
+        {
+            await _process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(15));
+        }
+        catch (TimeoutException)
+        {
+        }
+
+        _process.Dispose();
+    }
+
+    [GeneratedRegex(@"Now listening on:\s*(http://\S+)")]
+    private static partial Regex ListeningRegex();
+}

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/Infrastructure/FixtureProject.cs
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/Infrastructure/FixtureProject.cs
@@ -1,0 +1,284 @@
+using System.Text;
+
+namespace GovUk.Frontend.AspNetCore.PackageTests.Infrastructure;
+
+/// <summary>
+/// A throwaway project that consumes the packed <c>GovUk.Frontend.AspNetCore</c>, generated into the
+/// test run's sandbox and built with the real SDK.
+/// </summary>
+public sealed class FixtureProject
+{
+    /// <summary>
+    /// The configuration the generated projects build in. The targets under test don't vary by
+    /// configuration, so this is fixed rather than following the test project's.
+    /// </summary>
+    public const string Configuration = "Debug";
+
+    /// <summary>Every fixture is built for all the frameworks the library targets.</summary>
+    public static readonly string[] AllTargetFrameworks = ["net8.0", "net9.0", "net10.0"];
+
+    private readonly PackageTestContext _context;
+
+    private FixtureProject(PackageTestContext context, string name, string directory, IReadOnlyList<string> targetFrameworks)
+    {
+        _context = context;
+        Name = name;
+        Directory = directory;
+        TargetFrameworks = targetFrameworks;
+    }
+
+    public string Name { get; }
+
+    /// <summary>The generated project's directory; all the restore assertions are relative to it.</summary>
+    public string Directory { get; }
+
+    public IReadOnlyList<string> TargetFrameworks { get; }
+
+    public string ProjectFileName => Name + ".csproj";
+
+    /// <param name="properties">Properties to set in the project body, where a consumer would set them.</param>
+    /// <param name="directoryBuildProperties">
+    /// Properties to set in a <c>Directory.Build.props</c> instead, which MSBuild evaluates before the
+    /// package's own props rather than after.
+    /// </param>
+    public static FixtureProject CreateWebApp(
+        PackageTestContext context,
+        string name,
+        IReadOnlyDictionary<string, string>? properties = null,
+        IReadOnlyDictionary<string, string>? directoryBuildProperties = null,
+        IReadOnlyList<string>? targetFrameworks = null) =>
+        Create(context, name, "Microsoft.NET.Sdk.Web", "WebApp", properties, directoryBuildProperties, targetFrameworks);
+
+    /// <inheritdoc cref="CreateWebApp" />
+    public static FixtureProject CreateClassLibrary(
+        PackageTestContext context,
+        string name,
+        IReadOnlyDictionary<string, string>? properties = null,
+        IReadOnlyDictionary<string, string>? directoryBuildProperties = null,
+        IReadOnlyList<string>? targetFrameworks = null) =>
+        Create(context, name, "Microsoft.NET.Sdk", "ClassLib", properties, directoryBuildProperties, targetFrameworks);
+
+    private static FixtureProject Create(
+        PackageTestContext context,
+        string name,
+        string sdk,
+        string fixtureName,
+        IReadOnlyDictionary<string, string>? properties,
+        IReadOnlyDictionary<string, string>? directoryBuildProperties,
+        IReadOnlyList<string>? targetFrameworks)
+    {
+        targetFrameworks ??= AllTargetFrameworks;
+
+        var directory = Path.Combine(context.SandboxDirectory, "projects", name);
+        System.IO.Directory.CreateDirectory(directory);
+
+        var project = new FixtureProject(context, name, directory, targetFrameworks);
+
+        project.WriteSandboxFiles(directoryBuildProperties);
+        project.WriteProjectFile(sdk, properties);
+        CopyDirectory(Path.Combine(context.FixturesDirectory, fixtureName), directory);
+
+        return project;
+    }
+
+    /// <summary>
+    /// Builds the project for every target framework in one invocation.
+    /// </summary>
+    /// <remarks>
+    /// Single-process (<c>-m:1</c>) on purpose: the restore targets copy into the project directory, so
+    /// every target framework's build writes the same destination files and parallel copies would race.
+    /// </remarks>
+    public Task<DotnetCliResult> BuildAsync(params string[] extraArguments) =>
+        DotnetCli.RunAsync(
+            [
+                "build",
+                ProjectFileName,
+                "--configuration", Configuration,
+                "-m:1",
+                // Lingering build nodes hold handles on the sandbox and stop it being cleaned up.
+                "-nodeReuse:false",
+                "--nologo",
+                "-v:m",
+                .. extraArguments
+            ],
+            Directory);
+
+    public Task<DotnetCliResult> RestoreAsync() =>
+        DotnetCli.RunAsync(["restore", ProjectFileName, "--nologo", "-v:m"], Directory);
+
+    /// <summary>
+    /// Invokes a single target, for cases where a full build would mask what's being tested.
+    /// </summary>
+    public Task<DotnetCliResult> RunTargetAsync(string target, params string[] extraArguments) =>
+        DotnetCli.RunAsync(
+            [
+                "msbuild",
+                ProjectFileName,
+                $"-t:{target}",
+                $"-p:Configuration={Configuration}",
+                // Force an inner build so the target sees the same state it would during a real build.
+                $"-p:TargetFramework={TargetFrameworks[^1]}",
+                "-m:1",
+                "-nodeReuse:false",
+                "-nologo",
+                "-v:m",
+                .. extraArguments
+            ],
+            Directory);
+
+    public string PathTo(string relativePath) =>
+        Path.Combine(Directory, relativePath.Replace('/', Path.DirectorySeparatorChar));
+
+    public string OutputPathFor(string targetFramework) =>
+        Path.Combine(Directory, "bin", Configuration, targetFramework);
+
+    public string AssemblyPathFor(string targetFramework) =>
+        Path.Combine(OutputPathFor(targetFramework), Name + ".dll");
+
+    public bool FileExists(string relativePath) => File.Exists(PathTo(relativePath));
+
+    public void AssertFileExists(string relativePath)
+    {
+        if (!FileExists(relativePath))
+        {
+            Assert.Fail($"Expected '{relativePath}' to have been restored into the project.{DescribeRestoredFiles()}");
+        }
+    }
+
+    public void AssertFileDoesNotExist(string relativePath)
+    {
+        if (FileExists(relativePath))
+        {
+            Assert.Fail($"Expected '{relativePath}' not to have been restored into the project.{DescribeRestoredFiles()}");
+        }
+    }
+
+    public void AssertDirectoryIsEmptyOrMissing(string relativePath)
+    {
+        var path = PathTo(relativePath);
+
+        if (System.IO.Directory.Exists(path) &&
+            System.IO.Directory.EnumerateFileSystemEntries(path).Any())
+        {
+            Assert.Fail($"Expected '{relativePath}' to be empty or missing.{DescribeRestoredFiles()}");
+        }
+    }
+
+    /// <summary>
+    /// The files the targets copied into the project directory, relative to it, excluding build output
+    /// and the fixture's own sources.
+    /// </summary>
+    public IReadOnlyList<string> GetRestoredFiles() =>
+        System.IO.Directory.EnumerateFiles(Directory, "*", SearchOption.AllDirectories)
+            .Select(f => Path.GetRelativePath(Directory, f).Replace(Path.DirectorySeparatorChar, '/'))
+            .Where(f => !f.StartsWith("bin/", StringComparison.Ordinal) && !f.StartsWith("obj/", StringComparison.Ordinal))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+    private string DescribeRestoredFiles()
+    {
+        var files = GetRestoredFiles();
+
+        // Asset folders run to hundreds of files; a truncated list is enough to see what happened.
+        var shown = files.Take(60).ToArray();
+        var suffix = files.Count > shown.Length ? $"{Environment.NewLine}  ... and {files.Count - shown.Length} more" : "";
+
+        return $"{Environment.NewLine}Files in the project directory:{Environment.NewLine}  " +
+            string.Join($"{Environment.NewLine}  ", shown) + suffix;
+    }
+
+    private static string RenderProperties(IReadOnlyDictionary<string, string>? properties, string indent)
+    {
+        var rendered = new StringBuilder();
+
+        foreach (var (key, value) in properties ?? new Dictionary<string, string>())
+        {
+            rendered.AppendLine($"{indent}<{key}>{value}</{key}>");
+        }
+
+        return rendered.ToString();
+    }
+
+    private void WriteProjectFile(string sdk, IReadOnlyDictionary<string, string>? properties)
+    {
+        var scenarioProperties = RenderProperties(properties, "    ");
+
+        // The scenario's properties go in the project body, where a consumer would put them; passing them
+        // as global properties on the command line evaluates differently.
+        File.WriteAllText(
+            Path.Combine(Directory, ProjectFileName),
+            $"""
+            <Project Sdk="{sdk}">
+
+              <PropertyGroup>
+                <TargetFrameworks>{string.Join(';', TargetFrameworks)}</TargetFrameworks>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
+                <RootNamespace>PackageTestFixture</RootNamespace>
+            {scenarioProperties}  </PropertyGroup>
+
+              <ItemGroup>
+                <PackageReference Include="GovUk.Frontend.AspNetCore" Version="{_context.PackageVersion}" />
+              </ItemGroup>
+
+            </Project>
+
+            """);
+    }
+
+    private void WriteSandboxFiles(IReadOnlyDictionary<string, string>? directoryBuildProperties)
+    {
+        // Stops MSBuild's upward search, so the sandbox can't inherit the repo's build customisation, and
+        // keeps restore out of the machine's global packages folder.
+        File.WriteAllText(
+            Path.Combine(Directory, "Directory.Build.props"),
+            $"""
+            <Project>
+              <PropertyGroup>
+                <RestorePackagesPath>{_context.PackagesDirectory}</RestorePackagesPath>
+            {RenderProperties(directoryBuildProperties, "    ")}  </PropertyGroup>
+            </Project>
+
+            """);
+
+        File.WriteAllText(Path.Combine(Directory, "Directory.Build.targets"), "<Project>\n</Project>\n");
+
+        // Clearing the inherited sources keeps whatever the machine has configured out of the picture,
+        // and the source mapping guarantees the package under test comes from the local feed rather than
+        // a released version off nuget.org that happens to have the same id.
+        File.WriteAllText(
+            Path.Combine(Directory, "NuGet.config"),
+            $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+                <add key="package-under-test" value="{_context.PackageFeed}" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="nuget.org">
+                  <package pattern="*" />
+                </packageSource>
+                <packageSource key="package-under-test">
+                  <package pattern="GovUk.Frontend.AspNetCore" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+
+            """);
+
+        File.Copy(Path.Combine(_context.RepoRoot, "global.json"), Path.Combine(Directory, "global.json"), overwrite: true);
+    }
+
+    private static void CopyDirectory(string source, string destination)
+    {
+        foreach (var file in System.IO.Directory.EnumerateFiles(source, "*", SearchOption.AllDirectories))
+        {
+            var target = Path.Combine(destination, Path.GetRelativePath(source, file));
+            System.IO.Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+            File.Copy(file, target, overwrite: true);
+        }
+    }
+}

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/Infrastructure/GeneratedBuildInfo.cs
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/Infrastructure/GeneratedBuildInfo.cs
@@ -1,0 +1,102 @@
+using System.Text.RegularExpressions;
+
+namespace GovUk.Frontend.AspNetCore.PackageTests.Infrastructure;
+
+/// <summary>
+/// The <c>GovUkFrontendBuildInfoAttribute</c> the targets emitted, read back out of the generated
+/// assembly info source.
+/// </summary>
+/// <remarks>
+/// Reading the generated C# rather than the compiled attribute is deliberate: <c>WriteCodeFragment</c>
+/// emits literal parameters verbatim, so a directory containing a backslash or a quote produces source
+/// that is subtly wrong, and the raw text is what makes that visible.
+/// </remarks>
+public sealed partial class GeneratedBuildInfo
+{
+    private GeneratedBuildInfo(string arguments, IReadOnlyList<string?> values)
+    {
+        RawArguments = arguments;
+        EnableGovUkFrontendSupport = values[0] == "true";
+        AssetsDirectory = values[1];
+        JavaScriptDirectory = values[2];
+        StylesheetDirectory = values[3];
+    }
+
+    /// <summary>The argument list exactly as it appears in the generated source.</summary>
+    public string RawArguments { get; }
+
+    public bool EnableGovUkFrontendSupport { get; }
+
+    public string? AssetsDirectory { get; }
+
+    public string? JavaScriptDirectory { get; }
+
+    public string? StylesheetDirectory { get; }
+
+    public static GeneratedBuildInfo Read(FixtureProject project, string targetFramework)
+    {
+        var objDirectory = Path.Combine(project.Directory, "obj", FixtureProject.Configuration, targetFramework);
+
+        var assemblyInfoFiles = Directory.Exists(objDirectory)
+            ? Directory.GetFiles(objDirectory, "*.AssemblyInfo.cs")
+            : [];
+
+        if (assemblyInfoFiles.Length != 1)
+        {
+            throw new InvalidOperationException(
+                $"Expected exactly one generated assembly info file in '{objDirectory}' but found {assemblyInfoFiles.Length}.");
+        }
+
+        var source = File.ReadAllText(assemblyInfoFiles[0]);
+        var match = AttributeRegex().Match(source);
+
+        if (!match.Success)
+        {
+            throw new InvalidOperationException(
+                $"No GovUkFrontendBuildInfoAttribute found in '{assemblyInfoFiles[0]}'.{Environment.NewLine}{source}");
+        }
+
+        var arguments = match.Groups[1].Value;
+        var values = ParseArguments(arguments);
+
+        if (values.Count != 4)
+        {
+            throw new InvalidOperationException(
+                $"Expected 4 arguments to GovUkFrontendBuildInfoAttribute but found {values.Count}: {arguments}");
+        }
+
+        return new GeneratedBuildInfo(arguments, values);
+    }
+
+    /// <summary>
+    /// Splits the argument list and unquotes the string literals; a bare <c>null</c> becomes
+    /// <see langword="null"/>.
+    /// </summary>
+    private static List<string?> ParseArguments(string arguments)
+    {
+        var values = new List<string?>();
+
+        foreach (var argument in arguments.Split(',').Select(a => a.Trim()))
+        {
+            if (argument == "null")
+            {
+                values.Add(null);
+            }
+            else if (argument.StartsWith('"') && argument.EndsWith('"'))
+            {
+                // The generated source escapes backslashes; undo that so the value can be compared with
+                // the directory the project asked for.
+                values.Add(argument[1..^1].Replace("\\\\", "\\", StringComparison.Ordinal));
+            }
+            else
+            {
+                values.Add(argument);
+            }
+        }
+
+        return values;
+    }
+
+    [GeneratedRegex(@"GovUkFrontendBuildInfoAttribute\(([^)]*)\)")]
+    private static partial Regex AttributeRegex();
+}

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/Infrastructure/HostedAppFixture.cs
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/Infrastructure/HostedAppFixture.cs
@@ -1,0 +1,52 @@
+namespace GovUk.Frontend.AspNetCore.PackageTests.Infrastructure;
+
+/// <summary>
+/// Builds a fixture project once for a whole test class, so only the app launches are per test.
+/// </summary>
+public abstract class HostedAppFixture(PackageTestContext context) : IAsyncLifetime
+{
+    public PackageTestContext Context { get; } = context;
+
+    public FixtureProject Project { get; private set; } = null!;
+
+    /// <summary>A file that the targets didn't restore, for checking what the middleware leaves alone.</summary>
+    public const string UnrelatedStaticFile = "not-govuk.txt";
+
+    protected abstract FixtureProject CreateProject();
+
+    public async ValueTask InitializeAsync()
+    {
+        Project = CreateProject();
+
+        Directory.CreateDirectory(Project.PathTo("wwwroot"));
+        await File.WriteAllTextAsync(Project.PathTo($"wwwroot/{UnrelatedStaticFile}"), "Not part of govuk-frontend.");
+
+        (await Project.BuildAsync()).AssertSucceeded();
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public Task<FixtureApp> StartAsync(string targetFramework) => FixtureApp.StartAsync(Project, targetFramework);
+}
+
+/// <summary>A project that takes the package's defaults.</summary>
+public sealed class DefaultConfigurationAppFixture(PackageTestContext context) : HostedAppFixture(context)
+{
+    protected override FixtureProject CreateProject() =>
+        FixtureProject.CreateWebApp(Context, "HostingDefaults");
+}
+
+/// <summary>A project that moves everything the package restores into a subdirectory of the web root.</summary>
+public sealed class CustomDirectoryAppFixture(PackageTestContext context) : HostedAppFixture(context)
+{
+    protected override FixtureProject CreateProject() =>
+        FixtureProject.CreateWebApp(
+            Context,
+            "HostingCustomDirectories",
+            new Dictionary<string, string>()
+            {
+                ["GovUkFrontendAssetsDirectory"] = "wwwroot/govuk/assets",
+                ["GovUkFrontendJavaScriptDirectory"] = "wwwroot/govuk",
+                ["GovUkFrontendStylesheetDirectory"] = "wwwroot/govuk"
+            });
+}

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/Infrastructure/HostedPage.cs
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/Infrastructure/HostedPage.cs
@@ -1,0 +1,39 @@
+using System.Net;
+using AngleSharp.Html.Dom;
+using AngleSharp.Html.Parser;
+
+namespace GovUk.Frontend.AspNetCore.PackageTests.Infrastructure;
+
+/// <summary>
+/// The URLs the library's page template advertises for the files the targets restored.
+/// </summary>
+public sealed record HostedPage(string Stylesheet, string Script, string FavIcon, string Manifest)
+{
+    public static async Task<HostedPage> GetAsync(FixtureApp app, string path = "/")
+    {
+        using var response = await app.Client.GetAsync(path);
+
+        if (response.StatusCode != HttpStatusCode.OK)
+        {
+            Assert.Fail($"GET {path} returned {(int)response.StatusCode}.{Environment.NewLine}{await response.Content.ReadAsStringAsync()}");
+        }
+
+        await using var content = await response.Content.ReadAsStreamAsync();
+        var document = (IHtmlDocument)await new HtmlParser().ParseDocumentAsync(content);
+
+        return new HostedPage(
+            Attribute(document, "link[rel=stylesheet]", "href"),
+            Attribute(document, "script[type=module][src]", "src"),
+            Attribute(document, "link[rel=icon][sizes='48x48']", "href"),
+            Attribute(document, "link[rel=manifest]", "href"));
+
+        static string Attribute(IHtmlDocument document, string selector, string attributeName)
+        {
+            var element = document.QuerySelector(selector) ??
+                throw new InvalidOperationException($"No element matched '{selector}'.{Environment.NewLine}{document.DocumentElement.OuterHtml}");
+
+            return element.GetAttribute(attributeName) ??
+                throw new InvalidOperationException($"'{selector}' has no '{attributeName}' attribute.");
+        }
+    }
+}

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/Infrastructure/PackageTestContext.cs
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/Infrastructure/PackageTestContext.cs
@@ -1,0 +1,127 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace GovUk.Frontend.AspNetCore.PackageTests.Infrastructure;
+
+/// <summary>
+/// Everything the tests need to know about the package under test, plus the sandbox root that the
+/// generated projects live in.
+/// </summary>
+/// <remarks>
+/// One instance per test run; see <c>AssemblyInfo.cs</c>. The sandbox lives outside the repository so
+/// the generated projects don't inherit the repo's <c>Directory.Build.props</c> or <c>nuget.config</c>.
+/// </remarks>
+public sealed class PackageTestContext : IDisposable
+{
+    private const string KeepSandboxVariableName = "GOVUK_PACKAGE_TESTS_KEEP_SANDBOX";
+
+    private bool _disposed;
+
+    public PackageTestContext()
+    {
+        RepoRoot = GetAssemblyMetadata("RepoRoot");
+        PackageFeed = GetAssemblyMetadata("PackageTestFeed");
+
+        var packages = Directory.Exists(PackageFeed)
+            ? Directory.GetFiles(PackageFeed, "GovUk.Frontend.AspNetCore.*.nupkg")
+            : [];
+
+        if (packages.Length != 1)
+        {
+            throw new InvalidOperationException(
+                $"Expected exactly one GovUk.Frontend.AspNetCore package in '{PackageFeed}' but found {packages.Length}. " +
+                "Build this project to pack the library under test.");
+        }
+
+        PackageVersion = Path.GetFileNameWithoutExtension(packages[0])["GovUk.Frontend.AspNetCore.".Length..];
+        GovUkFrontendVersion = ReadGovUkFrontendVersion(RepoRoot);
+        FixturesDirectory = Path.Combine(AppContext.BaseDirectory, "Fixtures");
+
+        // Alongside the feed rather than in the sandbox, so repeat runs don't re-download the package
+        // under test's dependencies. It's wiped along with the rest of obj/.
+        PackagesDirectory = Path.Combine(Path.GetDirectoryName(PackageFeed.TrimEnd(Path.DirectorySeparatorChar))!, "test-packages");
+        Directory.CreateDirectory(PackagesDirectory);
+
+        SandboxDirectory = Path.Combine(Path.GetTempPath(), "govuk-frontend-package-tests", Path.GetRandomFileName());
+        Directory.CreateDirectory(SandboxDirectory);
+    }
+
+    /// <summary>The root of the repository, used to locate <c>global.json</c>.</summary>
+    public string RepoRoot { get; }
+
+    /// <summary>The folder feed containing the freshly packed package under test.</summary>
+    public string PackageFeed { get; }
+
+    /// <summary>The version of the freshly packed package under test.</summary>
+    public string PackageVersion { get; }
+
+    /// <summary>The version of govuk-frontend the package ships, i.e. the value of the <c>v</c> query parameter.</summary>
+    public string GovUkFrontendVersion { get; }
+
+    /// <summary>Where the fixture app sources were copied to in this assembly's output.</summary>
+    public string FixturesDirectory { get; }
+
+    /// <summary>The temporary root that all generated projects live under.</summary>
+    public string SandboxDirectory { get; }
+
+    /// <summary>
+    /// A restore packages folder shared by every generated project, so the package under test is only
+    /// extracted once and the machine's global cache is never touched.
+    /// </summary>
+    /// <remarks>
+    /// The package under test's extracted copy is removed when it's repacked, so a rebuild can't leave a
+    /// stale one behind for a version number that happens to repeat.
+    /// </remarks>
+    public string PackagesDirectory { get; }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        if (Environment.GetEnvironmentVariable(KeepSandboxVariableName) is "1" or "true")
+        {
+            return;
+        }
+
+        TryDeleteDirectory(SandboxDirectory);
+    }
+
+    private static string GetAssemblyMetadata(string key) =>
+        typeof(PackageTestContext).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+            .SingleOrDefault(a => a.Key == key)?.Value ??
+        throw new InvalidOperationException($"No '{key}' assembly metadata found.");
+
+    private static string ReadGovUkFrontendVersion(string repoRoot)
+    {
+        var propsPath = Path.Combine(repoRoot, "Directory.Build.props");
+        var match = Regex.Match(File.ReadAllText(propsPath), @"<GovUkFrontendVersion>([^<]+)</GovUkFrontendVersion>");
+
+        return match.Success
+            ? match.Groups[1].Value
+            : throw new InvalidOperationException($"No GovUkFrontendVersion found in '{propsPath}'.");
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // A leaked build server or app process can keep a handle open; leaving a temp folder behind
+            // is not worth failing a run over.
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/RestoreTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/RestoreTests.cs
@@ -1,0 +1,454 @@
+using GovUk.Frontend.AspNetCore.PackageTests.Infrastructure;
+
+namespace GovUk.Frontend.AspNetCore.PackageTests;
+
+/// <summary>
+/// What the package's targets copy into a consuming project, and the build info they generate from it.
+/// </summary>
+public class RestoreTests(PackageTestContext context)
+{
+    private const string DeprecationWarning =
+        "The CopyGovUkFrontendAssetsToWebRoot property is deprecated; use RestoreGovUkFrontendAssets instead.";
+
+    [Fact]
+    public async Task WebSdkProject_WithNoConfiguration_RestoresAssetsJavascriptAndStylesheet()
+    {
+        var project = FixtureProject.CreateWebApp(context, nameof(WebSdkProject_WithNoConfiguration_RestoresAssetsJavascriptAndStylesheet));
+
+        var result = await project.BuildAsync();
+
+        result.AssertSucceeded();
+        result.AssertHasNoWarning(DeprecationWarning);
+
+        project.AssertFileExists("wwwroot/assets/images/favicon.ico");
+        project.AssertFileExists("wwwroot/assets/images/govuk-crest.svg");
+        project.AssertFileExists("wwwroot/assets/manifest.json");
+        project.AssertFileExists("wwwroot/govuk-frontend.min.js");
+        project.AssertFileExists("wwwroot/govuk-frontend.min.css");
+
+        // The fonts are a separate subdirectory of assets, so they prove the copy is recursive.
+        Assert.NotEmpty(Directory.GetFiles(project.PathTo("wwwroot/assets/fonts"), "*.woff2"));
+
+        // The stylesheet is the one this repo compiles, which appends the version to the asset URLs it
+        // references, not the one that ships inside the npm package, which doesn't.
+        Assert.Contains(
+            $"?v={context.GovUkFrontendVersion}",
+            await File.ReadAllTextAsync(project.PathTo("wwwroot/govuk-frontend.min.css")),
+            StringComparison.Ordinal);
+
+        // Both of these are opt-in.
+        project.AssertDirectoryIsEmptyOrMissing("lib");
+
+        AssertBuildInfoForEveryTargetFramework(
+            project,
+            enableSupport: true,
+            assetsDirectory: "wwwroot/assets",
+            javaScriptDirectory: "wwwroot",
+            stylesheetDirectory: "wwwroot");
+    }
+
+    [Fact]
+    public async Task NonWebSdkProject_WithNoConfiguration_RestoresNothing()
+    {
+        var project = FixtureProject.CreateClassLibrary(context, nameof(NonWebSdkProject_WithNoConfiguration_RestoresNothing));
+
+        var result = await project.BuildAsync();
+
+        result.AssertSucceeded();
+
+        // EnableGovUkFrontendSupport only defaults to true for Web SDK projects.
+        project.AssertDirectoryIsEmptyOrMissing("wwwroot");
+        project.AssertDirectoryIsEmptyOrMissing("lib");
+
+        AssertBuildInfoForEveryTargetFramework(
+            project,
+            enableSupport: false,
+            assetsDirectory: null,
+            javaScriptDirectory: null,
+            stylesheetDirectory: null);
+    }
+
+    [Fact]
+    public async Task NonWebSdkProject_WithSupportEnabled_RestoresAssetsJavascriptAndStylesheet()
+    {
+        var project = FixtureProject.CreateClassLibrary(
+            context,
+            nameof(NonWebSdkProject_WithSupportEnabled_RestoresAssetsJavascriptAndStylesheet),
+            new Dictionary<string, string>() { ["EnableGovUkFrontendSupport"] = "true" });
+
+        var result = await project.BuildAsync();
+
+        result.AssertSucceeded();
+
+        project.AssertFileExists("wwwroot/assets/images/favicon.ico");
+        project.AssertFileExists("wwwroot/govuk-frontend.min.js");
+        project.AssertFileExists("wwwroot/govuk-frontend.min.css");
+    }
+
+    [Fact]
+    public async Task WithAllRestoreOptionsEnabled_RestoresNpmPackageAndSupportFiles()
+    {
+        var project = FixtureProject.CreateWebApp(
+            context,
+            nameof(WithAllRestoreOptionsEnabled_RestoresNpmPackageAndSupportFiles),
+            new Dictionary<string, string>()
+            {
+                ["RestoreGovUkFrontendAssets"] = "true",
+                ["RestoreGovUkFrontendJavascript"] = "true",
+                ["RestoreGovUkFrontendStylesheet"] = "true",
+                ["RestoreGovUkFrontendNpmPackage"] = "true",
+                ["RestoreGovUkFrontendSupportPackage"] = "true"
+            });
+
+        var result = await project.BuildAsync();
+
+        result.AssertSucceeded();
+
+        project.AssertFileExists("wwwroot/assets/images/favicon.ico");
+        project.AssertFileExists("wwwroot/govuk-frontend.min.js");
+        project.AssertFileExists("wwwroot/govuk-frontend.min.css");
+
+        // The whole npm package, not just the built bundles.
+        project.AssertFileExists("lib/govuk-frontend/govuk-frontend.min.js");
+        project.AssertFileExists("lib/govuk-frontend/assets/images/favicon.ico");
+        project.AssertFileExists("lib/govuk-frontend/index.scss");
+
+        // The Sass support module, which is generated at pack time rather than coming from npm.
+        project.AssertFileExists("lib/govuk-frontend-aspnetcore/index.scss");
+        project.AssertFileExists("lib/govuk-frontend-aspnetcore/_constants.scss");
+
+        Assert.Contains(
+            context.GovUkFrontendVersion,
+            await File.ReadAllTextAsync(project.PathTo("lib/govuk-frontend-aspnetcore/_constants.scss")));
+    }
+
+    [Fact]
+    public async Task WithCustomDirectories_RestoresToThoseDirectories()
+    {
+        var project = FixtureProject.CreateWebApp(
+            context,
+            nameof(WithCustomDirectories_RestoresToThoseDirectories),
+            new Dictionary<string, string>()
+            {
+                ["GovUkFrontendAssetsDirectory"] = "wwwroot/govuk/assets",
+                ["GovUkFrontendJavaScriptDirectory"] = "wwwroot/govuk",
+                ["GovUkFrontendStylesheetDirectory"] = "wwwroot/govuk",
+                ["RestoreGovUkFrontendNpmPackage"] = "true",
+                ["GovUkFrontendNpmPackageDirectory"] = "vendor/npm",
+                ["RestoreGovUkFrontendSupportPackage"] = "true",
+                ["GovUkFrontendSupportPackageDirectory"] = "vendor/support"
+            });
+
+        var result = await project.BuildAsync();
+
+        result.AssertSucceeded();
+
+        project.AssertFileExists("wwwroot/govuk/assets/images/favicon.ico");
+        project.AssertFileExists("wwwroot/govuk/govuk-frontend.min.js");
+        project.AssertFileExists("wwwroot/govuk/govuk-frontend.min.css");
+        project.AssertFileExists("vendor/npm/govuk-frontend.min.js");
+        project.AssertFileExists("vendor/support/index.scss");
+
+        project.AssertFileDoesNotExist("wwwroot/govuk-frontend.min.js");
+        project.AssertFileDoesNotExist("wwwroot/govuk-frontend.min.css");
+        project.AssertDirectoryIsEmptyOrMissing("wwwroot/assets");
+        project.AssertDirectoryIsEmptyOrMissing("lib");
+
+        AssertBuildInfoForEveryTargetFramework(
+            project,
+            enableSupport: true,
+            assetsDirectory: "wwwroot/govuk/assets",
+            javaScriptDirectory: "wwwroot/govuk",
+            stylesheetDirectory: "wwwroot/govuk");
+    }
+
+    /// <summary>
+    /// A directory written the way a Windows author would write it has to survive being embedded in the
+    /// generated attribute, where an unescaped backslash is an escape sequence rather than a separator.
+    /// </summary>
+    /// <remarks>
+    /// MSBuild is not consistent about whether it normalises the separators before they reach the
+    /// generated source — on Unix the same build emits them verbatim for one target framework and
+    /// normalised for the next — so the value is compared with the separators normalised, the way
+    /// <c>VersionedAssetMiddleware</c> compares it. What has to hold either way is that a backslash which
+    /// does survive is escaped, since an unescaped one is a C# escape sequence rather than a separator.
+    /// </remarks>
+    [Fact]
+    public async Task WithWindowsStyleDirectorySeparators_RestoresToThoseDirectoriesAndEscapesTheGeneratedBuildInfo()
+    {
+        var project = FixtureProject.CreateWebApp(
+            context,
+            nameof(WithWindowsStyleDirectorySeparators_RestoresToThoseDirectoriesAndEscapesTheGeneratedBuildInfo),
+            new Dictionary<string, string>()
+            {
+                ["GovUkFrontendAssetsDirectory"] = @"wwwroot\govuk\assets",
+                ["GovUkFrontendJavaScriptDirectory"] = @"wwwroot\govuk",
+                ["GovUkFrontendStylesheetDirectory"] = @"wwwroot\govuk"
+            });
+
+        var result = await project.BuildAsync();
+
+        // A literal parameter would have produced source that doesn't compile, or a string containing a
+        // \g escape.
+        result.AssertSucceeded();
+
+        project.AssertFileExists("wwwroot/govuk/assets/images/favicon.ico");
+        project.AssertFileExists("wwwroot/govuk/govuk-frontend.min.js");
+        project.AssertFileExists("wwwroot/govuk/govuk-frontend.min.css");
+
+        foreach (var targetFramework in project.TargetFrameworks)
+        {
+            var buildInfo = GeneratedBuildInfo.Read(project, targetFramework);
+
+            Assert.Equal("wwwroot/govuk/assets", Normalize(buildInfo.AssetsDirectory));
+            Assert.Equal("wwwroot/govuk", Normalize(buildInfo.JavaScriptDirectory));
+            Assert.Equal("wwwroot/govuk", Normalize(buildInfo.StylesheetDirectory));
+
+            if (buildInfo.AssetsDirectory!.Contains('\\', StringComparison.Ordinal))
+            {
+                Assert.Contains(@"""wwwroot\\govuk\\assets""", buildInfo.RawArguments, StringComparison.Ordinal);
+            }
+        }
+
+        static string? Normalize(string? directory) => directory?.Replace('\\', '/');
+    }
+
+    [Fact]
+    public async Task WithAllRestoreOptionsDisabled_RestoresNothingAndReportsNoDirectories()
+    {
+        var project = FixtureProject.CreateWebApp(
+            context,
+            nameof(WithAllRestoreOptionsDisabled_RestoresNothingAndReportsNoDirectories),
+            new Dictionary<string, string>()
+            {
+                ["RestoreGovUkFrontendAssets"] = "false",
+                ["RestoreGovUkFrontendJavascript"] = "false",
+                ["RestoreGovUkFrontendStylesheet"] = "false",
+                ["RestoreGovUkFrontendNpmPackage"] = "false",
+                ["RestoreGovUkFrontendSupportPackage"] = "false"
+            });
+
+        var result = await project.BuildAsync();
+
+        result.AssertSucceeded();
+
+        project.AssertDirectoryIsEmptyOrMissing("wwwroot");
+        project.AssertDirectoryIsEmptyOrMissing("lib");
+
+        // Support is still on, so the middleware is still added; it just has nothing to mark as immutable.
+        AssertBuildInfoForEveryTargetFramework(
+            project,
+            enableSupport: true,
+            assetsDirectory: null,
+            javaScriptDirectory: null,
+            stylesheetDirectory: null);
+    }
+
+    [Fact]
+    public async Task WithSupportDisabled_RestoresNothingEvenWhenTheRestoreOptionsAreEnabled()
+    {
+        var project = FixtureProject.CreateWebApp(
+            context,
+            nameof(WithSupportDisabled_RestoresNothingEvenWhenTheRestoreOptionsAreEnabled),
+            new Dictionary<string, string>()
+            {
+                ["EnableGovUkFrontendSupport"] = "false",
+                ["RestoreGovUkFrontendAssets"] = "true",
+                ["RestoreGovUkFrontendJavascript"] = "true",
+                ["RestoreGovUkFrontendStylesheet"] = "true",
+                ["RestoreGovUkFrontendNpmPackage"] = "true",
+                ["RestoreGovUkFrontendSupportPackage"] = "true"
+            });
+
+        var result = await project.BuildAsync();
+
+        result.AssertSucceeded();
+
+        project.AssertDirectoryIsEmptyOrMissing("wwwroot");
+        project.AssertDirectoryIsEmptyOrMissing("lib");
+
+        AssertBuildInfoForEveryTargetFramework(
+            project,
+            enableSupport: false,
+            assetsDirectory: null,
+            javaScriptDirectory: null,
+            stylesheetDirectory: null);
+    }
+
+    [Fact]
+    public async Task WithDeprecatedCopyAssetsPropertySetToTrue_RestoresAssetsAndWarns()
+    {
+        var project = FixtureProject.CreateWebApp(
+            context,
+            nameof(WithDeprecatedCopyAssetsPropertySetToTrue_RestoresAssetsAndWarns),
+            new Dictionary<string, string>() { ["CopyGovUkFrontendAssetsToWebRoot"] = "true" });
+
+        var result = await project.BuildAsync();
+
+        result.AssertSucceeded();
+        result.AssertHasWarning(DeprecationWarning);
+
+        project.AssertFileExists("wwwroot/assets/images/favicon.ico");
+    }
+
+    /// <summary>
+    /// Pins a known bug: <c>CopyGovUkFrontendAssetsToWebRoot</c> has no effect when it's set where a
+    /// consumer would naturally set it.
+    /// </summary>
+    /// <remarks>
+    /// The backward-compatibility shim that maps it onto <c>RestoreGovUkFrontendAssets</c> lives in the
+    /// package's props file, which MSBuild evaluates before the project body, so it only ever sees an
+    /// empty value. The deprecation warning still fires because that lives in the targets file, which is
+    /// evaluated afterwards — so the build tells you the property is deprecated while silently ignoring
+    /// it. See <see cref="WithDeprecatedCopyAssetsPropertySetToFalseInDirectoryBuildProps_DoesNotRestoreAssets"/>
+    /// for the placement where it does work.
+    /// </remarks>
+    [Fact]
+    public async Task WithDeprecatedCopyAssetsPropertySetToFalseInProjectBody_StillRestoresAssets()
+    {
+        var project = FixtureProject.CreateWebApp(
+            context,
+            nameof(WithDeprecatedCopyAssetsPropertySetToFalseInProjectBody_StillRestoresAssets),
+            new Dictionary<string, string>() { ["CopyGovUkFrontendAssetsToWebRoot"] = "false" });
+
+        var result = await project.BuildAsync();
+
+        result.AssertSucceeded();
+        result.AssertHasWarning(DeprecationWarning);
+
+        project.AssertFileExists("wwwroot/assets/images/favicon.ico");
+    }
+
+    [Fact]
+    public async Task WithDeprecatedCopyAssetsPropertySetToFalseInDirectoryBuildProps_DoesNotRestoreAssets()
+    {
+        var project = FixtureProject.CreateWebApp(
+            context,
+            nameof(WithDeprecatedCopyAssetsPropertySetToFalseInDirectoryBuildProps_DoesNotRestoreAssets),
+            directoryBuildProperties: new Dictionary<string, string>() { ["CopyGovUkFrontendAssetsToWebRoot"] = "false" });
+
+        var result = await project.BuildAsync();
+
+        result.AssertSucceeded();
+        result.AssertHasWarning(DeprecationWarning);
+
+        project.AssertDirectoryIsEmptyOrMissing("wwwroot/assets");
+
+        // The old property only ever controlled the assets.
+        project.AssertFileExists("wwwroot/govuk-frontend.min.js");
+        project.AssertFileExists("wwwroot/govuk-frontend.min.css");
+    }
+
+    /// <summary>
+    /// Pins the same evaluation-order bug for the other two properties the props file derives from
+    /// user-set values: setting a support package directory is documented to imply
+    /// <c>RestoreGovUkFrontendSupportPackage</c>, and either opt-in is documented to imply
+    /// <c>EnableGovUkFrontendSupport</c>, but neither is visible to the props file from the project body.
+    /// </summary>
+    [Fact]
+    public async Task WithDerivedPropertiesSetInProjectBody_TheDerivationDoesNotHappen()
+    {
+        var project = FixtureProject.CreateClassLibrary(
+            context,
+            nameof(WithDerivedPropertiesSetInProjectBody_TheDerivationDoesNotHappen),
+            new Dictionary<string, string>()
+            {
+                // Documented to imply EnableGovUkFrontendSupport.
+                ["RestoreGovUkFrontendNpmPackage"] = "true",
+                // Documented to imply RestoreGovUkFrontendSupportPackage.
+                ["GovUkFrontendSupportPackageDirectory"] = "vendor/support"
+            });
+
+        var result = await project.BuildAsync();
+
+        result.AssertSucceeded();
+
+        project.AssertDirectoryIsEmptyOrMissing("lib");
+        project.AssertDirectoryIsEmptyOrMissing("vendor");
+
+        AssertBuildInfoForEveryTargetFramework(
+            project,
+            enableSupport: false,
+            assetsDirectory: null,
+            javaScriptDirectory: null,
+            stylesheetDirectory: null);
+    }
+
+    [Fact]
+    public async Task WithDerivedPropertiesSetInDirectoryBuildProps_TheDerivationHappens()
+    {
+        var project = FixtureProject.CreateClassLibrary(
+            context,
+            nameof(WithDerivedPropertiesSetInDirectoryBuildProps_TheDerivationHappens),
+            directoryBuildProperties: new Dictionary<string, string>()
+            {
+                ["RestoreGovUkFrontendNpmPackage"] = "true",
+                ["GovUkFrontendSupportPackageDirectory"] = "vendor/support"
+            });
+
+        var result = await project.BuildAsync();
+
+        result.AssertSucceeded();
+
+        project.AssertFileExists("lib/govuk-frontend/govuk-frontend.min.js");
+        project.AssertFileExists("vendor/support/index.scss");
+    }
+
+    /// <summary>
+    /// The IDE runs design-time builds on project load and after every edit; copying files during those
+    /// means the IDE churns the project directory in the background.
+    /// </summary>
+    [Fact]
+    public async Task DesignTimeBuild_DoesNotCopyAnyFiles()
+    {
+        var project = FixtureProject.CreateWebApp(context, nameof(DesignTimeBuild_DoesNotCopyAnyFiles));
+
+        (await project.RestoreAsync()).AssertSucceeded();
+
+        (await project.RunTargetAsync("RestoreGovUkFrontend", "-p:DesignTimeBuild=true")).AssertSucceeded();
+
+        project.AssertDirectoryIsEmptyOrMissing("wwwroot");
+
+        // Running the same target without the flag proves the target was reachable in the first place,
+        // so the assertion above can't pass just because nothing ran.
+        (await project.RunTargetAsync("RestoreGovUkFrontend")).AssertSucceeded();
+
+        project.AssertFileExists("wwwroot/govuk-frontend.min.css");
+    }
+
+    [Fact]
+    public async Task Rebuild_AfterRestoredFilesAreDeleted_RestoresThemAgain()
+    {
+        var project = FixtureProject.CreateWebApp(context, nameof(Rebuild_AfterRestoredFilesAreDeleted_RestoresThemAgain));
+
+        (await project.BuildAsync()).AssertSucceeded();
+
+        File.Delete(project.PathTo("wwwroot/govuk-frontend.min.css"));
+        File.Delete(project.PathTo("wwwroot/govuk-frontend.min.js"));
+        File.Delete(project.PathTo("wwwroot/assets/images/favicon.ico"));
+
+        (await project.BuildAsync()).AssertSucceeded();
+
+        project.AssertFileExists("wwwroot/govuk-frontend.min.css");
+        project.AssertFileExists("wwwroot/govuk-frontend.min.js");
+        project.AssertFileExists("wwwroot/assets/images/favicon.ico");
+    }
+
+    private static void AssertBuildInfoForEveryTargetFramework(
+        FixtureProject project,
+        bool enableSupport,
+        string? assetsDirectory,
+        string? javaScriptDirectory,
+        string? stylesheetDirectory)
+    {
+        foreach (var targetFramework in project.TargetFrameworks)
+        {
+            var buildInfo = GeneratedBuildInfo.Read(project, targetFramework);
+
+            Assert.Equal(enableSupport, buildInfo.EnableGovUkFrontendSupport);
+            Assert.Equal(assetsDirectory, buildInfo.AssetsDirectory);
+            Assert.Equal(javaScriptDirectory, buildInfo.JavaScriptDirectory);
+            Assert.Equal(stylesheetDirectory, buildInfo.StylesheetDirectory);
+        }
+    }
+}

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/xunit.runner.json
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "maxParallelThreads": 4,
+  "longRunningTestSeconds": 300
+}


### PR DESCRIPTION
## Why

The package's props and targets are the only part of the library with no test coverage, despite a run of corrective PRs (#463, #510, #511, #513, #514). Everything they do — copying the assets, JavaScript, stylesheet, npm package and Sass support files into a consuming project, and generating `GovUkFrontendBuildInfoAttribute` so `VersionedAssetMiddleware` and `PageTemplateHelper` know where those files ended up — was only exercised by building the samples and the docs app, neither of which asserts anything.

The gap was widest around the packed layout. `Package/content/govuk-frontend/**` only exists at pack time (projected there by `Link` metadata), which is why the docs app has to override `_GovUkFrontendNpmContentDirectory`. Nothing verified that the real package's content lands where the real targets look for it.

## What

A new `tests/GovUk.Frontend.AspNetCore.PackageTests` project that:

1. Packs the actual nupkg into `obj/test-feed` before the tests build.
2. Generates throwaway consuming projects in a temp sandbox — each with its own `Directory.Build.props`, a `NuGet.config` with source mapping, and an isolated `RestorePackagesPath` so the machine's global cache is never touched. Scenario properties go in the project body, where a consumer puts them, since global properties evaluate differently.
3. Builds each fixture for **net8.0, net9.0 and net10.0** in a single invocation.
4. Asserts what was restored where, and reads `GovUkFrontendBuildInfoAttribute` back out of the generated assembly info.
5. Launches the built apps as child processes on an ephemeral port and makes real HTTP requests.

42 tests, about 50 seconds from cold.

### Restore coverage

Web SDK defaults; non-Web-SDK defaults and opt-in; all five `Restore*` options on and off; `EnableGovUkFrontendSupport=false` overriding them; custom directories; Windows-style separators; the deprecated property; the design-time build guard; and self-healing after restored files are deleted.

### Hosting coverage

The hosting tests ask the page template which URLs it emits and then fetch *those*, rather than hard-coding paths — so the assertion is that the URL the library tells you to use is the URL that works, and it keeps testing the real contract as the defaults move. On top of that:

- the immutable `Cache-Control` on a version match, and its absence on a mismatch, on no version, and on a file the targets didn't restore;
- the asset URLs referenced from *inside* the stylesheet, which pins that the restored CSS is the one this repo compiles (with `?v=` appended) rather than the one inside the npm package;
- fingerprinted URLs on net9.0+, which is also what proves the restored files reached the static web assets manifest.

## Two bugs found, pinned rather than fixed

Both are documented in the tests' XML docs so a future reader doesn't "fix" the assertion:

1. **`CopyGovUkFrontendAssetsToWebRoot` is warned about but ignored.** Setting it in a csproj has no effect, because the shim mapping it onto `RestoreGovUkFrontendAssets` lives in the **props** file, which NuGet imports before the project body is evaluated. The deprecation warning still fires, since that lives in the targets — so the build warns about a property it then ignores. The same applies to `GovUkFrontendSupportPackageDirectory` → `RestoreGovUkFrontendSupportPackage` and the `EnableGovUkFrontendSupport` derivations. Paired tests cover the `Directory.Build.props` placement, where the derivation does work.

2. **`PageTemplateHelper` ignores the configured directories.** `GetStylesheetFileName`/`GetJavascriptFileName` build URLs from the file names alone and never consult `BuildInfo.GovUkFrontend*Directory`, so a project with a custom stylesheet or JavaScript directory gets a page template pointing at a 404 unless the caller passes a `pathBase`.

Fixing the first means moving the derivations *and* the defaults they interact with into the targets file, which is a design decision worth making separately.

## Verifying the tests actually catch things

Four regressions were seeded into the targets locally. Three failed loudly:

| Seeded regression | Caught by |
| --- | --- |
| Read the stylesheet from the npm content directory | the `?v=` assertions on the restored CSS and its asset URLs |
| Copy the files after `AssignTargetPaths` | the fingerprinted-URL tests on net9.0/net10.0 |
| Emit the assets directory as a literal parameter | most of the hosting suite |
| Remove the `_CanCopyGovUkFrontendFiles` guard | the design-time build test |

One did **not**: dropping `BeforeTargets="ResolveProjectStaticWebAssets"` still passes, because that SDK target is itself hooked `BeforeTargets="AssignTargetPaths"`. The explicit name is protecting against ordering that is currently undefined but happens to resolve our way — no test can prove the absence of luck there, so it's worth keeping.

## Reviewer notes

- Runs as its own CI job rather than in `build_debug` and `build_release`. The targets don't vary by configuration, and the job packs its own nupkg so it doesn't depend on the other jobs. It's in the `release` job's `needs` so a broken targets file blocks publishing.
- `just package-tests` runs it locally; it's also part of `just test`.
- Set `GOVUK_PACKAGE_TESTS_KEEP_SANDBOX=1` to keep the generated projects around for debugging.
- `xUnit1051` is suppressed, matching the integration tests project.
- Unrelated but worth knowing: MSBuild is inconsistent about normalising backslashes into the generated attribute — the same build emits them verbatim for net8.0 and normalised for net9.0/net10.0. The test compares normalised, the way `VersionedAssetMiddleware` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)