### PR TITLE
Add short tag name support to the checkboxes tag helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,25 @@ Both elements can now generate their `formaction` attribute from the `asp-` attr
 
 As per the guidance, the first page, the pages either side of the current page and the last page are shown, with an ellipsis wherever pages have been skipped, plus Previous and Next links where there is a page to go to. Nothing is rendered at all when there is only one page. Child elements cannot be combined with these attributes.
 
+The checkboxes tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
+
+```razor
+<govuk-checkboxes for="ContactPreferences">
+    <legend>How would you like to be contacted?</legend>
+    <hint>Select all options that are relevant to you.</hint>
+    <item value="email">
+        Email
+        <conditional>
+            <govuk-input for="EmailAddress" type="email" input-class="govuk-!-width-one-third">
+                <govuk-input-label>Email address</govuk-input-label>
+            </govuk-input>
+        </conditional>
+    </item>
+</govuk-checkboxes>
+```
+
+`<legend>`, `<hint>`, `<error-message>`, `<item>`, `<divider>`, `<before-inputs>` and `<after-inputs>` go directly inside `<govuk-checkboxes>`; `<hint>` and `<conditional>` go inside an `<item>`. The `govuk-` prefixed names continue to work everywhere they did before, and remain the only spelling accepted inside a `<govuk-checkboxes-fieldset>` — the short names pair with the fieldset that `<govuk-checkboxes>` generates for a `<legend>` of its own.
+
 `TabsOptions.Title` is now `string?` rather than `TemplateString?`. It only ever comes from the `title` attribute, so it is always text.
 
 `SelectOptionsItem.Text` is `TemplateString?` again and its `Html` property is gone. Content written inside `<govuk-select-item>` is markup, and `TemplateString` already carries either kind, so the extra property added nothing.

--- a/docs/components/checkboxes.md
+++ b/docs/components/checkboxes.md
@@ -11,20 +11,20 @@
 
 ```razor
 <govuk-checkboxes for="Nationalities">
-    <govuk-checkboxes-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
+    <legend is-page-heading="true" class="govuk-fieldset__legend--l">
         What is your nationality?
-    </govuk-checkboxes-fieldset-legend>
+    </legend>
 
-    <govuk-checkboxes-hint>
+    <hint>
         If you have dual nationality, select all options that are relevant to you.
-    </govuk-checkboxes-hint>
+    </hint>
 
-    <govuk-checkboxes-item value="british">
+    <item value="british">
         British
-        <govuk-checkboxes-item-hint>including English, Scottish, Welsh and Northern Irish</govuk-checkboxes-item-hint>
-    </govuk-checkboxes-item>
-    <govuk-checkboxes-item value="irish">Irish</govuk-checkboxes-item>
-    <govuk-checkboxes-item value="other">Citizen of another country</govuk-checkboxes-item>
+        <hint>including English, Scottish, Welsh and Northern Irish</hint>
+    </item>
+    <item value="irish">Irish</item>
+    <item value="other">Citizen of another country</item>
 </govuk-checkboxes>
 ```
 
@@ -34,9 +34,9 @@
 
 ```razor
 <govuk-checkboxes for="Nationalities" fieldset legend-class="govuk-fieldset__legend--l" legend-is-page-heading="true">
-    <govuk-checkboxes-item value="british">British</govuk-checkboxes-item>
-    <govuk-checkboxes-item value="irish">Irish</govuk-checkboxes-item>
-    <govuk-checkboxes-item value="other">Citizen of another country</govuk-checkboxes-item>
+    <item value="british">British</item>
+    <item value="irish">Irish</item>
+    <item value="other">Citizen of another country</item>
 </govuk-checkboxes>
 ```
 
@@ -46,9 +46,9 @@
 
 ```razor
 <govuk-checkboxes for="AcceptedTermsAndConditions">
-    <govuk-checkboxes-item value="true">
+    <item value="true">
         I agree to the terms and conditions
-    </govuk-checkboxes-item>
+    </item>
 </govuk-checkboxes>
 ```
 
@@ -58,40 +58,40 @@
 
 ```razor
 <govuk-checkboxes for="ContactPreferences">
-    <govuk-checkboxes-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
+    <legend is-page-heading="true" class="govuk-fieldset__legend--l">
         How would you like to be contacted?
-    </govuk-checkboxes-fieldset-legend>
+    </legend>
 
-    <govuk-checkboxes-hint>
+    <hint>
         Select all options that are relevant to you.
-    </govuk-checkboxes-hint>
+    </hint>
 
-    <govuk-checkboxes-item value="email">
+    <item value="email">
         Email
-        <govuk-checkboxes-item-conditional>
+        <conditional>
             <govuk-input for="EmailAddress" type="email" autocomplete="email" spellcheck="false" input-class="govuk-!-width-one-third">
                 <govuk-input-label>Email address</govuk-input-label>
             </govuk-input>
-        </govuk-checkboxes-item-conditional>
-    </govuk-checkboxes-item>
+        </conditional>
+    </item>
 
-    <govuk-checkboxes-item value="phone">
+    <item value="phone">
         Phone
-        <govuk-checkboxes-item-conditional>
+        <conditional>
             <govuk-input for="PhoneNumber" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
                 <govuk-input-label>Phone number</govuk-input-label>
             </govuk-input>
-        </govuk-checkboxes-item-conditional>
-    </govuk-checkboxes-item>
+        </conditional>
+    </item>
 
-    <govuk-checkboxes-item value="text message">
+    <item value="text message">
         Text message
-        <govuk-checkboxes-item-conditional>
+        <conditional>
             <govuk-input for="MobilePhoneNumber" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
                 <govuk-input-label>Mobile phone number</govuk-input-label>
             </govuk-input>
-        </govuk-checkboxes-item-conditional>
-    </govuk-checkboxes-item>
+        </conditional>
+    </item>
 </govuk-checkboxes>
 ```
 
@@ -101,19 +101,19 @@
 
 ```razor
 <govuk-checkboxes for="CountriesTravellingTo">
-    <govuk-checkboxes-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
+    <legend is-page-heading="true" class="govuk-fieldset__legend--l">
         Will you be travelling to any of these countries?
-    </govuk-checkboxes-fieldset-legend>
+    </legend>
 
-    <govuk-checkboxes-hint>
+    <hint>
         Select all countries that apply
-    </govuk-checkboxes-hint>
+    </hint>
 
-    <govuk-checkboxes-item value="france">France</govuk-checkboxes-item>
-    <govuk-checkboxes-item value="portugal">Portugal</govuk-checkboxes-item>
-    <govuk-checkboxes-item value="spain">Spain</govuk-checkboxes-item>
-    <govuk-checkboxes-divider>or</govuk-checkboxes-divider>
-    <govuk-checkboxes-item value="none" behavior="CheckboxesItemBehavior.Exclusive">No, I will not be travelling to any of these countries</govuk-checkboxes-item>
+    <item value="france">France</item>
+    <item value="portugal">Portugal</item>
+    <item value="spain">Spain</item>
+    <divider>or</divider>
+    <item value="none" behavior="CheckboxesItemBehavior.Exclusive">No, I will not be travelling to any of these countries</item>
 </govuk-checkboxes>
 ```
 
