### PR TITLE
Add a base class for the item conditional tag helpers

### DIFF
--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesItemConditionalTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesItemConditionalTagHelper.cs
@@ -1,4 +1,3 @@
-using GovUk.Frontend.AspNetCore.ComponentGeneration;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.TagHelpers;
@@ -8,35 +7,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = CheckboxesItemTagHelper.TagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the conditional reveal for the item.")]
-public class CheckboxesItemConditionalTagHelper : TagHelper
+public class CheckboxesItemConditionalTagHelper : FormGroupItemConditionalTagHelperBase
 {
     internal const string TagName = "govuk-checkboxes-item-conditional";
-
-    /// <inheritdoc/>
-    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
-    {
-        ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(output);
-
-        var itemContext = context.GetContextItem<CheckboxesItemContext>();
-
-        var content = await output.GetChildContentAsync();
-
-        if (output.Content.IsModified)
-        {
-            content = output.Content;
-        }
-
-        var attributes = new AttributeCollection(output.Attributes);
-
-        var conditionalOptions = new CheckboxesOptionsItemConditional
-        {
-            Attributes = attributes,
-            Html = content.Snapshot()
-        };
-
-        itemContext.SetConditional(conditionalOptions, context.TagName);
-
-        output.SuppressOutput();
-    }
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesItemContext.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesItemContext.cs
@@ -2,45 +2,16 @@ using GovUk.Frontend.AspNetCore.ComponentGeneration;
 
 namespace GovUk.Frontend.AspNetCore.TagHelpers;
 
-internal class CheckboxesItemContext
+internal class CheckboxesItemContext : FormGroupItemContext
 {
-    public (CheckboxesOptionsItemConditional Options, string TagName)? Conditional { get; private set; }
-    public (HintOptions Options, string TagName)? Hint { get; private set; }
+    protected override string ConditionalTagName => CheckboxesItemConditionalTagHelper.TagName;
 
-    public void SetConditional(CheckboxesOptionsItemConditional options, string tagName)
-    {
-        ArgumentNullException.ThrowIfNull(options);
-        ArgumentNullException.ThrowIfNull(tagName);
+    protected override string HintTagName => CheckboxesItemHintTagHelper.TagName;
 
-        if (Conditional is not null)
-        {
-            throw ExceptionHelper.OnlyOneElementIsPermittedIn(
-                CheckboxesItemConditionalTagHelper.TagName,
-                CheckboxesItemTagHelper.TagName);
-        }
+    protected override string ItemTagName => CheckboxesItemTagHelper.TagName;
 
-        Conditional = (options, tagName);
-    }
-
-    public void SetHint(HintOptions options, string tagName)
-    {
-        ArgumentNullException.ThrowIfNull(options);
-        ArgumentNullException.ThrowIfNull(tagName);
-
-        if (Hint is not null)
-        {
-            throw ExceptionHelper.OnlyOneElementIsPermittedIn(
-                CheckboxesItemHintTagHelper.TagName,
-                CheckboxesItemTagHelper.TagName);
-        }
-
-        if (Conditional is not null)
-        {
-            throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(
-                CheckboxesItemHintTagHelper.TagName,
-                CheckboxesItemConditionalTagHelper.TagName);
-        }
-
-        Hint = (options, tagName);
-    }
+    public CheckboxesOptionsItemConditional? GetConditionalOptions() =>
+        Conditional is { } conditional ?
+            new CheckboxesOptionsItemConditional { Attributes = conditional.Attributes, Html = conditional.Html } :
+            null;
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesItemHintTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesItemHintTagHelper.cs
@@ -18,7 +18,7 @@ public class CheckboxesItemHintTagHelper : TagHelper
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(output);
 
-        var itemContext = context.GetContextItem<CheckboxesItemContext>();
+        var itemContext = context.GetContextItem<FormGroupItemContext>();
 
         var content = await output.GetChildContentAsync();
 

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesItemTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesItemTagHelper.cs
@@ -109,7 +109,9 @@ public class CheckboxesItemTagHelper : TagHelper
     /// <inheritdoc/>
     public override void Init(TagHelperContext context)
     {
-        context.SetContextItem(new CheckboxesItemContext());
+        var itemContext = new CheckboxesItemContext();
+        context.SetContextItem(itemContext);
+        context.SetContextItem<FormGroupItemContext>(itemContext);
     }
 
     /// <inheritdoc/>
@@ -161,7 +163,7 @@ public class CheckboxesItemTagHelper : TagHelper
             },
             Hint = itemContext.Hint?.Options,
             Checked = @checked,
-            Conditional = itemContext.Conditional?.Options,
+            Conditional = itemContext.GetConditionalOptions(),
             Behaviour = Behavior is CheckboxesItemBehavior.Exclusive ? "exclusive" : null,
             Disabled = Disabled,
             Attributes = inputAttributes,

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupItemConditionalTagHelperBase.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupItemConditionalTagHelperBase.cs
@@ -1,0 +1,37 @@
+using GovUk.Frontend.AspNetCore.ComponentGeneration;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace GovUk.Frontend.AspNetCore.TagHelpers;
+
+/// <summary>
+/// Represents the conditional reveal of an item in a GDS form component.
+/// </summary>
+public abstract class FormGroupItemConditionalTagHelperBase : TagHelper
+{
+    private protected FormGroupItemConditionalTagHelperBase()
+    {
+    }
+
+    /// <inheritdoc/>
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(output);
+
+        var itemContext = context.GetContextItem<FormGroupItemContext>();
+
+        var content = await output.GetChildContentAsync();
+
+        if (output.Content.IsModified)
+        {
+            content = output.Content;
+        }
+
+        itemContext.SetConditional(
+            new AttributeCollection(output.Attributes),
+            content.Snapshot(),
+            context.TagName);
+
+        output.SuppressOutput();
+    }
+}

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupItemContext.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupItemContext.cs
@@ -1,0 +1,50 @@
+using GovUk.Frontend.AspNetCore.ComponentGeneration;
+using Microsoft.AspNetCore.Html;
+
+namespace GovUk.Frontend.AspNetCore.TagHelpers;
+
+internal abstract class FormGroupItemContext
+{
+    internal record ConditionalInfo(AttributeCollection Attributes, IHtmlContent? Html, string TagName);
+
+    public ConditionalInfo? Conditional { get; private set; }
+
+    public (HintOptions Options, string TagName)? Hint { get; private set; }
+
+    protected abstract string ConditionalTagName { get; }
+
+    protected abstract string HintTagName { get; }
+
+    protected abstract string ItemTagName { get; }
+
+    public void SetConditional(AttributeCollection attributes, IHtmlContent? html, string tagName)
+    {
+        ArgumentNullException.ThrowIfNull(attributes);
+        ArgumentNullException.ThrowIfNull(tagName);
+
+        if (Conditional is not null)
+        {
+            throw ExceptionHelper.OnlyOneElementIsPermittedIn(ConditionalTagName, ItemTagName);
+        }
+
+        Conditional = new ConditionalInfo(attributes, html, tagName);
+    }
+
+    public void SetHint(HintOptions options, string tagName)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(tagName);
+
+        if (Hint is not null)
+        {
+            throw ExceptionHelper.OnlyOneElementIsPermittedIn(HintTagName, ItemTagName);
+        }
+
+        if (Conditional is not null)
+        {
+            throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(HintTagName, ConditionalTagName);
+        }
+
+        Hint = (options, tagName);
+    }
+}

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/RadiosItemConditionalTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/RadiosItemConditionalTagHelper.cs
@@ -1,4 +1,3 @@
-using GovUk.Frontend.AspNetCore.ComponentGeneration;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.TagHelpers;
@@ -8,35 +7,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = RadiosItemTagHelper.TagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the conditional reveal for the item.")]
-public class RadiosItemConditionalTagHelper : TagHelper
+public class RadiosItemConditionalTagHelper : FormGroupItemConditionalTagHelperBase
 {
     internal const string TagName = "govuk-radios-item-conditional";
-
-    /// <inheritdoc/>
-    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
-    {
-        ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(output);
-
-        var itemContext = context.GetContextItem<RadiosItemContext>();
-
-        var content = await output.GetChildContentAsync();
-
-        if (output.Content.IsModified)
-        {
-            content = output.Content;
-        }
-
-        var attributes = new AttributeCollection(output.Attributes);
-
-        var conditionalOptions = new RadiosOptionsItemConditional
-        {
-            Attributes = attributes,
-            Html = content.Snapshot()
-        };
-
-        itemContext.SetConditional(conditionalOptions, context.TagName);
-
-        output.SuppressOutput();
-    }
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/RadiosItemContext.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/RadiosItemContext.cs
@@ -2,45 +2,16 @@ using GovUk.Frontend.AspNetCore.ComponentGeneration;
 
 namespace GovUk.Frontend.AspNetCore.TagHelpers;
 
-internal class RadiosItemContext
+internal class RadiosItemContext : FormGroupItemContext
 {
-    public (RadiosOptionsItemConditional Options, string TagName)? Conditional { get; private set; }
-    public (HintOptions Options, string TagName)? Hint { get; private set; }
+    protected override string ConditionalTagName => RadiosItemConditionalTagHelper.TagName;
 
-    public void SetConditional(RadiosOptionsItemConditional options, string tagName)
-    {
-        ArgumentNullException.ThrowIfNull(options);
-        ArgumentNullException.ThrowIfNull(tagName);
+    protected override string HintTagName => RadiosItemHintTagHelper.TagName;
 
-        if (Conditional is not null)
-        {
-            throw ExceptionHelper.OnlyOneElementIsPermittedIn(
-                RadiosItemConditionalTagHelper.TagName,
-                RadiosItemTagHelper.TagName);
-        }
+    protected override string ItemTagName => RadiosItemTagHelper.TagName;
 
-        Conditional = (options, tagName);
-    }
-
-    public void SetHint(HintOptions options, string tagName)
-    {
-        ArgumentNullException.ThrowIfNull(options);
-        ArgumentNullException.ThrowIfNull(tagName);
-
-        if (Hint is not null)
-        {
-            throw ExceptionHelper.OnlyOneElementIsPermittedIn(
-                RadiosItemHintTagHelper.TagName,
-                RadiosItemTagHelper.TagName);
-        }
-
-        if (Conditional is not null)
-        {
-            throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(
-                RadiosItemHintTagHelper.TagName,
-                RadiosItemConditionalTagHelper.TagName);
-        }
-
-        Hint = (options, tagName);
-    }
+    public RadiosOptionsItemConditional? GetConditionalOptions() =>
+        Conditional is { } conditional ?
+            new RadiosOptionsItemConditional { Attributes = conditional.Attributes, Html = conditional.Html } :
+            null;
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/RadiosItemHintTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/RadiosItemHintTagHelper.cs
@@ -18,7 +18,7 @@ public class RadiosItemHintTagHelper : TagHelper
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(output);
 
-        var itemContext = context.GetContextItem<RadiosItemContext>();
+        var itemContext = context.GetContextItem<FormGroupItemContext>();
 
         var content = await output.GetChildContentAsync();
 

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/RadiosItemTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/RadiosItemTagHelper.cs
@@ -97,7 +97,9 @@ public class RadiosItemTagHelper : TagHelper
     /// <inheritdoc/>
     public override void Init(TagHelperContext context)
     {
-        context.SetContextItem(new RadiosItemContext());
+        var itemContext = new RadiosItemContext();
+        context.SetContextItem(itemContext);
+        context.SetContextItem<FormGroupItemContext>(itemContext);
     }
 
     /// <inheritdoc/>
@@ -143,7 +145,7 @@ public class RadiosItemTagHelper : TagHelper
             },
             Hint = itemContext.Hint?.Options,
             Checked = @checked,
-            Conditional = itemContext.Conditional?.Options,
+            Conditional = itemContext.GetConditionalOptions(),
             Disabled = Disabled,
             Attributes = inputAttributes,
             ItemAttributes = itemAttributes

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesItemConditionalTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesItemConditionalTagHelperTests.cs
@@ -27,6 +27,6 @@ public class CheckboxesItemConditionalTagHelperTests : TagHelperTestBase<Checkbo
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal("Conditional", checkboxesItemContext.Conditional?.Options.Html?.ToHtmlString());
+        Assert.Equal("Conditional", checkboxesItemContext.Conditional?.Html?.ToHtmlString());
     }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesItemContextTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesItemContextTests.cs
