### PR TITLE
Make the page template follow the restored asset directories

### DIFF
--- a/src/GovUk.Frontend.AspNetCore/GovUkFrontendExtensions.cs
+++ b/src/GovUk.Frontend.AspNetCore/GovUkFrontendExtensions.cs
@@ -3,6 +3,7 @@ using GovUk.Frontend.AspNetCore.Localization;
 using GovUk.Frontend.AspNetCore.ModelBinding;
 using GovUk.Frontend.AspNetCore.TagHelpers;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.Extensions.DependencyInjection;
@@ -50,7 +51,12 @@ public static class GovUkFrontendExtensions
         services.TryAddSingleton<IModelHelper, DefaultModelHelper>();
         services.AddSingleton<IConfigureOptions<MvcOptions>, ConfigureMvcOptions>();
         services.AddSingleton<IConfigureOptions<GovUkFrontendOptions>, ConfigureGovUkFrontendOptions>();
-        services.AddTransient<PageTemplateHelper>();
+        // Resolved through IWebHostEnvironment, which a non-web host won't have; such a host has nothing
+        // to serve the files from either, so the defaults are the right answer there.
+        services.TryAddSingleton(sp => GovUkFrontendPaths.Create(
+            sp.GetService<IWebHostEnvironment>(),
+            sp.GetRequiredService<IOptions<GovUkFrontendOptions>>().Value.BuildInfo));
+        services.AddTransient(sp => new PageTemplateHelper(sp.GetRequiredService<GovUkFrontendPaths>()));
         services.AddSingleton<ITagHelperInitializer<ButtonTagHelper>, ButtonTagHelperInitializer>();
         services.AddSingleton<ITagHelperInitializer<FileUploadTagHelper>, FileUploadTagHelperInitializer>();
         services.AddHttpContextAccessor();