@@ -123,24 +123,24 @@
 
 ```razor
 <govuk-checkboxes name="nationality">
-    <govuk-checkboxes-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
+    <legend is-page-heading="true" class="govuk-fieldset__legend--l">
         What is your nationality?
-    </govuk-checkboxes-fieldset-legend>
+    </legend>
 
-    <govuk-checkboxes-hint>
+    <hint>
         If you have dual nationality, select all options that are relevant to you.
-    </govuk-checkboxes-hint>
+    </hint>
 
-    <govuk-checkboxes-error-message>
+    <error-message>
         Select if you are British, Irish or a citizen of a different country
-    </govuk-checkboxes-error-message>
+    </error-message>
 
-    <govuk-checkboxes-item value="british">
+    <item value="british">
         British
-        <govuk-checkboxes-item-hint>including English, Scottish, Welsh and Northern Irish</govuk-checkboxes-item-hint>
-    </govuk-checkboxes-item>
-    <govuk-checkboxes-item value="irish">Irish</govuk-checkboxes-item>
-    <govuk-checkboxes-item value="other">Citizen of another country</govuk-checkboxes-item>
+        <hint>including English, Scottish, Welsh and Northern Irish</hint>
+    </item>
+    <item value="irish">Irish</item>
+    <item value="other">Citizen of another country</item>
 </govuk-checkboxes>
 ```
 
@@ -165,7 +165,7 @@
 
 #### `<govuk-checkboxes-fieldset>`
 
-A container element used when the checkboxes should be contained within a fieldset element. When used, every hint, error message, item and divider must be placed inside this element rather than the root checkboxes element.
+A container element used when the checkboxes should be contained within a fieldset element. When used, every hint, error message, item and divider must be placed inside this element rather than the root checkboxes element, and each must use its govuk- prefixed name; the short names are only available directly inside the root checkboxes element.
 
 Must be inside a `<govuk-checkboxes>` element.
 
@@ -174,7 +174,7 @@ Must be inside a `<govuk-checkboxes>` element.
 | `described-by` | `string` | One or more element IDs to add to the `aria-describedby` attribute. |
 
 
-#### `<govuk-checkboxes-fieldset-legend>`
+#### `<legend>` / `<govuk-checkboxes-fieldset-legend>`
 
 The content is the HTML to use within the legend. When this element is specified directly inside the root checkboxes element a fieldset is generated automatically.
 
@@ -185,14 +185,14 @@ Must be inside a `<govuk-checkboxes>` or `<govuk-checkboxes-fieldset>` element.
 | `is-page-heading` | `bool?` | Whether the legend also acts as the heading for the page. The default is `false`. |
 
 
-#### `<govuk-checkboxes-hint>`
+#### `<hint>` / `<govuk-checkboxes-hint>`
 
 The content is the HTML to use within the component's hint.
 
 Must be inside a `<govuk-checkboxes>` or `<govuk-checkboxes-fieldset>` element.
 
 
-#### `<govuk-checkboxes-error-message>`
+#### `<error-message>` / `<govuk-checkboxes-error-message>`
 
 The content is the HTML to use within the component's error message.
 
@@ -203,14 +203,14 @@ Must be inside a `<govuk-checkboxes>` or `<govuk-checkboxes-fieldset>` element.
 | `visually-hidden-text` | `string` | A visually hidden prefix used before the error message. The default is `"Error"`. |
 
 
-#### `<govuk-checkboxes-before-inputs>`
+#### `<before-inputs>` / `<govuk-checkboxes-before-inputs>`
 
 The content is the HTML to use before the checkboxes.
 
 Must be inside a `<govuk-checkboxes>` or `<govuk-checkboxes-fieldset>` element.
 
 
-#### `<govuk-checkboxes-item>`
+#### `<item>` / `<govuk-checkboxes-item>`
 
 The content is the HTML to use within the label for the generated input element.
 
@@ -227,28 +227,28 @@ Must be inside a `<govuk-checkboxes>` or `<govuk-checkboxes-fieldset>` element.
 | `value` | `string` | The `value` attribute for the item. |
 
 
-#### `<govuk-checkboxes-item-hint>`
+#### `<hint>` / `<govuk-checkboxes-item-hint>`
 
 The content is the HTML to use within the item's hint.
 
-Must be inside a `<govuk-checkboxes-item>` element.
+Must be inside an `<item>` or `<govuk-checkboxes-item>` element.
 
 
-#### `<govuk-checkboxes-item-conditional>`
+#### `<conditional>` / `<govuk-checkboxes-item-conditional>`
 
 The content is the HTML to use within the conditional reveal for the item.
 
-Must be inside a `<govuk-checkboxes-item>` element.
+Must be inside an `<item>` or `<govuk-checkboxes-item>` element.
 
 
-#### `<govuk-checkboxes-divider>`
+#### `<divider>` / `<govuk-checkboxes-divider>`
 
 The content is the HTML to use within the item divider.
 
 Must be inside a `<govuk-checkboxes>` or `<govuk-checkboxes-fieldset>` element.
 
 
-#### `<govuk-checkboxes-after-inputs>`
+#### `<after-inputs>` / `<govuk-checkboxes-after-inputs>`
 
 The content is the HTML to use after the checkboxes.
 

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesExample.cshtml
@@ -3,19 +3,19 @@
 
 <example>
     <govuk-checkboxes for="Nationalities">
-        <govuk-checkboxes-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
+        <legend is-page-heading="true" class="govuk-fieldset__legend--l">
             What is your nationality?
-        </govuk-checkboxes-fieldset-legend>
+        </legend>
 
-        <govuk-checkboxes-hint>
+        <hint>
             If you have dual nationality, select all options that are relevant to you.
-        </govuk-checkboxes-hint>
+        </hint>
 
-        <govuk-checkboxes-item value="british">
+        <item value="british">
             British
-            <govuk-checkboxes-item-hint>including English, Scottish, Welsh and Northern Irish</govuk-checkboxes-item-hint>
-        </govuk-checkboxes-item>
-        <govuk-checkboxes-item value="irish">Irish</govuk-checkboxes-item>
-        <govuk-checkboxes-item value="other">Citizen of another country</govuk-checkboxes-item>
+            <hint>including English, Scottish, Welsh and Northern Irish</hint>
+        </item>
+        <item value="irish">Irish</item>
+        <item value="other">Citizen of another country</item>
     </govuk-checkboxes>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithConditionalExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithConditionalExample.cshtml
@@ -3,39 +3,39 @@
 
 <example>
     <govuk-checkboxes for="ContactPreferences">
-        <govuk-checkboxes-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
+        <legend is-page-heading="true" class="govuk-fieldset__legend--l">
             How would you like to be contacted?
-        </govuk-checkboxes-fieldset-legend>
+        </legend>
 
-        <govuk-checkboxes-hint>
+        <hint>
             Select all options that are relevant to you.
-        </govuk-checkboxes-hint>
+        </hint>
 
-        <govuk-checkboxes-item value="email">
+        <item value="email">
             Email