@@ -10,13 +10,12 @@ public class CheckboxesItemContextTests
     {
         // Arrange
         var context = new CheckboxesItemContext();
-        var conditionalOptions = new CheckboxesOptionsItemConditional { Html = new TemplateString("Conditional") };
 
         // Act
-        context.SetConditional(conditionalOptions, "govuk-checkboxes-item-conditional");
+        context.SetConditional(new AttributeCollection(), new TemplateString("Conditional"), "govuk-checkboxes-item-conditional");
 
         // Assert
-        Assert.Equal("Conditional", context.Conditional?.Options.Html?.ToHtmlString());
+        Assert.Equal("Conditional", context.Conditional?.Html?.ToHtmlString());
     }
 
     [Fact]
@@ -24,12 +23,10 @@ public class CheckboxesItemContextTests
     {
         // Arrange
         var context = new CheckboxesItemContext();
-        var existingConditionalOptions = new CheckboxesOptionsItemConditional { Html = new TemplateString("Existing conditional") };
-        context.SetConditional(existingConditionalOptions, "govuk-checkboxes-item-conditional");
+        context.SetConditional(new AttributeCollection(), new TemplateString("Existing conditional"), "govuk-checkboxes-item-conditional");
 
         // Act
-        var conditionalOptions = new CheckboxesOptionsItemConditional { Html = new TemplateString("Conditional") };
-        var ex = Record.Exception(() => context.SetConditional(conditionalOptions, "govuk-checkboxes-item-conditional"));
+        var ex = Record.Exception(() => context.SetConditional(new AttributeCollection(), new TemplateString("Conditional"), "govuk-checkboxes-item-conditional"));
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
@@ -55,8 +52,7 @@ public class CheckboxesItemContextTests
     {
         // Arrange
         var context = new CheckboxesItemContext();
-        var existingConditionalOptions = new CheckboxesOptionsItemConditional { Html = new TemplateString("Existing conditional") };
-        context.SetConditional(existingConditionalOptions, "govuk-checkboxes-item-conditional");
+        context.SetConditional(new AttributeCollection(), new TemplateString("Existing conditional"), "govuk-checkboxes-item-conditional");
 
         // Act
         var hintOptions = new HintOptions { Html = new TemplateString("Hint") };

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesItemTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesItemTagHelperTests.cs
@@ -401,8 +401,7 @@ public class CheckboxesItemTagHelperTests : TagHelperTestBase<CheckboxesItemTagH
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var itemContext = context.GetContextItem<CheckboxesItemContext>();
-                var conditionalOptions = new CheckboxesOptionsItemConditional { Html = new TemplateString("Conditional") };
-                itemContext.SetConditional(conditionalOptions, "govuk-checkboxes-item-conditional");
+                itemContext.SetConditional(new AttributeCollection(), new TemplateString("Conditional"), "govuk-checkboxes-item-conditional");
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosItemConditionalTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosItemConditionalTagHelperTests.cs
@@ -27,6 +27,6 @@ public class RadiosItemConditionalTagHelperTests : TagHelperTestBase<RadiosItemC
         await tagHelper.ProcessAsync(context, output);
 
         // Assert
-        Assert.Equal("Conditional", radiosItemContext.Conditional?.Options.Html?.ToHtmlString());
+        Assert.Equal("Conditional", radiosItemContext.Conditional?.Html?.ToHtmlString());
     }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosItemContextTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosItemContextTests.cs
@@ -12,10 +12,10 @@ public class RadiosItemContextTests
         var context = new RadiosItemContext();
 
         // Act
-        context.SetConditional(new RadiosOptionsItemConditional { Html = new TemplateString("Conditional") }, tagName: "govuk-radios-item-conditional");
+        context.SetConditional(new AttributeCollection(), new TemplateString("Conditional"), tagName: "govuk-radios-item-conditional");
 
         // Assert
-        Assert.Equal("Conditional", context.Conditional?.Options.Html?.ToHtmlString());
+        Assert.Equal("Conditional", context.Conditional?.Html?.ToHtmlString());
     }
 
     [Fact]