--- a/src/GovUk.Frontend.AspNetCore/GovUkFrontendPaths.cs
+++ b/src/GovUk.Frontend.AspNetCore/GovUkFrontendPaths.cs
@@ -1,0 +1,113 @@
+using Microsoft.AspNetCore.Hosting;
+
+namespace GovUk.Frontend.AspNetCore;
+
+/// <summary>
+/// The URL paths that the files restored by the package's build targets are served from.
+/// </summary>
+/// <remarks>
+/// The targets record the directories they copied into as project-relative paths on
+/// <see cref="GovUkFrontendBuildInfoAttribute"/>. Turning those into URLs means stripping the web root,
+/// since only what's underneath it gets served, and normalising the separators, since the directories
+/// come from MSBuild properties and use whichever separator the project author wrote.
+/// <para>
+/// A <see langword="null"/> here means the build didn't restore that file, which is not the same as it
+/// being at the default location: URL generation falls back to the default, because that's where a
+/// project managing the file itself would be expected to put it, but the versioned asset middleware
+/// treats it as nothing to match, because a file the build didn't produce can't be assumed to change
+/// only when govuk-frontend does.
+/// </para>
+/// <para>
+/// Each non-null value is either empty or rooted, so it can be used as a
+/// <see cref="Microsoft.AspNetCore.Http.PathString"/>.
+/// </para>
+/// </remarks>
+internal sealed class GovUkFrontendPaths
+{
+    /// <summary>Where the library looked before the directories became configurable.</summary>
+    private const string DefaultAssets = "/assets";
+    private const string DefaultCompiledContent = "";
+
+    private GovUkFrontendPaths(string? assets, string? javaScript, string? stylesheet)
+    {
+        Assets = assets;
+        JavaScript = javaScript;
+        Stylesheet = stylesheet;
+    }
+
+    /// <summary>What a project gets when the build restored nothing it knows about.</summary>
+    public static GovUkFrontendPaths None { get; } = new(null, null, null);
+
+    /// <summary>The directory the assets were restored to, or <see langword="null"/> if they weren't.</summary>
+    public string? Assets { get; }
+
+    /// <summary>The directory <c>govuk-frontend.min.js</c> was restored to, or <see langword="null"/>.</summary>
+    public string? JavaScript { get; }
+
+    /// <summary>The directory <c>govuk-frontend.min.css</c> was restored to, or <see langword="null"/>.</summary>
+    public string? Stylesheet { get; }
+
+    /// <summary>The restored <c>govuk-frontend.min.js</c>, or <see langword="null"/> if it wasn't restored.</summary>
+    public string? RestoredJavaScriptFile => JavaScript is null ? null : JavaScript + "/" + PageTemplateHelper.JavascriptFileName;
+
+    /// <summary>The restored <c>govuk-frontend.min.css</c>, or <see langword="null"/> if it wasn't restored.</summary>
+    public string? RestoredStylesheetFile => Stylesheet is null ? null : Stylesheet + "/" + PageTemplateHelper.StylesheetFileName;
+
+    /// <summary>The directory to resolve asset URLs against, falling back to the default.</summary>
+    public string AssetsUrlPath => Assets ?? DefaultAssets;
+
+    /// <summary>The URL path of <c>govuk-frontend.min.js</c>, falling back to the default location.</summary>
+    public string JavaScriptUrlPath => (JavaScript ?? DefaultCompiledContent) + "/" + PageTemplateHelper.JavascriptFileName;
+
+    /// <summary>The URL path of <c>govuk-frontend.min.css</c>, falling back to the default location.</summary>
+    public string StylesheetUrlPath => (Stylesheet ?? DefaultCompiledContent) + "/" + PageTemplateHelper.StylesheetFileName;
+
+    /// <summary>The base path to generate script URLs against, falling back to the default location.</summary>
+    public string JavaScriptUrlBase => JavaScript ?? DefaultCompiledContent;
+
+    /// <summary>The base path to generate stylesheet URLs against, falling back to the default location.</summary>
+    public string StylesheetUrlBase => Stylesheet ?? DefaultCompiledContent;
+
+    public static GovUkFrontendPaths Create(IWebHostEnvironment? environment, GovUkFrontendBuildInfoAttribute? buildInfo)
+    {
+        // A web root outside the content root can't be expressed relative to it, and nothing the targets
+        // copied could be underneath it anyway.
+        if (environment is null ||
+            buildInfo is null ||
+            !environment.WebRootPath.StartsWith(environment.ContentRootPath, StringComparison.Ordinal))
+        {
+            return None;
+        }
+
+        var relativeWebRoot = NormalizeSeparators(Path.GetRelativePath(environment.ContentRootPath, environment.WebRootPath))
+            .TrimEnd('/');
+
+        return new GovUkFrontendPaths(
+            GetPathUnderWebRoot(buildInfo.GovUkFrontendAssetsDirectory),
+            GetPathUnderWebRoot(buildInfo.GovUkFrontendJavaScriptDirectory),
+            GetPathUnderWebRoot(buildInfo.GovUkFrontendStylesheetDirectory));
+
+        string? GetPathUnderWebRoot(string? directory)
+        {
+            if (directory is null)
+            {
+                return null;
+            }
+
+            var normalized = NormalizeSeparators(directory).TrimEnd('/');
+
+            if (!normalized.StartsWith(relativeWebRoot, StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            var underWebRoot = normalized[relativeWebRoot.Length..];
+
+            // Guards against a sibling directory whose name merely starts with the web root's, which would
+            // otherwise produce a path that isn't rooted.
+            return underWebRoot.Length == 0 || underWebRoot.StartsWith('/') ? underWebRoot : null;
+        }
+    }
+
+    private static string NormalizeSeparators(string path) => path.Replace('\\', '/');
+}

--- a/src/GovUk.Frontend.AspNetCore/PageTemplateHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/PageTemplateHelper.cs
@@ -21,15 +21,37 @@ public class PageTemplateHelper
 
     private const string JsEnabledScript = "document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');";
 
+    private readonly GovUkFrontendPaths _paths;
+
+    /// <summary>
+    /// Creates a new <see cref="PageTemplateHelper"/> that generates URLs for the default locations.
+    /// </summary>
+    /// <remarks>
+    /// Resolve this from the service provider instead wherever possible; an instance created this way
+    /// has no way of knowing where the build restored the files to, so it always assumes the defaults.
+    /// </remarks>
+    public PageTemplateHelper() : this(GovUkFrontendPaths.None)
+    {
+    }
+
+    internal PageTemplateHelper(GovUkFrontendPaths paths)
+    {
+        ArgumentNullException.ThrowIfNull(paths);
+
+        _paths = paths;
+    }
+
     /// <summary>
     /// Gets the version of the GOV.UK Frontend library.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static string GovUkFrontendVersion => GovUkFrontendInfo.Version;
 
-    internal static PathString DefaultAssetsPath => new("/assets");
-
-    internal static PathString DefaultCompiledContentPath => new("");
+    /// <summary>
+    /// The directory the govuk-frontend assets are served from, which is where the page template's head
+    /// icons are resolved against unless a view overrides it.
+    /// </summary>
+    internal PathString AssetsPath => new(_paths.AssetsUrlPath);
 
     /// <summary>
     /// Generates the script that adds a <c>js-enabled</c> CSS class.
@@ -72,7 +94,7 @@ public class PageTemplateHelper
     /// <param name="cspNonce">The CSP nonce attribute to be added to the generated <c>script</c> tag.</param>
     /// <returns><see cref="IHtmlContent"/> containing the <c>script</c> tag.</returns>
     public IHtmlContent GenerateScriptImports(string? cspNonce = null) =>
-        GenerateScriptImports(pathBase: DefaultCompiledContentPath, cspNonce);
+        GenerateScriptImports(pathBase: _paths.JavaScriptUrlBase, cspNonce);
 
     /// <summary>
     /// Generates the script that adds a <c>js-enabled</c> CSS class.
@@ -123,7 +145,7 @@ public class PageTemplateHelper
     /// The contents of this property should be inserted in the <c>head</c> tag.
     /// </remarks>
     /// <returns><see cref="IHtmlContent"/> containing the <c>link</c> tags.</returns>
-    public IHtmlContent GenerateStyleImports() => GenerateStyleImports(pathBase: DefaultCompiledContentPath);
+    public IHtmlContent GenerateStyleImports() => GenerateStyleImports(pathBase: _paths.StylesheetUrlBase);
 
     /// <summary>
     /// Generates the HTML that imports the GOV.UK Frontend library styles.
@@ -159,7 +181,7 @@ public class PageTemplateHelper
     /// Gets all the CSP hashes for the inline scripts used in the page template.
     /// </summary>
     /// <returns>A list of hashes to be included in your site's <c>Content-Security-Policy</c> header within the <c>script-src</c> directive.</returns>
-    public string GetCspScriptHashes() => GetCspScriptHashes(pathBase: "");
+    public string GetCspScriptHashes() => GetCspScriptHashes(pathBase: _paths.JavaScriptUrlBase);
 
     /// <summary>
     /// Gets all the CSP hashes for the inline scripts used in the page template.
@@ -185,7 +207,7 @@ public class PageTemplateHelper
     /// Gets the CSP hash for the GOV.UK Frontend initialization script.
     /// </summary>
     /// <returns>A hash to be included in your site's <c>Content-Security-Policy</c> header within the <c>script-src</c> directive.</returns>
-    public string GetInitScriptCspHash() => GetInitScriptCspHash(pathBase: "");
+    public string GetInitScriptCspHash() => GetInitScriptCspHash(pathBase: _paths.JavaScriptUrlBase);
 
     /// <summary>
     /// Gets the CSP hash for the GOV.UK Frontend initialization script.
@@ -207,7 +229,7 @@ public class PageTemplateHelper
     {
         ArgumentNullException.ThrowIfNull(httpContext);
 
-        var scriptPath = ResolveContentUrl(httpContext, JavascriptFileName);
+        var scriptPath = ResolveContentUrl(httpContext, _paths.JavaScriptUrlPath);
         return GenerateCspHash(GetInitScriptContents(scriptPath));
     }
 
@@ -228,7 +250,7 @@ public class PageTemplateHelper
     {
         ArgumentNullException.ThrowIfNull(httpContext);
 
-        return ResolveContentUrl(httpContext, JavascriptFileName);
+        return ResolveContentUrl(httpContext, _paths.JavaScriptUrlPath);
     }
 
     /// <summary>
@@ -248,7 +270,7 @@ public class PageTemplateHelper
     {
         ArgumentNullException.ThrowIfNull(httpContext);
 
-        return ResolveContentUrl(httpContext, StylesheetFileName);
+        return ResolveContentUrl(httpContext, _paths.StylesheetUrlPath);
     }
 
     internal string ResolveContentUrl(HttpContext httpContext, string path)

--- a/src/GovUk.Frontend.AspNetCore/VersionedAssetMiddleware.cs
+++ b/src/GovUk.Frontend.AspNetCore/VersionedAssetMiddleware.cs
@@ -1,7 +1,4 @@
-using System.Diagnostics;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Options;
 
 namespace GovUk.Frontend.AspNetCore;
 
@@ -15,57 +12,17 @@ internal class VersionedAssetMiddleware : IMiddleware
     private readonly PathString? _stylesheetPath;
     private readonly PathString? _javascriptPath;
 
-    public VersionedAssetMiddleware(
-        IWebHostEnvironment environment,
-        IOptions<GovUkFrontendOptions> optionsAccessor)
+    // Only the files the build actually restored are marked immutable. A file the project manages itself
+    // can sit at the same URL and change without the govuk-frontend version changing, so it must not pick
+    // up a year-long cache just because the request happens to carry a matching version.
+    public VersionedAssetMiddleware(GovUkFrontendPaths paths)
     {
-        ArgumentNullException.ThrowIfNull(environment);
-        ArgumentNullException.ThrowIfNull(optionsAccessor);
+        ArgumentNullException.ThrowIfNull(paths);
 
-        if (!environment.WebRootPath.StartsWith(environment.ContentRootPath, StringComparison.Ordinal))
-        {
-            return;
-        }
-
-        var relativeWebRoot = NormalizeSeparators(Path.GetRelativePath(environment.ContentRootPath, environment.WebRootPath));
-
-        var buildInfo = optionsAccessor.Value.BuildInfo;
-
-        Debug.Assert(buildInfo?.EnableGovUkFrontendSupport is true);
-
-        if (GetPathUnderWebRoot(buildInfo?.GovUkFrontendAssetsDirectory) is { } assetDirectory)
-        {
-            _staticAssetsDirectory = assetDirectory;
-        }
-
-        if (GetPathUnderWebRoot(buildInfo?.GovUkFrontendJavaScriptDirectory) is { } jsDirectory)
-        {
-            _javascriptPath = jsDirectory + "/" + PageTemplateHelper.JavascriptFileName;
-        }
-
-        if (GetPathUnderWebRoot(buildInfo?.GovUkFrontendStylesheetDirectory) is { } cssDirectory)
-        {
-            _stylesheetPath = cssDirectory + "/" + PageTemplateHelper.StylesheetFileName;
-        }
-
-        // The directories come from MSBuild properties so they use whichever separator the project author
-        // wrote (the defaults use '\'); PathString only accepts '/'.
-        string? GetPathUnderWebRoot(string? directory)
-        {
-            if (directory is null)
-            {
-                return null;
-            }
-
-            var normalized = NormalizeSeparators(directory);
-
-            return normalized.StartsWith(relativeWebRoot, StringComparison.Ordinal)
-                ? normalized[relativeWebRoot.Length..].TrimEnd('/')
-                : null;
-        }
+        _staticAssetsDirectory = paths.Assets is { } assets ? new PathString(assets) : null;
+        _javascriptPath = paths.RestoredJavaScriptFile is { } javaScript ? new PathString(javaScript) : null;
+        _stylesheetPath = paths.RestoredStylesheetFile is { } stylesheet ? new PathString(stylesheet) : null;
     }
-
-    private static string NormalizeSeparators(string path) => path.Replace('\\', '/');
 
     public async Task InvokeAsync(HttpContext context, RequestDelegate next)
     {

--- a/src/GovUk.Frontend.AspNetCore/Views/Shared/_GovUkPageTemplate.cshtml
+++ b/src/GovUk.Frontend.AspNetCore/Views/Shared/_GovUkPageTemplate.cshtml
@@ -73,7 +73,7 @@
 
     string GetStaticAssetUrl(string path)
     {
-        var assetPath = ViewData[ViewDataKeys.AssetPath] as PathString? ?? PageTemplateHelper.DefaultAssetsPath;
+        var assetPath = ViewData[ViewDataKeys.AssetPath] as PathString? ?? PageTemplateHelper.AssetsPath;
         var fullPath = assetPath + "/" + path;
         return PageTemplateHelper.ResolveContentUrl(ViewContext.HttpContext, fullPath);
     }

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/Fixtures/WebApp/Pages/Index.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/Fixtures/WebApp/Pages/Index.cshtml
@@ -1,6 +1,8 @@
 @page
+@using GovUk.Frontend.AspNetCore
 @using Microsoft.AspNetCore.Http
 @using static GovUk.Frontend.AspNetCore.Views.GovUkPageTemplateConstants
+@inject PageTemplateHelper PageTemplateHelper
 @{
     // The library's own page template, so the URLs under test are the ones a real consumer's pages
     // would emit: the stylesheet, the script imports and the head icons that live under the assets
@@ -16,3 +18,7 @@
 }
 
 <p class="govuk-body">Package test app</p>
+
+@* So a test can check the hashes still cover the scripts the page template actually emitted. *@
+<meta name="csp-script-hashes" content="@PageTemplateHelper.GetCspScriptHashes(ViewContext.HttpContext)">
+

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/HostingTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/HostingTests.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.RegularExpressions;
 using GovUk.Frontend.AspNetCore.PackageTests.Infrastructure;
 
@@ -128,6 +130,25 @@ public partial class HostingTests(DefaultConfigurationAppFixture fixture, Packag
         }
     }
 
+    /// <summary>
+    /// The init script embeds the URL of the JavaScript file, so the CSP hash and the emitted script have
+    /// to be built from the same URL. A page whose hash doesn't cover its own script is one that a strict
+    /// Content-Security-Policy would block.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(TargetFrameworks))]
+    public async Task TheCspHashesCoverTheScriptThePageActuallyEmitted(string targetFramework)
+    {
+        await using var app = await fixture.StartAsync(targetFramework);
+
+        var page = await HostedPage.GetAsync(app);
+
+        Assert.Contains(Sha256CspHash(page.InlineInitScript), page.CspScriptHashes, StringComparison.Ordinal);
+    }
+
+    internal static string Sha256CspHash(string value) =>
+        $"'sha256-{Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(value)))}'";
+
     private static IEnumerable<string> RestoredFilePaths() =>
     [
         "/govuk-frontend.min.css",
@@ -215,39 +236,56 @@ public class CustomDirectoryHostingTests(CustomDirectoryAppFixture fixture, Pack
     }
 
     /// <summary>
-    /// Pins a known gap: <c>PageTemplateHelper</c> builds its URLs from the file names alone and never
-    /// consults the directories in the build info, so moving the stylesheet or the script leaves the page
-    /// template pointing at a URL that isn't there. Callers have to pass a <c>pathBase</c> themselves.
+    /// The page template has to follow the directories the build restored into, or a project that moves
+    /// them gets a page pointing at URLs that aren't there.
     /// </summary>
     [Theory]
     [MemberData(nameof(TargetFrameworks))]
-    public async Task ThePageTemplateStillAdvertisesTheDefaultUrls(string targetFramework)
+    public async Task ThePageTemplateAdvertisesTheCustomDirectoryUrlsAndTheyAreServed(string targetFramework)
     {
         await using var app = await fixture.StartAsync(targetFramework);
 
         var page = await HostedPage.GetAsync(app);
 
-        Assert.StartsWith("/govuk-frontend.min.css", page.Stylesheet, StringComparison.Ordinal);
-        Assert.StartsWith("/govuk-frontend.min.js", page.Script, StringComparison.Ordinal);
+        Assert.StartsWith("/govuk/govuk-frontend.min", page.Stylesheet, StringComparison.Ordinal);
+        Assert.StartsWith("/govuk/govuk-frontend.min", page.Script, StringComparison.Ordinal);
+        Assert.StartsWith("/govuk/assets/", page.FavIcon, StringComparison.Ordinal);
+        Assert.StartsWith("/govuk/assets/", page.Manifest, StringComparison.Ordinal);
 
-        using var stylesheet = await app.Client.GetAsync(page.Stylesheet);
-        Assert.Equal(HttpStatusCode.NotFound, stylesheet.StatusCode);
+        await HostingTests.AssertServedAsync(app, page.Stylesheet, "text/css");
+        await HostingTests.AssertServedAsync(app, page.Script, "text/javascript");
+        await HostingTests.AssertServedAsync(app, page.FavIcon, expectedContentType: null);
+        await HostingTests.AssertServedAsync(app, page.Manifest, expectedContentType: null);
     }
 
     /// <summary>
-    /// The assets path is configurable through view data, so the head icons can be pointed at the moved
-    /// directory even though the stylesheet and script can't.
+    /// Where it matters most: the init script embeds the JavaScript URL, so if only one of the hash and
+    /// the script picked up the custom directory they'd disagree.
     /// </summary>
     [Theory]
     [MemberData(nameof(TargetFrameworks))]
-    public async Task TheHeadIconsFollowTheConfiguredAssetPath(string targetFramework)
+    public async Task TheCspHashesCoverTheScriptThePageActuallyEmitted(string targetFramework)
     {
         await using var app = await fixture.StartAsync(targetFramework);
 
-        var page = await HostedPage.GetAsync(app, "/?assetPath=/govuk/assets");
+        var page = await HostedPage.GetAsync(app);
 
-        Assert.StartsWith("/govuk/assets/", page.FavIcon, StringComparison.Ordinal);
+        Assert.Contains("/govuk/govuk-frontend.min", page.InlineInitScript, StringComparison.Ordinal);
+        Assert.Contains(HostingTests.Sha256CspHash(page.InlineInitScript), page.CspScriptHashes, StringComparison.Ordinal);
+    }
 
-        await HostingTests.AssertServedAsync(app, page.FavIcon, expectedContentType: null);
+    /// <summary>
+    /// A view can still point the head icons somewhere else, which is what the assets path view data key
+    /// is for.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(TargetFrameworks))]
+    public async Task TheHeadIconsFollowTheAssetPathViewDataKeyWhenItIsSet(string targetFramework)
+    {
+        await using var app = await fixture.StartAsync(targetFramework);
+
+        var page = await HostedPage.GetAsync(app, "/?assetPath=/somewhere-else");
+
+        Assert.StartsWith("/somewhere-else/", page.FavIcon, StringComparison.Ordinal);
     }
 }

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/Infrastructure/HostedPage.cs
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/Infrastructure/HostedPage.cs
@@ -7,7 +7,13 @@ namespace GovUk.Frontend.AspNetCore.PackageTests.Infrastructure;
 /// <summary>
 /// The URLs the library's page template advertises for the files the targets restored.
 /// </summary>
-public sealed record HostedPage(string Stylesheet, string Script, string FavIcon, string Manifest)
+public sealed record HostedPage(
+    string Stylesheet,
+    string Script,
+    string FavIcon,
+    string Manifest,
+    string CspScriptHashes,
+    string InlineInitScript)
 {
     public static async Task<HostedPage> GetAsync(FixtureApp app, string path = "/")
     {
@@ -21,11 +27,19 @@ public sealed record HostedPage(string Stylesheet, string Script, string FavIcon
         await using var content = await response.Content.ReadAsStreamAsync();
         var document = (IHtmlDocument)await new HtmlParser().ParseDocumentAsync(content);
 
+        // The page template emits the import as a module with a src and the initAll call as an inline
+        // module alongside it.
+        var inlineInitScript = document.QuerySelector("script[type=module]:not([src])")?.TextContent ??
+            throw new InvalidOperationException(
+                $"No inline module script found.{Environment.NewLine}{document.DocumentElement.OuterHtml}");
+
         return new HostedPage(
             Attribute(document, "link[rel=stylesheet]", "href"),
             Attribute(document, "script[type=module][src]", "src"),
             Attribute(document, "link[rel=icon][sizes='48x48']", "href"),
-            Attribute(document, "link[rel=manifest]", "href"));
+            Attribute(document, "link[rel=manifest]", "href"),
+            Attribute(document, "meta[name=csp-script-hashes]", "content"),
+            inlineInitScript);
 
         static string Attribute(IHtmlDocument document, string selector, string attributeName)
         {

--- a/tests/GovUk.Frontend.AspNetCore.Tests/GovUkFrontendPathsTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/GovUkFrontendPathsTests.cs
@@ -1,0 +1,162 @@
+namespace GovUk.Frontend.AspNetCore.Tests;
+
+public class GovUkFrontendPathsTests
+{
+    [Fact]
+    public void Create_WithTheDefaultDirectories_MapsThemToTheDefaultUrls()
+    {
+        // Arrange
+        var buildInfo = new GovUkFrontendBuildInfoAttribute(true, "wwwroot/assets", "wwwroot", "wwwroot");
+
+        // Act
+        var paths = GovUkFrontendPaths.Create(CreateEnvironment(), buildInfo);
+
+        // Assert
+        Assert.Equal("/assets", paths.Assets);
+        Assert.Equal("", paths.JavaScript);
+        Assert.Equal("", paths.Stylesheet);
+        Assert.Equal("/govuk-frontend.min.js", paths.JavaScriptUrlPath);
+        Assert.Equal("/govuk-frontend.min.css", paths.StylesheetUrlPath);
+    }
+
+    [Fact]
+    public void Create_WithCustomDirectories_MapsThemRelativeToTheWebRoot()
+    {
+        // Arrange
+        var buildInfo = new GovUkFrontendBuildInfoAttribute(true, "wwwroot/govuk/assets", "wwwroot/govuk", "wwwroot/govuk");
+
+        // Act
+        var paths = GovUkFrontendPaths.Create(CreateEnvironment(), buildInfo);
+
+        // Assert
+        Assert.Equal("/govuk/assets", paths.Assets);
+        Assert.Equal("/govuk/govuk-frontend.min.js", paths.JavaScriptUrlPath);
+        Assert.Equal("/govuk/govuk-frontend.min.css", paths.StylesheetUrlPath);
+    }
+
+    [Fact]
+    public void Create_WithWindowsStyleSeparators_NormalizesThem()
+    {
+        // Arrange
+        var buildInfo = new GovUkFrontendBuildInfoAttribute(true, @"wwwroot\govuk\assets", @"wwwroot\govuk", @"wwwroot\govuk");
+
+        // Act
+        var paths = GovUkFrontendPaths.Create(CreateEnvironment(), buildInfo);
+
+        // Assert
+        Assert.Equal("/govuk/assets", paths.Assets);
+        Assert.Equal("/govuk", paths.JavaScript);
+        Assert.Equal("/govuk", paths.Stylesheet);
+    }
+
+    [Fact]
+    public void Create_WithANonDefaultWebRoot_StripsThatInstead()
+    {
+        // Arrange
+        var environment = CreateEnvironment(webRoot: "/app/public");
+        var buildInfo = new GovUkFrontendBuildInfoAttribute(true, "public/assets", "public", "public");
+
+        // Act
+        var paths = GovUkFrontendPaths.Create(environment, buildInfo);
+
+        // Assert
+        Assert.Equal("/assets", paths.Assets);
+        Assert.Equal("", paths.Stylesheet);
+    }
+
+    [Fact]
+    public void Create_WithADirectoryOutsideTheWebRoot_ReportsNoPath()
+    {
+        // Arrange - nothing outside the web root gets served, so there is no URL for it
+        var buildInfo = new GovUkFrontendBuildInfoAttribute(true, "lib/assets", "lib", "lib");
+
+        // Act
+        var paths = GovUkFrontendPaths.Create(CreateEnvironment(), buildInfo);
+
+        // Assert
+        Assert.Null(paths.Assets);
+        Assert.Null(paths.JavaScript);
+        Assert.Null(paths.Stylesheet);
+    }
+
+    [Fact]
+    public void Create_WithASiblingDirectoryWhoseNameStartsWithTheWebRoot_ReportsNoPath()
+    {
+        // Arrange
+        var buildInfo = new GovUkFrontendBuildInfoAttribute(true, "wwwrootstuff/assets", "wwwrootstuff", "wwwrootstuff");
+
+        // Act
+        var paths = GovUkFrontendPaths.Create(CreateEnvironment(), buildInfo);
+
+        // Assert
+        Assert.Null(paths.Assets);
+        Assert.Null(paths.JavaScript);
+        Assert.Null(paths.Stylesheet);
+    }
+
+    [Fact]
+    public void Create_WithAWebRootOutsideTheContentRoot_ReportsNoPaths()
+    {
+        // Arrange
+        var environment = CreateEnvironment(contentRoot: "/app", webRoot: "/var/www");
+        var buildInfo = new GovUkFrontendBuildInfoAttribute(true, "wwwroot/assets", "wwwroot", "wwwroot");
+
+        // Act
+        var paths = GovUkFrontendPaths.Create(environment, buildInfo);
+
+        // Assert
+        Assert.Null(paths.Assets);
+    }
+
+    [Fact]
+    public void Create_WithNoBuildInfo_ReportsNoPaths()
+    {
+        // Act
+        var paths = GovUkFrontendPaths.Create(CreateEnvironment(), buildInfo: null);
+
+        // Assert
+        Assert.Null(paths.Assets);
+        Assert.Null(paths.JavaScript);
+        Assert.Null(paths.Stylesheet);
+    }
+
+    [Fact]
+    public void Create_WithNoEnvironment_ReportsNoPaths()
+    {
+        // Arrange
+        var buildInfo = new GovUkFrontendBuildInfoAttribute(true, "wwwroot/assets", "wwwroot", "wwwroot");
+
+        // Act
+        var paths = GovUkFrontendPaths.Create(environment: null, buildInfo);
+
+        // Assert
+        Assert.Null(paths.Assets);
+    }
+
+    /// <summary>
+    /// A file the build didn't restore still has to get a URL, since the project may be managing it
+    /// itself; what it doesn't get is a claim that the build put it there.
+    /// </summary>
+    [Fact]
+    public void UrlPaths_WhenNothingWasRestored_FallBackToTheDefaults()
+    {
+        // Act
+        var paths = GovUkFrontendPaths.None;
+
+        // Assert
+        Assert.Equal("/assets", paths.AssetsUrlPath);
+        Assert.Equal("/govuk-frontend.min.js", paths.JavaScriptUrlPath);
+        Assert.Equal("/govuk-frontend.min.css", paths.StylesheetUrlPath);
+
+        Assert.Null(paths.RestoredJavaScriptFile);
+        Assert.Null(paths.RestoredStylesheetFile);
+    }
+
+    private static IWebHostEnvironment CreateEnvironment(string contentRoot = "/app", string? webRoot = null)
+    {
+        var environment = new Mock<IWebHostEnvironment>();
+        environment.SetupGet(e => e.ContentRootPath).Returns(contentRoot);
+        environment.SetupGet(e => e.WebRootPath).Returns(webRoot ?? Path.Combine(contentRoot, "wwwroot"));
+        return environment.Object;
+    }
+}


### PR DESCRIPTION
## The bug

`PageTemplateHelper` builds its URLs from the file names alone and never consults the directories recorded on `GovUkFrontendBuildInfoAttribute`. So a project that sets `GovUkFrontendStylesheetDirectory` or `GovUkFrontendJavaScriptDirectory` gets a page template pointing at `/govuk-frontend.min.css` and `/govuk-frontend.min.js` — which 404, because the build restored the files somewhere else. The head icons had the same problem, resolving against a hard-coded `/assets`.

`VersionedAssetMiddleware` *did* know where the files went — it has to, to decide what gets the immutable cache header — so the information was already in the process, just not shared. The only workaround was for the caller to pass a `pathBase` to every generate method.

Found by the package tests in #516, which pinned the behaviour as a known gap.

## The fix

The web-root-relative mapping (strip the web root, normalise the separators) moves out of `VersionedAssetMiddleware` into a `GovUkFrontendPaths` type that both it and `PageTemplateHelper` share.

**The important part is what didn't get collapsed.** The middleware distinguishes two cases and the fix has to preserve that:

- a directory that resolves to a path → the build restored the file there;
- `null` → the build didn't restore that file at all.

Those are *not* the same as "it's at the default location". So `GovUkFrontendPaths` exposes both readings: URL generation falls back to the default (a project managing the file itself would put it there, and that's where the library has always pointed), while the middleware keeps treating `null` as nothing to match. Otherwise a project with `RestoreGovUkFrontendStylesheet=false` serving its own compiled CSS from `/govuk-frontend.min.css` would start getting a one-year immutable cache on a file that changes whenever its Sass does, without the govuk-frontend version moving. `Samples.Sass` in this repo is exactly that project.

I got this wrong on the first pass and had to walk it back, so it's flagged in the code comments as well.

## API surface

- `PageTemplateHelper`'s public parameterless constructor stays and still generates the default URLs, so anything doing `new PageTemplateHelper()` keeps compiling and behaving as before. The real paths arrive through a new internal constructor, and the DI registration now uses a factory to call it.
- `GovUkFrontendPaths` is internal.
- `VersionedAssetMiddleware` no longer takes `IWebHostEnvironment`/`IOptions` directly.

## Behaviour changes

- A project with custom stylesheet/JavaScript/assets directories now gets working URLs from the page template. That's the fix.
- Such a project previously had to pass a `pathBase` to work around this. Those calls still work — the explicit `pathBase` overloads are untouched — but they're now redundant, and a `pathBase` that duplicates the configured directory would double it up. Worth a release note.
- A project with defaults sees no change: the stylesheet and script directories map to an empty prefix and the assets to `/assets`, exactly as before.

## Tests

- `GovUkFrontendPathsTests` covers the mapping directly: defaults, custom directories, backslashes, a non-default web root, a directory outside the web root, a sibling directory whose name merely starts with the web root's (`wwwrootstuff`, which used to produce an unrooted path and throw), a web root outside the content root, and the null-build-info and null-environment cases.
- The package test that pinned the old behaviour now asserts the page template's URLs are the custom ones and that they're served.
- New: `TheCspHashesCoverTheScriptThePageActuallyEmitted`, in both the default and custom-directory classes. The init script embeds the JavaScript URL, so if only one of the hash and the script picked up the custom directory they'd disagree and a strict CSP would block the page. Verified by seeding that exact mismatch — the custom-directory copy of the test goes red, the default one can't, which is why it's in both.

Rebased onto `main` now that #516 and #517 have merged. Re-verified against that combined state: 49 package tests, 1697 unit tests, 77 integration tests across all three TFMs, plus `just build-samples` and a docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)