### PR TITLE
Rewrite the README's opening paragraph in plainer language

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 [![Build](https://github.com/x-govuk/govuk-frontend-aspnetcore/actions/workflows/build.yml/badge.svg)](https://github.com/x-govuk/govuk-frontend-aspnetcore/actions/workflows/build.yml)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/GovUk.Frontend.AspNetCore)](https://www.nuget.org/packages/GovUk.Frontend.AspNetCore)
 
-This library simplifies setting up an ASP.NET Core application to use the [GOV.UK Design System](https://design-system.service.gov.uk/).
-It provides tag helpers that integrate seamlessly with ASP.NET Core's model binding, enabling you to build accessible, compliant services quickly.
-All front-end assets—including fonts, images, CSS and JavaScript, are automatically hosted, so you can focus on building your application.
+This library handles two things for you when using the [GOV.UK Design System](https://design-system.service.gov.uk/) in an ASP.NET Core application:
+getting the GOV.UK Frontend assets into your project, and rendering the components.
+The assets are copied in when your project builds, and the components are written as tag helpers that work with your view model.
 
 ```razor
-@* Build a complete form with labels, hints and error handling in just a few lines *@
+@* Labels, hints and error messages come from the model *@
 
 <govuk-input for="EmailAddress">
     <govuk-input-label>Email address</govuk-input-label>

--- a/src/GovUk.Frontend.AspNetCore/Package/README.md
+++ b/src/GovUk.Frontend.AspNetCore/Package/README.md
@@ -1,11 +1,11 @@
 # ASP.NET Core integration for GOV.UK Design System
 
-This library simplifies setting up an ASP.NET Core application to use the [GOV.UK Design System](https://design-system.service.gov.uk/).
-It provides tag helpers that integrate seamlessly with ASP.NET Core's model binding, enabling you to build accessible, compliant services quickly.
-All front-end assets—including fonts, images, CSS and JavaScript, are automatically hosted, so you can focus on building your application.
+This library handles two things for you when using the [GOV.UK Design System](https://design-system.service.gov.uk/) in an ASP.NET Core application:
+getting the GOV.UK Frontend assets into your project, and rendering the components.
+The assets are copied in when your project builds, and the components are written as tag helpers that work with your view model.
 
 ```razor
-@* Build a complete form with labels, hints and error handling in just a few lines *@
+@* Labels, hints and error messages come from the model *@
 
 <govuk-input for="EmailAddress">
     <govuk-input-label>Email address</govuk-input-label>


### PR DESCRIPTION
## What changed

The opening paragraph of the README, and the identical paragraph in the NuGet package README.

Before:

> This library simplifies setting up an ASP.NET Core application to use the GOV.UK Design System. It provides tag helpers that integrate seamlessly with ASP.NET Core's model binding, enabling you to build accessible, compliant services quickly. All front-end assets—including fonts, images, CSS and JavaScript, are automatically hosted, so you can focus on building your application.

After:

> This library handles two things for you when using the GOV.UK Design System in an ASP.NET Core application: getting the GOV.UK Frontend assets into your project, and rendering the components. The assets are copied in when your project builds, and the components are written as tag helpers that work with your view model.

The comment in the code sample below it is changed from "Build a complete form with labels, hints and error handling in just a few lines" to "Labels, hints and error messages come from the model", for the same reason.

## Why

The original read as marketing copy — "integrate seamlessly", "enabling you to build accessible, compliant services quickly", "so you can focus on building your application" — without saying much about what the library actually does. The replacement names the two jobs it does instead.

## For reviewers

Two things I changed on accuracy grounds, beyond tone:

- "All front-end assets ... are automatically hosted" doesn't match the documented default. With `EnableGovUkFrontendSupport` set, assets are copied into `wwwroot` at build time; auto-hosting is the fallback the README already flags as "will be removed in a future version".
- "accessible, compliant" is a property of the Design System rather than something this library delivers, so it's dropped.

Docs only — no code changes.