@@ -23,10 +23,10 @@ public class RadiosItemContextTests
     {
         // Arrange
         var context = new RadiosItemContext();
-        context.SetConditional(new RadiosOptionsItemConditional { Html = new TemplateString("Existing conditional") }, tagName: "govuk-radios-item-conditional");
+        context.SetConditional(new AttributeCollection(), new TemplateString("Existing conditional"), tagName: "govuk-radios-item-conditional");
 
         // Act
-        var ex = Record.Exception(() => context.SetConditional(new RadiosOptionsItemConditional { Html = new TemplateString("Conditional") }, tagName: "govuk-radios-item-conditional"));
+        var ex = Record.Exception(() => context.SetConditional(new AttributeCollection(), new TemplateString("Conditional"), tagName: "govuk-radios-item-conditional"));
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
@@ -51,7 +51,7 @@ public class RadiosItemContextTests
     {
         // Arrange
         var context = new RadiosItemContext();
-        context.SetConditional(new RadiosOptionsItemConditional { Html = new TemplateString("Existing conditional") }, tagName: "govuk-radios-item-conditional");
+        context.SetConditional(new AttributeCollection(), new TemplateString("Existing conditional"), tagName: "govuk-radios-item-conditional");
 
         // Act
         var ex = Record.Exception(() => context.SetHint(new HintOptions { Html = new TemplateString("Hint") }, tagName: "govuk-radios-item-hint"));

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosItemTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/RadiosItemTagHelperTests.cs
@@ -318,8 +318,7 @@ public class RadiosItemTagHelperTests : TagHelperTestBase<RadiosItemTagHelper>
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var itemContext = context.GetContextItem<RadiosItemContext>();
-                var conditionalOptions = new RadiosOptionsItemConditional { Html = new TemplateString("Conditional") };
-                itemContext.SetConditional(conditionalOptions, "govuk-radios-item-conditional");
+                itemContext.SetConditional(new AttributeCollection(), new TemplateString("Conditional"), "govuk-radios-item-conditional");
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TagHelperTestBase.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TagHelperTestBase.cs
@@ -74,6 +74,12 @@ public abstract class TagHelperTestBase<T> where T : ITagHelper
             items[typeof(FormGroupContext3)] = formGroupContext;
         }
 
+        // Form group item tag helpers register their context under FormGroupItemContext too
+        foreach (var formGroupItemContext in contexts.OfType<FormGroupItemContext>())
+        {
+            items[typeof(FormGroupItemContext)] = formGroupItemContext;
+        }
+
         return new TagHelperContext(
             tagName ?? TagName,
             tagHelperAttributes,


### PR DESCRIPTION
The checkboxes and radios item conditional tag helpers each carried their own copy of the same `ProcessAsync`, so they now derive from a new `FormGroupItemConditionalTagHelperBase` and keep only their target elements, tag name and documentation — following `FormGroupFieldsetLegendTagHelperBase` from #526.

## What changed

**`FormGroupItemConditionalTagHelperBase`** holds the shared `ProcessAsync`: resolve the item context, snapshot the child content (or `output.Content` if modified), pass the attributes, content and `context.TagName` to the context, suppress the output.

**`FormGroupItemContext`** is a new shared base for `CheckboxesItemContext` and `RadiosItemContext`, which were near-identical. It owns the `Hint` and `Conditional` state and both setters, including the "only one element" and "hint must come before conditional" checks. Subclasses are now ~12 lines: three abstract tag names used in the error messages, plus a `GetConditionalOptions()` factory returning their own `…OptionsItemConditional` record — the same shape as `FormGroupContext3.GetHintOptions()`.

`SetConditional` now takes the attributes and content instead of an already-built options record, matching `FormGroupContext3.SetHint` and `FormGroupFieldsetContext2.SetLegend`.

**Context lookups** go through the shared type. Each item tag helper's `Init` registers its context under `FormGroupItemContext` as well as its concrete type — the same pairing `CheckboxesTagHelper` uses for `FormGroupContext3` — so the conditional and item hint tag helpers can resolve it by the shared type. The item tag helpers keep their concrete lookup, since they need the typed options factory. `TagHelperTestBase.CreateTagHelperContext` gained a matching registration loop alongside the existing `FormGroupContext3` one.

## For reviewers

- No behaviour change intended. The base keeps the unconditional `await output.GetChildContentAsync()` both helpers already had, rather than the `TagMode` null check used by the legend base, so a self-closing `<govuk-checkboxes-item-conditional />` still produces empty rather than null `Html`. Error messages still name the same tag constants as before.
- Full suite passes on net8.0/9.0/10.0 (1702 unit, 77 integration, 49 package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)