-            <govuk-checkboxes-item-conditional>
+            <conditional>
                 <govuk-input for="EmailAddress" type="email" autocomplete="email" spellcheck="false" input-class="govuk-!-width-one-third">
                     <govuk-input-label>Email address</govuk-input-label>
                 </govuk-input>
-            </govuk-checkboxes-item-conditional>
-        </govuk-checkboxes-item>
+            </conditional>
+        </item>
 
-        <govuk-checkboxes-item value="phone">
+        <item value="phone">
             Phone
-            <govuk-checkboxes-item-conditional>
+            <conditional>
                 <govuk-input for="PhoneNumber" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
                     <govuk-input-label>Phone number</govuk-input-label>
                 </govuk-input>
-            </govuk-checkboxes-item-conditional>
-        </govuk-checkboxes-item>
+            </conditional>
+        </item>
 
-        <govuk-checkboxes-item value="text message">
+        <item value="text message">
             Text message
-            <govuk-checkboxes-item-conditional>
+            <conditional>
                 <govuk-input for="MobilePhoneNumber" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
                     <govuk-input-label>Mobile phone number</govuk-input-label>
                 </govuk-input>
-            </govuk-checkboxes-item-conditional>
-        </govuk-checkboxes-item>
+            </conditional>
+        </item>
     </govuk-checkboxes>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithErrorExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithErrorExample.cshtml
@@ -2,23 +2,23 @@
 
 <example>
     <govuk-checkboxes name="nationality">
-        <govuk-checkboxes-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
+        <legend is-page-heading="true" class="govuk-fieldset__legend--l">
             What is your nationality?
-        </govuk-checkboxes-fieldset-legend>
+        </legend>
 
-        <govuk-checkboxes-hint>
+        <hint>
             If you have dual nationality, select all options that are relevant to you.
-        </govuk-checkboxes-hint>
+        </hint>
 
-        <govuk-checkboxes-error-message>
+        <error-message>
             Select if you are British, Irish or a citizen of a different country
-        </govuk-checkboxes-error-message>
+        </error-message>
 
-        <govuk-checkboxes-item value="british">
+        <item value="british">
             British
-            <govuk-checkboxes-item-hint>including English, Scottish, Welsh and Northern Irish</govuk-checkboxes-item-hint>
-        </govuk-checkboxes-item>
-        <govuk-checkboxes-item value="irish">Irish</govuk-checkboxes-item>
-        <govuk-checkboxes-item value="other">Citizen of another country</govuk-checkboxes-item>
+            <hint>including English, Scottish, Welsh and Northern Irish</hint>
+        </item>
+        <item value="irish">Irish</item>
+        <item value="other">Citizen of another country</item>
     </govuk-checkboxes>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithGeneratedFieldsetExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithGeneratedFieldsetExample.cshtml
@@ -3,8 +3,8 @@
 
 <example>
     <govuk-checkboxes for="Nationalities" fieldset legend-class="govuk-fieldset__legend--l" legend-is-page-heading="true">
-        <govuk-checkboxes-item value="british">British</govuk-checkboxes-item>
-        <govuk-checkboxes-item value="irish">Irish</govuk-checkboxes-item>
-        <govuk-checkboxes-item value="other">Citizen of another country</govuk-checkboxes-item>
+        <item value="british">British</item>
+        <item value="irish">Irish</item>
+        <item value="other">Citizen of another country</item>
     </govuk-checkboxes>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithNoneExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithNoneExample.cshtml
@@ -3,18 +3,18 @@
 
 <example>
     <govuk-checkboxes for="CountriesTravellingTo">
-        <govuk-checkboxes-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
+        <legend is-page-heading="true" class="govuk-fieldset__legend--l">
             Will you be travelling to any of these countries?
-        </govuk-checkboxes-fieldset-legend>
+        </legend>
 
-        <govuk-checkboxes-hint>
+        <hint>
             Select all countries that apply
-        </govuk-checkboxes-hint>
+        </hint>
 
-        <govuk-checkboxes-item value="france">France</govuk-checkboxes-item>
-        <govuk-checkboxes-item value="portugal">Portugal</govuk-checkboxes-item>
-        <govuk-checkboxes-item value="spain">Spain</govuk-checkboxes-item>
-        <govuk-checkboxes-divider>or</govuk-checkboxes-divider>
-        <govuk-checkboxes-item value="none" behavior="CheckboxesItemBehavior.Exclusive">No, I will not be travelling to any of these countries</govuk-checkboxes-item>
+        <item value="france">France</item>
+        <item value="portugal">Portugal</item>
+        <item value="spain">Spain</item>
+        <divider>or</divider>
+        <item value="none" behavior="CheckboxesItemBehavior.Exclusive">No, I will not be travelling to any of these countries</item>
     </govuk-checkboxes>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithoutFieldsetExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithoutFieldsetExample.cshtml
@@ -3,8 +3,8 @@
 
 <example>
     <govuk-checkboxes for="AcceptedTermsAndConditions">
-        <govuk-checkboxes-item value="true">
+        <item value="true">
             I agree to the terms and conditions
-        </govuk-checkboxes-item>
+        </item>
     </govuk-checkboxes>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/TagHelperApiProvider.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/TagHelperApiProvider.cs
@@ -30,7 +30,11 @@ public class TagHelperApiProvider
         _formActionTagHelper = typeof(GovUkFrontendOptions).Assembly.GetType($"{TagHelperNamespace}.FormActionTagHelper")!;
     }
 
