### PR TITLE
Add a base class for the fieldset legend tag helpers

### DIFF
--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesFieldsetLegendTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesFieldsetLegendTagHelper.cs
@@ -1,4 +1,3 @@
-using GovUk.Frontend.AspNetCore.ComponentGeneration;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.TagHelpers;
@@ -9,44 +8,14 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 [HtmlTargetElement(TagName, ParentTag = CheckboxesFieldsetTagHelper.TagName)]
 [HtmlTargetElement(TagName, ParentTag = CheckboxesTagHelper.TagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the legend. When this element is specified directly inside the root checkboxes element a fieldset is generated automatically.")]
-public class CheckboxesFieldsetLegendTagHelper : TagHelper
+public class CheckboxesFieldsetLegendTagHelper : FormGroupFieldsetLegendTagHelperBase
 {
     internal const string TagName = "govuk-checkboxes-fieldset-legend";
 
-    private const string IsPageHeadingAttributeName = "is-page-heading";
-
     /// <summary>
-    /// Whether the legend also acts as the heading for the page.
+    /// Creates a <see cref="CheckboxesFieldsetLegendTagHelper"/>.
     /// </summary>
-    /// <remarks>
-    /// The default is <c>false</c>.
-    /// </remarks>
-    [HtmlAttributeName(IsPageHeadingAttributeName)]
-    public bool? IsPageHeading { get; set; }
-
-    /// <inheritdoc/>
-    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    public CheckboxesFieldsetLegendTagHelper()
     {
-        ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(output);
-
-        var fieldsetContext = context.GetContextItem<FormGroupFieldsetContext2>();
-
-        var content = output.TagMode == TagMode.StartTagAndEndTag ?
-            await output.GetChildContentAsync() :
-            null;
-
-        if (output.Content.IsModified)
-        {
-            content = output.Content;
-        }
-
-        fieldsetContext.SetLegend(
-            IsPageHeading,
-            new AttributeCollection(output.Attributes),
-            html: content.Snapshot(),
-            TagName);
-
-        output.SuppressOutput();
     }
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputFieldsetLegendTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputFieldsetLegendTagHelper.cs
@@ -1,4 +1,3 @@
-using GovUk.Frontend.AspNetCore.ComponentGeneration;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.TagHelpers;
@@ -9,44 +8,14 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 [HtmlTargetElement(TagName, ParentTag = DateInputFieldsetTagHelper.TagName)]
 [HtmlTargetElement(TagName, ParentTag = DateInputTagHelper.TagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the legend. When this element is specified directly inside the root date input element a fieldset is generated automatically.")]
-public class DateInputFieldsetLegendTagHelper : TagHelper
+public class DateInputFieldsetLegendTagHelper : FormGroupFieldsetLegendTagHelperBase
 {
     internal const string TagName = "govuk-date-input-fieldset-legend";
 
-    private const string IsPageHeadingAttributeName = "is-page-heading";
-
     /// <summary>
-    /// Whether the legend also acts as the heading for the page.
+    /// Creates a <see cref="DateInputFieldsetLegendTagHelper"/>.
     /// </summary>
-    /// <remarks>
-    /// The default is <c>false</c>.
-    /// </remarks>
-    [HtmlAttributeName(IsPageHeadingAttributeName)]
-    public bool? IsPageHeading { get; set; }
-
-    /// <inheritdoc/>
-    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    public DateInputFieldsetLegendTagHelper()
     {
-        ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(output);
-
-        var fieldsetContext = context.GetContextItem<FormGroupFieldsetContext2>();
-
-        var content = output.TagMode == TagMode.StartTagAndEndTag ?
-            await output.GetChildContentAsync() :
-            null;
-
-        if (output.Content.IsModified)
-        {
-            content = output.Content;
-        }
-
-        fieldsetContext.SetLegend(
-            IsPageHeading,
-            new AttributeCollection(output.Attributes),
-            html: content?.Snapshot(),
-            TagName);
-
-        output.SuppressOutput();
     }
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupFieldsetLegendTagHelperBase.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupFieldsetLegendTagHelperBase.cs
@@ -1,0 +1,51 @@
+using GovUk.Frontend.AspNetCore.ComponentGeneration;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace GovUk.Frontend.AspNetCore.TagHelpers;
+
+/// <summary>
+/// Represents the legend in a GDS form component's fieldset.
+/// </summary>
+public abstract class FormGroupFieldsetLegendTagHelperBase : TagHelper
+{
+    private const string IsPageHeadingAttributeName = "is-page-heading";
+
+    private protected FormGroupFieldsetLegendTagHelperBase()
+    {
+    }
+
+    /// <summary>
+    /// Whether the legend also acts as the heading for the page.
+    /// </summary>
+    /// <remarks>
+    /// The default is <c>false</c>.
+    /// </remarks>
+    [HtmlAttributeName(IsPageHeadingAttributeName)]
+    public bool? IsPageHeading { get; set; }
+
+    /// <inheritdoc/>
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(output);
+
+        var fieldsetContext = context.GetContextItem<FormGroupFieldsetContext2>();
+
+        var content = output.TagMode == TagMode.StartTagAndEndTag ?
+            await output.GetChildContentAsync() :
+            null;
+
+        if (output.Content.IsModified)
+        {
+            content = output.Content;
+        }
+
+        fieldsetContext.SetLegend(
+            IsPageHeading,
+            new AttributeCollection(output.Attributes),
+            html: content?.Snapshot(),
+            context.TagName);
+
+        output.SuppressOutput();
+    }
+}

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/RadiosFieldsetLegendTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/RadiosFieldsetLegendTagHelper.cs
@@ -1,4 +1,3 @@
-using GovUk.Frontend.AspNetCore.ComponentGeneration;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.TagHelpers;
@@ -9,44 +8,14 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 [HtmlTargetElement(TagName, ParentTag = RadiosFieldsetTagHelper.TagName)]
 [HtmlTargetElement(TagName, ParentTag = RadiosTagHelper.TagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the legend. When this element is specified directly inside the root radios element a fieldset is generated automatically.")]
-public class RadiosFieldsetLegendTagHelper : TagHelper
+public class RadiosFieldsetLegendTagHelper : FormGroupFieldsetLegendTagHelperBase
 {
     internal const string TagName = "govuk-radios-fieldset-legend";
 
-    private const string IsPageHeadingAttributeName = "is-page-heading";
-
     /// <summary>
-    /// Whether the legend also acts as the heading for the page.
+    /// Creates a <see cref="RadiosFieldsetLegendTagHelper"/>.
     /// </summary>
-    /// <remarks>
-    /// The default is <c>false</c>.
-    /// </remarks>
-    [HtmlAttributeName(IsPageHeadingAttributeName)]
-    public bool? IsPageHeading { get; set; }
-
-    /// <inheritdoc/>
-    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    public RadiosFieldsetLegendTagHelper()
     {
-        ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(output);
-
-        var fieldsetContext = context.GetContextItem<FormGroupFieldsetContext2>();
-
-        var content = output.TagMode == TagMode.StartTagAndEndTag ?
-            await output.GetChildContentAsync() :
-            null;
-
-        if (output.Content.IsModified)
-        {
-            content = output.Content;
-        }
-
-        fieldsetContext.SetLegend(
-            IsPageHeading,
-            new AttributeCollection(output.Attributes),
-            html: content.Snapshot(),
-            TagName);
-
-        output.SuppressOutput();
     }
 }


### PR DESCRIPTION
The date input, checkboxes and radios legend tag helpers each carried their own copy of the same `ProcessAsync`, so they now derive from `FormGroupFieldsetLegendTagHelperBase`, alongside the existing label, hint and error message bases. Each subclass keeps only its target elements, its tag name and its documentation.

Two behaviour details worth a look in review:

- The base passes `context.TagName` to `SetLegend` rather than the tag name constant, matching the sibling bases. It is the same value today; it means the duplicate legend error will name whichever element was actually used once short tag names exist.
- The base snapshots the content with a null check, which the date input version already did. A self-closing `<govuk-checkboxes-fieldset-legend />` or `<govuk-radios-fieldset-legend />` used to throw a `NullReferenceException`; it now sets a legend with no HTML, falling back to the model display name.

No short tag name is added for the legend element here — that belongs with the rest of that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)