-    public TagHelperApi GetTagHelperApi(string tagHelperName, string? forTagName = null)
+    /// <param name="forShortTagName">
+    /// The short name that goes with <paramref name="forTagName"/>, for tag helpers that target more than one
+    /// element; it targets a different parent element so it cannot be deduced from <paramref name="forTagName"/>.
+    /// </param>
+    public TagHelperApi GetTagHelperApi(string tagHelperName, string? forTagName = null, string? forShortTagName = null)
     {
         ArgumentNullException.ThrowIfNull(tagHelperName);
 
@@ -46,11 +50,18 @@ public class TagHelperApiProvider
         // Tag helpers that target several elements are documented an element at a time
         if (forTagName is not null)
         {
-            htmlTargetElementAttrs = htmlTargetElementAttrs.Where(e => e.Tag == forTagName).ToArray();
+            htmlTargetElementAttrs = htmlTargetElementAttrs
+                .Where(e => e.Tag == forTagName || e.Tag == forShortTagName)
+                .ToArray();
 
-            if (htmlTargetElementAttrs.Length == 0)
+            if (!htmlTargetElementAttrs.Any(e => e.Tag == forTagName))
             {
                 throw new ArgumentException($"Could not find HtmlTargetElementAttribute for '{forTagName}' on '{tagHelperClassName}'.", nameof(forTagName));
+            }
+
+            if (forShortTagName is not null && !htmlTargetElementAttrs.Any(e => e.Tag == forShortTagName))
+            {
+                throw new ArgumentException($"Could not find HtmlTargetElementAttribute for '{forShortTagName}' on '{tagHelperClassName}'.", nameof(forShortTagName));
             }
         }
 

--- a/src/GovUk.Frontend.AspNetCore.Docs/TemplateRenderer.cs
+++ b/src/GovUk.Frontend.AspNetCore.Docs/TemplateRenderer.cs
@@ -84,8 +84,9 @@ public class TemplateRenderer
     {
         var tagHelperName = args.At(0).ToStringValue();
         var forTagName = args.Count > 1 ? args.At(1).ToStringValue() : null;
+        var forShortTagName = args.Count > 2 ? args.At(2).ToStringValue() : null;
 
-        var tagHelperApi = _tagHelperApiProvider.GetTagHelperApi(tagHelperName, forTagName);
+        var tagHelperApi = _tagHelperApiProvider.GetTagHelperApi(tagHelperName, forTagName, forShortTagName);
         var contentDescription = tagHelperApi.ContentDescription;
 
         var sb = new StringBuilder();
@@ -120,8 +121,11 @@ public class TemplateRenderer
             // Show the short tag name before the full one
             var orderedParentTagNames = tagHelperApi.ParentTagNames.OrderByDescending(tn => !tn.StartsWith("govuk-")).ThenBy(tn => tn).ToArray();
 
+            // The first tag name is the one the article is read against, e.g. an <item>
+            var article = orderedParentTagNames[0] is ['a' or 'e' or 'i' or 'o' or 'u', ..] ? "an" : "a";
+
             sb.AppendLine();
-            sb.AppendLine($"Must be inside a {string.Join(" or ", orderedParentTagNames.Select(t => $"`<{t}>`"))} element.");
+            sb.AppendLine($"Must be inside {article} {string.Join(" or ", orderedParentTagNames.Select(t => $"`<{t}>`"))} element.");
         }
 
         if (tagHelperApi.Attributes.Count > 0)

--- a/src/GovUk.Frontend.AspNetCore.Docs/Templates/components/checkboxes.liquid
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Templates/components/checkboxes.liquid
@@ -47,7 +47,7 @@
 
 {{ tag_helper_api("CheckboxesFieldsetTagHelper") }}
 
-{{ tag_helper_api("FormGroupFieldsetLegendTagHelper", "govuk-checkboxes-fieldset-legend") }}
+{{ tag_helper_api("FormGroupFieldsetLegendTagHelper", "govuk-checkboxes-fieldset-legend", "legend") }}
 
 {{ tag_helper_api("CheckboxesHintTagHelper") }}
 
@@ -59,7 +59,7 @@
 
 {{ tag_helper_api("CheckboxesItemHintTagHelper") }}
 
-{{ tag_helper_api("FormGroupItemConditionalTagHelper", "govuk-checkboxes-item-conditional") }}
+{{ tag_helper_api("FormGroupItemConditionalTagHelper", "govuk-checkboxes-item-conditional", "conditional") }}
 
 {{ tag_helper_api("CheckboxesItemDividerTagHelper") }}
 

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesAfterInputsTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesAfterInputsTagHelper.cs
@@ -7,6 +7,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the content after the inputs in a GDS checkboxes component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = CheckboxesTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = CheckboxesTagHelper.TagName)]
 [HtmlTargetElement(TagName, ParentTag = CheckboxesFieldsetTagHelper.TagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use after the checkboxes.")]
 public class CheckboxesAfterInputsTagHelper : TagHelper
@@ -14,11 +15,9 @@ public class CheckboxesAfterInputsTagHelper : TagHelper
     private readonly ILogger<CheckboxesAfterInputsTagHelper> _logger;
 
     internal const string TagName = "govuk-checkboxes-after-inputs";
+    internal const string ShortTagName = ShortTagNames.AfterInputs;
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = new[]
-    {
-        TagName
-    };
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <summary>
     /// Creates a new <see cref="CheckboxesAfterInputsTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesBeforeInputsTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesBeforeInputsTagHelper.cs
@@ -7,6 +7,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the content before the inputs in a GDS checkboxes component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = CheckboxesTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = CheckboxesTagHelper.TagName)]
 [HtmlTargetElement(TagName, ParentTag = CheckboxesFieldsetTagHelper.TagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use before the checkboxes.")]
 public class CheckboxesBeforeInputsTagHelper : TagHelper
@@ -14,11 +15,9 @@ public class CheckboxesBeforeInputsTagHelper : TagHelper
     private readonly ILogger<CheckboxesBeforeInputsTagHelper> _logger;
 
     internal const string TagName = "govuk-checkboxes-before-inputs";
+    internal const string ShortTagName = ShortTagNames.BeforeInputs;
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = new[]
-    {
-        TagName
-    };
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <summary>
     /// Creates a new <see cref="CheckboxesBeforeInputsTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesContext.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesContext.cs
@@ -8,6 +8,7 @@ internal class CheckboxesContext(string? name, ModelExpression? @for) : FormGrou
 {
     private bool _fieldsetIsOpen;
     private readonly List<CheckboxesOptionsItem> _items = [];
+    private string? _firstItemTagName;
     private (IHtmlContent Content, string TagName)? _beforeInputs;
     private (IHtmlContent Content, string TagName)? _afterInputs;
 
@@ -33,7 +34,9 @@ internal class CheckboxesContext(string? name, ModelExpression? @for) : FormGrou
 
     protected override IReadOnlyCollection<string> ErrorMessageTagNames => CheckboxesErrorMessageTagHelper.AllTagNames;
 
-    protected string ItemTagName => CheckboxesItemTagHelper.TagName;
+    // Messages about an item that has already been added name it as it was written in the view,
+    // which may be either the govuk- prefixed name or the short one
+    protected string ItemTagName => _firstItemTagName ?? CheckboxesItemTagHelper.TagName;
 
     protected override IReadOnlyCollection<string> HintTagNames => CheckboxesHintTagHelper.AllTagNames;
 
@@ -47,15 +50,17 @@ internal class CheckboxesContext(string? name, ModelExpression? @for) : FormGrou
 
     private IReadOnlyCollection<string> AfterInputsTagNames => CheckboxesAfterInputsTagHelper.AllTagNames;
 
-    public void AddItem(CheckboxesOptionsItem item)
+    public void AddItem(CheckboxesOptionsItem item, string tagName)
     {
         ArgumentNullException.ThrowIfNull(item);
+        ArgumentNullException.ThrowIfNull(tagName);
 
         if (Fieldset is not null && !_fieldsetIsOpen)
         {
-            throw new InvalidOperationException($"<{ItemTagName}> must be inside <{FieldsetTagName}>.");
+            throw new InvalidOperationException($"<{tagName}> must be inside <{FieldsetTagName}>.");
         }
 
+        _firstItemTagName ??= tagName;
         _items.Add(item);
     }
 

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesErrorMessageTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesErrorMessageTagHelper.cs
@@ -5,27 +5,14 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 
 /// <inheritdoc/>
 [HtmlTargetElement(TagName, ParentTag = CheckboxesTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = CheckboxesTagHelper.TagName)]
-#endif
 [HtmlTargetElement(TagName, ParentTag = CheckboxesFieldsetTagHelper.TagName)]
-#if SHORT_TAG_NAMES
-[HtmlTargetElement(ShortTagName, ParentTag = CheckboxesFieldsetTagHelper.TagName)]
-[HtmlTargetElement(TagName, ParentTag = CheckboxesFieldsetTagHelper.ShortTagName)]
-[HtmlTargetElement(ShortTagName, ParentTag = CheckboxesFieldsetTagHelper.ShortTagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's error message.")]
 public class CheckboxesErrorMessageTagHelper : FormGroupErrorMessageTagHelperBase
 {
     internal const string TagName = "govuk-checkboxes-error-message";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     private protected override void SetErrorMessage(TagHelperContent? content, TagHelperContext context, TagHelperOutput output)
     {

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesFieldsetTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesFieldsetTagHelper.cs
@@ -6,9 +6,6 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the fieldset in a GDS checkboxes component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = CheckboxesTagHelper.TagName)]
-#if SHORT_TAG_NAMES
-[HtmlTargetElement(ShortTagName, ParentTag = CheckboxesTagHelper.TagName)]
-#endif
 [RestrictChildren(
     FormGroupFieldsetLegendTagHelper.CheckboxesTagName,
     CheckboxesItemTagHelper.TagName,
@@ -17,24 +14,13 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
     CheckboxesErrorMessageTagHelper.TagName,
     CheckboxesBeforeInputsTagHelper.TagName,
     CheckboxesAfterInputsTagHelper.TagName
-#if SHORT_TAG_NAMES
-    ,
-    FormGroupHintTagHelperBase.ShortTagName,
-    FormGroupErrorMessageTagHelperBase.ShortTagName
-#endif
 )]
-[TagHelperDocumentation(ContentDescription = "A container element used when the checkboxes should be contained within a fieldset element. When used, every hint, error message, item and divider must be placed inside this element rather than the root checkboxes element.")]
+[TagHelperDocumentation(ContentDescription = "A container element used when the checkboxes should be contained within a fieldset element. When used, every hint, error message, item and divider must be placed inside this element rather than the root checkboxes element, and each must use its govuk- prefixed name; the short names are only available directly inside the root checkboxes element.")]
 public class CheckboxesFieldsetTagHelper : FormGroupFieldsetTagHelperBase
 {
     internal const string TagName = "govuk-checkboxes-fieldset";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName];
 
     /// <summary>
     /// Creates a <see cref="CheckboxesFieldsetTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesHintTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesHintTagHelper.cs
@@ -6,23 +6,12 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the hint in a GDS date input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = CheckboxesTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = CheckboxesTagHelper.TagName)]
-#endif
 [HtmlTargetElement(TagName, ParentTag = CheckboxesFieldsetTagHelper.TagName)]
-#if SHORT_TAG_NAMES
-[HtmlTargetElement(ShortTagName, ParentTag = CheckboxesFieldsetTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's hint.")]
 public class CheckboxesHintTagHelper : FormGroupHintTagHelperBase
 {
     internal const string TagName = "govuk-checkboxes-hint";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesItemDividerTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesItemDividerTagHelper.cs
@@ -7,11 +7,13 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the divider text to separate items in a GDS checkboxes component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = CheckboxesTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = CheckboxesTagHelper.TagName)]
 [HtmlTargetElement(TagName, ParentTag = CheckboxesFieldsetTagHelper.TagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the item divider.")]
 public class CheckboxesItemDividerTagHelper : TagHelper
 {
     internal const string TagName = "govuk-checkboxes-divider";
+    internal const string ShortTagName = ShortTagNames.Divider;
 
     /// <inheritdoc/>
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
@@ -28,10 +30,12 @@ public class CheckboxesItemDividerTagHelper : TagHelper
             content = output.Content;
         }
 
-        checkboxesContext.AddItem(new CheckboxesOptionsItem
-        {
-            Divider = new TemplateString(content.Snapshot())
-        });
+        checkboxesContext.AddItem(
+            new CheckboxesOptionsItem
+            {
+                Divider = new TemplateString(content.Snapshot())
+            },
+            context.TagName);
 
         output.SuppressOutput();
     }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesItemHintTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesItemHintTagHelper.cs
@@ -7,10 +7,12 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the hint of a checkbox item in a GDS checkboxes component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = CheckboxesItemTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = CheckboxesItemTagHelper.ShortTagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the item's hint.")]
 public class CheckboxesItemHintTagHelper : TagHelper
 {
     internal const string TagName = "govuk-checkboxes-item-hint";
+    private const string ShortTagName = ShortTagNames.Hint;
 
     /// <inheritdoc/>
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesItemTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesItemTagHelper.cs
@@ -12,11 +12,13 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents an item in a GDS checkboxes component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = CheckboxesTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = CheckboxesTagHelper.TagName)]
 [HtmlTargetElement(TagName, ParentTag = CheckboxesFieldsetTagHelper.TagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the label for the generated input element.")]
 public class CheckboxesItemTagHelper : TagHelper
 {
     internal const string TagName = "govuk-checkboxes-item";
+    internal const string ShortTagName = ShortTagNames.Item;
 
     private const string CheckedAttributeName = "checked";
     private const string DisabledAttributeName = "disabled";
@@ -149,26 +151,28 @@ public class CheckboxesItemTagHelper : TagHelper
 
         var inputAttributes = new AttributeCollection(InputAttributes);
 
-        checkboxesContext.AddItem(new CheckboxesOptionsItem
-        {
-            Text = null,
-            Html = content.Snapshot(),
-            Id = Id,
-            Name = Name,
-            Value = Value,
-            Label = new LabelOptions
+        checkboxesContext.AddItem(
+            new CheckboxesOptionsItem
             {
-                Classes = labelClasses,
-                Attributes = labelAttributes
+                Text = null,
+                Html = content.Snapshot(),
+                Id = Id,
+                Name = Name,
+                Value = Value,
+                Label = new LabelOptions
+                {
+                    Classes = labelClasses,
+                    Attributes = labelAttributes
+                },
+                Hint = itemContext.Hint?.Options,
+                Checked = @checked,
+                Conditional = itemContext.GetConditionalOptions(),
+                Behaviour = Behavior is CheckboxesItemBehavior.Exclusive ? "exclusive" : null,
+                Disabled = Disabled,
+                Attributes = inputAttributes,
+                ItemAttributes = itemAttributes
             },
-            Hint = itemContext.Hint?.Options,
-            Checked = @checked,
-            Conditional = itemContext.GetConditionalOptions(),
-            Behaviour = Behavior is CheckboxesItemBehavior.Exclusive ? "exclusive" : null,
-            Disabled = Disabled,
-            Attributes = inputAttributes,
-            ItemAttributes = itemAttributes
-        });
+            context.TagName);
 
         output.SuppressOutput();
     }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CheckboxesTagHelper.cs
@@ -15,12 +15,19 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 [RestrictChildren(
     CheckboxesFieldsetTagHelper.TagName,
     FormGroupFieldsetLegendTagHelper.CheckboxesTagName,
+    FormGroupFieldsetLegendTagHelper.ShortTagName,
     CheckboxesItemTagHelper.TagName,
+    CheckboxesItemTagHelper.ShortTagName,
     CheckboxesItemDividerTagHelper.TagName,
+    CheckboxesItemDividerTagHelper.ShortTagName,
     CheckboxesHintTagHelper.TagName,
+    CheckboxesHintTagHelper.ShortTagName,
     CheckboxesErrorMessageTagHelper.TagName,
+    CheckboxesErrorMessageTagHelper.ShortTagName,
     CheckboxesBeforeInputsTagHelper.TagName,
-    CheckboxesAfterInputsTagHelper.TagName
+    CheckboxesBeforeInputsTagHelper.ShortTagName,
+    CheckboxesAfterInputsTagHelper.TagName,
+    CheckboxesAfterInputsTagHelper.ShortTagName
 )]
 [OutputElementHint(DefaultComponentGenerator.ComponentElementTypes.FormGroup)]
 public class CheckboxesTagHelper : TagHelper

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupErrorMessageTagHelperBase.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupErrorMessageTagHelperBase.cs
@@ -8,9 +8,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// </summary>
 public abstract class FormGroupErrorMessageTagHelperBase : TagHelper
 {
-#if SHORT_TAG_NAMES
     internal const string ShortTagName = ShortTagNames.ErrorMessage;
-#endif
 
     private const string VisuallyHiddenTextAttributeName = "visually-hidden-text";
 

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupFieldsetLegendTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupFieldsetLegendTagHelper.cs
@@ -8,6 +8,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// </summary>
 [HtmlTargetElement(CheckboxesTagName, ParentTag = CheckboxesFieldsetTagHelper.TagName)]
 [HtmlTargetElement(CheckboxesTagName, ParentTag = CheckboxesTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = CheckboxesTagHelper.TagName)]
 [HtmlTargetElement(DateInputTagName, ParentTag = DateInputFieldsetTagHelper.TagName)]
 [HtmlTargetElement(DateInputTagName, ParentTag = DateInputTagHelper.TagName)]
 [HtmlTargetElement(RadiosTagName, ParentTag = RadiosFieldsetTagHelper.TagName)]
@@ -20,6 +21,7 @@ public class FormGroupFieldsetLegendTagHelper : TagHelper
     internal const string CheckboxesTagName = "govuk-checkboxes-fieldset-legend";
     internal const string DateInputTagName = "govuk-date-input-fieldset-legend";
     internal const string RadiosTagName = "govuk-radios-fieldset-legend";
+    internal const string ShortTagName = ShortTagNames.Legend;
 
     private const string IsPageHeadingAttributeName = "is-page-heading";
 

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupHintTagHelperBase.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupHintTagHelperBase.cs
@@ -8,9 +8,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// </summary>
 public abstract class FormGroupHintTagHelperBase : TagHelper
 {
-#if SHORT_TAG_NAMES
     internal const string ShortTagName = ShortTagNames.Hint;
-#endif
 
     private protected FormGroupHintTagHelperBase()
     {

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupItemConditionalTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupItemConditionalTagHelper.cs
@@ -7,12 +7,14 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the conditional reveal of an item in a GDS form component.
 /// </summary>
 [HtmlTargetElement(CheckboxesTagName, ParentTag = CheckboxesItemTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = CheckboxesItemTagHelper.ShortTagName)]
 [HtmlTargetElement(RadiosTagName, ParentTag = RadiosItemTagHelper.TagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the conditional reveal for the item.")]
 public class FormGroupItemConditionalTagHelper : TagHelper
 {
     internal const string CheckboxesTagName = "govuk-checkboxes-item-conditional";
     internal const string RadiosTagName = "govuk-radios-item-conditional";
+    private const string ShortTagName = ShortTagNames.Conditional;
 
     /// <inheritdoc/>
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/ShortTagNames.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/ShortTagNames.cs
@@ -6,9 +6,13 @@ internal static class ShortTagNames
     public const string ActionButton = "action-button";
     public const string ActionLink = "action-link";
     public const string AfterInput = "after-input";
+    public const string AfterInputs = "after-inputs";
     public const string BeforeInput = "before-input";
+    public const string BeforeInputs = "before-inputs";
     public const string CardActions = "card-actions";
+    public const string Conditional = "conditional";
     public const string Day = "day";
+    public const string Divider = "divider";
     public const string End = "end";
     public const string ErrorMessage = "error-message";
     public const string Fieldset = "fieldset";
@@ -16,6 +20,7 @@ internal static class ShortTagNames
     public const string Item = "item";
     public const string Key = "key";
     public const string Label = "label";
+    public const string Legend = "legend";
     public const string Month = "month";
     public const string Nav = "nav";
     public const string PanelActions = "panel-actions";

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
@@ -1,0 +1,100 @@
+using AngleSharp.Dom;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Frontend.AspNetCore.IntegrationTests;
+
+public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixture<ShortTagNamesTestsFixture>
+{
+    [Theory]
+    [InlineData("Checkboxes", "short", "long")]
+    [InlineData("Checkboxes", "short-error-message", "long-error-message")]
+    public async Task ShortTagNames_GenerateTheSameMarkupAsTheGovUkPrefixedNames(
+        string component,
+        string shortTestId,
+        string longTestId)
+    {
+        // Act
+        var document = await GetDocumentAsync(component);
+
+        // Assert
+        var shortContainer = GetContainer(document, shortTestId);
+        var longContainer = GetContainer(document, longTestId);
+
+        // Guards against both containers being empty, which would make the comparison vacuous
+        Assert.NotNull(shortContainer.QuerySelector("fieldset > legend"));
+        Assert.NotEmpty(shortContainer.QuerySelectorAll("input[type='checkbox']"));
+
+        // An unrecognised element is written out as-is, so a short name that never bound to a tag
+        // helper would show up here as, say, an <item> element outside the fieldset
+        Assert.Equal(longContainer.InnerHtml, shortContainer.InnerHtml);
+    }
+
+    private async Task<IDocument> GetDocumentAsync(string component)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/ShortTagNamesTests/{component}");
+        var response = await fixture.HttpClient.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+
+        return await response.GetHtmlDocument();
+    }
+
+    private static IElement GetContainer(IDocument document, string testId) =>
+        document.QuerySelector($"[data-testid='{testId}']") ??
+            throw new InvalidOperationException($"No element found with the test ID '{testId}'.");
+}
+
+public class ShortTagNamesTestsFixture : ServerFixture
+{
+    public ShortTagNamesTestsFixture()
+    {
+        HttpClient = new HttpClient() { BaseAddress = new Uri(BaseUrl) };
+    }
+
+    public HttpClient HttpClient { get; }
+
+    public override async ValueTask InitializeAsync()
+    {
+        // No browser needed for these tests
+        await StartHostAsync();
+    }
+
+    public override ValueTask DisposeAsync()
+    {
+        HttpClient.Dispose();
+        return base.DisposeAsync();
+    }
+
+    protected override void Configure(IApplicationBuilder app)
+    {
+        base.Configure(app);
+
+        app.UseEndpoints(endpoints => endpoints.MapControllers());
+    }
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        base.ConfigureServices(services);
+
+        services
+            .AddMvc()
+            .AddRazorOptions(options => options.ViewLocationFormats.Add("/ShortTagNamesTestsViews/{0}.cshtml"));
+    }
+}
+
+[Route("ShortTagNamesTests")]
+public class ShortTagNamesTestsController : Controller
+{
+    [HttpGet("Checkboxes")]
+    public IActionResult GetCheckboxes() => View("Checkboxes", new ShortTagNamesTestsModel());
+}
+
+public class ShortTagNamesTestsModel
+{
+    public string[]? ContactPreferences { get; set; }
+
+    public string? EmailAddress { get; set; }
+
+    public string? PhoneNumber { get; set; }
+
+    public string? MobilePhoneNumber { get; set; }
+}

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/Checkboxes.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/Checkboxes.cshtml
@@ -1,0 +1,110 @@
+@model GovUk.Frontend.AspNetCore.IntegrationTests.ShortTagNamesTestsModel
+
+@* The same component written with the short tag names and with the govuk- prefixed ones;
+   the two must generate identical markup *@
+
+<div data-testid="short">
+    <govuk-checkboxes for="ContactPreferences">
+        <legend>The legend</legend>
+
+        <hint>
+            Select all options that are relevant to you.
+        </hint>
+
+        <before-inputs>Before inputs</before-inputs>
+
+        <item value="email">
+            Email
+            <hint>We'll only use this to contact you about your application</hint>
+            <conditional>
+                <govuk-input for="EmailAddress" type="email" autocomplete="email" spellcheck="false" input-class="govuk-!-width-one-third">
+                    <govuk-input-label>Email address</govuk-input-label>
+                </govuk-input>
+            </conditional>
+        </item>
+
+        <item value="phone">
+            Phone
+            <conditional>
+                <govuk-input for="PhoneNumber" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
+                    <govuk-input-label>Phone number</govuk-input-label>
+                </govuk-input>
+            </conditional>
+        </item>
+
+        <divider>or</divider>
+
+        <item value="text message">
+            Text message
+            <conditional>
+                <govuk-input for="MobilePhoneNumber" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
+                    <govuk-input-label>Mobile phone number</govuk-input-label>
+                </govuk-input>
+            </conditional>
+        </item>
+
+        <after-inputs>After inputs</after-inputs>
+    </govuk-checkboxes>
+</div>
+
+<div data-testid="long">
+    <govuk-checkboxes for="ContactPreferences">
+        <govuk-checkboxes-fieldset-legend>The legend</govuk-checkboxes-fieldset-legend>
+
+        <govuk-checkboxes-hint>
+            Select all options that are relevant to you.
+        </govuk-checkboxes-hint>
+
+        <govuk-checkboxes-before-inputs>Before inputs</govuk-checkboxes-before-inputs>
+
+        <govuk-checkboxes-item value="email">
+            Email
+            <govuk-checkboxes-item-hint>We'll only use this to contact you about your application</govuk-checkboxes-item-hint>
+            <govuk-checkboxes-item-conditional>
+                <govuk-input for="EmailAddress" type="email" autocomplete="email" spellcheck="false" input-class="govuk-!-width-one-third">
+                    <govuk-input-label>Email address</govuk-input-label>
+                </govuk-input>
+            </govuk-checkboxes-item-conditional>
+        </govuk-checkboxes-item>
+
+        <govuk-checkboxes-item value="phone">
+            Phone
+            <govuk-checkboxes-item-conditional>
+                <govuk-input for="PhoneNumber" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
+                    <govuk-input-label>Phone number</govuk-input-label>
+                </govuk-input>
+            </govuk-checkboxes-item-conditional>
+        </govuk-checkboxes-item>
+
+        <govuk-checkboxes-divider>or</govuk-checkboxes-divider>
+
+        <govuk-checkboxes-item value="text message">
+            Text message
+            <govuk-checkboxes-item-conditional>
+                <govuk-input for="MobilePhoneNumber" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
+                    <govuk-input-label>Mobile phone number</govuk-input-label>
+                </govuk-input>
+            </govuk-checkboxes-item-conditional>
+        </govuk-checkboxes-item>
+
+        <govuk-checkboxes-after-inputs>After inputs</govuk-checkboxes-after-inputs>
+    </govuk-checkboxes>
+</div>
+
+@* The error message, which needs a model state error to be rendered alongside the rest *@
+
+<div data-testid="short-error-message">
+    <govuk-checkboxes name="WithError">
+        <legend>The legend</legend>
+        <error-message>Select how you would like to be contacted</error-message>
+        <item value="email">Email</item>
+    </govuk-checkboxes>
+</div>
+
+<div data-testid="long-error-message">
+    <govuk-checkboxes name="WithError">
+        <govuk-checkboxes-fieldset-legend>The legend</govuk-checkboxes-fieldset-legend>
+        <govuk-checkboxes-error-message>Select how you would like to be contacted</govuk-checkboxes-error-message>
+        <govuk-checkboxes-item value="email">Email</govuk-checkboxes-item>
+    </govuk-checkboxes>
+</div>

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/_ViewImports.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/_ViewImports.cshtml
@@ -1,0 +1,2 @@
+@addTagHelper *, GovUk.Frontend.AspNetCore
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/_ViewStart.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = null;
+}

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesContextTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesContextTests.cs
@@ -18,7 +18,7 @@ public class CheckboxesContextTests
         };
 
         // Act
-        context.AddItem(item);
+        context.AddItem(item, "govuk-checkboxes-item");
 
         // Assert
         var contextItem = Assert.Single(context.Items);
@@ -42,7 +42,7 @@ public class CheckboxesContextTests
         context.CloseFieldset();
 
         // Act
-        var ex = Record.Exception(() => context.AddItem(item));
+        var ex = Record.Exception(() => context.AddItem(item, "govuk-checkboxes-item"));
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
@@ -95,7 +95,7 @@ public class CheckboxesContextTests
             Value = new TemplateString("item1")
         };
 
-        context.AddItem(item);
+        context.AddItem(item, "govuk-checkboxes-item");
 
         // Act
         var ex = Record.Exception(() => context.OpenFieldset(new FormGroupFieldsetContext2(CheckboxesFieldsetTagHelper.TagName), new AttributeCollection()));
@@ -162,7 +162,7 @@ public class CheckboxesContextTests
             Value = new TemplateString("item1")
         };
 
-        context.AddItem(item);
+        context.AddItem(item, "govuk-checkboxes-item");
 
         // Act
         var ex = Record.Exception(
@@ -210,7 +210,7 @@ public class CheckboxesContextTests
             Value = new TemplateString("item1")
         };
 
-        context.AddItem(item);
+        context.AddItem(item, "govuk-checkboxes-item");
 
         // Act
         var ex = Record.Exception(() => context.SetHint(attributes: new AttributeCollection(), html: new TemplateString("Hint"), tagName: "govuk-checkboxes-hint"));
@@ -218,6 +218,28 @@ public class CheckboxesContextTests
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
         Assert.Equal("<govuk-checkboxes-hint> must be specified before <govuk-checkboxes-item>.", ex.Message);
+    }
+
+    [Fact]
+    public void SetHint_AlreadyGotItemAddedWithShortTagName_ThrowsInvalidOperationExceptionNamingTheShortTagName()
+    {
+        // Arrange
+        var context = new CheckboxesContext(name: null, @for: null);
+
+        var item = new CheckboxesOptionsItem()
+        {
+            Html = new TemplateString("Item 1"),
+            Value = new TemplateString("item1")
+        };
+
+        context.AddItem(item, "item");
+
+        // Act
+        var ex = Record.Exception(() => context.SetHint(attributes: new AttributeCollection(), html: new TemplateString("Hint"), tagName: "hint"));
+
+        // Assert
+        Assert.IsType<InvalidOperationException>(ex);
+        Assert.Equal("<hint> must be specified before <item>.", ex.Message);
     }
 
     [Fact]

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/CheckboxesTagHelperTests.cs
@@ -35,7 +35,7 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
                     Disabled = true,
                     Id = new TemplateString("first"),
                     Value = new TemplateString("first")
-                });
+                }, CheckboxesItemTagHelper.TagName);
 
                 checkboxesContext.AddItem(new CheckboxesOptionsItem()
                 {
@@ -44,7 +44,7 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
                     Disabled = false,
                     Id = new TemplateString("second"),
                     Value = new TemplateString("second")
-                });
+                }, CheckboxesItemTagHelper.TagName);
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
@@ -121,7 +121,7 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
                     Disabled = true,
                     Id = new TemplateString("first"),
                     Value = new TemplateString("first")
-                });
+                }, CheckboxesItemTagHelper.TagName);
 
                 checkboxesContext.AddItem(new CheckboxesOptionsItem()
                 {
@@ -130,7 +130,7 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
                     Disabled = false,
                     Id = new TemplateString("second"),
                     Value = new TemplateString("second")
-                });
+                }, CheckboxesItemTagHelper.TagName);
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
@@ -185,7 +185,7 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
                     },
                     Id = new TemplateString("first"),
                     Value = new TemplateString("first")
-                });
+                }, CheckboxesItemTagHelper.TagName);
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
@@ -244,7 +244,7 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
                     },
                     Id = new TemplateString("first"),
                     Value = new TemplateString("first")
-                });
+                }, CheckboxesItemTagHelper.TagName);
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
@@ -305,7 +305,7 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
                     },
                     Id = new TemplateString("first"),
                     Value = new TemplateString("first")
-                });
+                }, CheckboxesItemTagHelper.TagName);
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
@@ -374,7 +374,7 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
                     Disabled = true,
                     Id = new TemplateString("first"),
                     Value = new TemplateString("first")
-                });
+                }, CheckboxesItemTagHelper.TagName);
 
                 checkboxesContext.AddItem(new CheckboxesOptionsItem()
                 {
@@ -383,7 +383,7 @@ public class CheckboxesTagHelperTests : TagHelperTestBase<CheckboxesTagHelper>
                     Disabled = false,
                     Id = new TemplateString("second"),
                     Value = new TemplateString("second")
-                });
+                }, CheckboxesItemTagHelper.TagName);
 
                 checkboxesContext.CloseFieldset();
 

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FormGroupItemConditionalTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FormGroupItemConditionalTagHelperTests.cs
@@ -9,9 +9,9 @@ public class FormGroupItemConditionalTagHelperTests : TagHelperTestBase<FormGrou
     public async Task ProcessAsync_SetsConditionalOnContext()
     {
         // Arrange
-        FormGroupItemContext itemContext = TagName == FormGroupItemConditionalTagHelper.CheckboxesTagName ?
-            new CheckboxesItemContext() :
-            new RadiosItemContext();
+        FormGroupItemContext itemContext = TagName == FormGroupItemConditionalTagHelper.RadiosTagName ?
+            new RadiosItemContext() :
+            new CheckboxesItemContext();
 
         var context = CreateTagHelperContext(contexts: itemContext);
 


### PR DESCRIPTION
Adds the short tag name syntax to the checkboxes component, so this now works:

```razor
<govuk-checkboxes for="ContactPreferences">
    <legend>How would you like to be contacted?</legend>
    <hint>Select all options that are relevant to you.</hint>
    <before-inputs>Before inputs</before-inputs>
    <item value="email">
        Email
        <conditional>
            <govuk-input for="EmailAddress" type="email" input-class="govuk-!-width-one-third">
                <govuk-input-label>Email address</govuk-input-label>
            </govuk-input>
        </conditional>
    </item>
    <after-inputs>After inputs</after-inputs>
</govuk-checkboxes>
```

| Element | Short name | Where |
| --- | --- | --- |
| `govuk-checkboxes-fieldset-legend` | `legend` | in `<govuk-checkboxes>` |
| `govuk-checkboxes-hint` | `hint` | in `<govuk-checkboxes>` |
| `govuk-checkboxes-error-message` | `error-message` | in `<govuk-checkboxes>` |
| `govuk-checkboxes-item` | `item` | in `<govuk-checkboxes>` |
| `govuk-checkboxes-divider` | `divider` | in `<govuk-checkboxes>` |
| `govuk-checkboxes-before-inputs` / `-after-inputs` | `before-inputs` / `after-inputs` | in `<govuk-checkboxes>` |
| `govuk-checkboxes-item-hint` | `hint` | in `<item>` |
| `govuk-checkboxes-item-conditional` | `conditional` | in `<item>` |

As with the panel and summary list, short names pair with short parents: `<hint>` and `<conditional>` inside an item target `<item>`, and the `govuk-` prefixed ones target `<govuk-checkboxes-item>`.

The names are declared unconditionally rather than behind `SHORT_TAG_NAMES`, which is not defined for the library and so had compiled the checkboxes fieldset's existing short-name targets out entirely.

### Not inside a fieldset element

Short names are not accepted inside a `<govuk-checkboxes-fieldset>`; every child there keeps its `govuk-` prefixed name. `RestrictChildren` lists only those names, so a short one is a build error rather than markup that silently fails to bind:

```
error RZ2010: The <hint> tag is not allowed by parent <govuk-checkboxes-fieldset> tag helper.
```

The `<fieldset>` alias that `CheckboxesFieldsetTagHelper` had declared (inside the dead `#if`) goes with it, so there is no spelling of the fieldset element that takes short children. The short names pair with the fieldset that `<govuk-checkboxes>` generates for a `<legend>` of its own.

### Error messages

`CheckboxesContext.AddItem` now takes the tag name the item was written with, and records the first one, so messages about an item that has already been added name it as it appears in the view — `<hint> must be specified before <item>`, not `<govuk-checkboxes-item>`. `RadiosContext` is unchanged; the same change belongs with the radios conversion, where it will actually be observable.

### Docs

The generated API tables pick up both spellings. The legend and conditional tag helpers are shared with radios and date input, so `tag_helper_api` takes an optional short name to document alongside the prefixed one. The six checkboxes examples now use the short names; each renders byte-identical HTML to before, so the screenshots do not need regenerating.

### Testing

- The unit tests expand per tag name target, so every existing checkboxes test now runs under the short names too.
- New `ShortTagNamesTests` in the integration tests compiles a Razor view containing the component in both spellings and asserts the generated markup is identical — the only check that exercises tag helper registration end to end.
- 1726 unit tests and 79 integration tests pass; Release build is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)