### PR TITLE
Add short tag name support to the date input tag helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Both elements can now generate their `formaction` attribute from the `asp-` attr
 
 As per the guidance, the first page, the pages either side of the current page and the last page are shown, with an ellipsis wherever pages have been skipped, plus Previous and Next links where there is a page to go to. Nothing is rendered at all when there is only one page. Child elements cannot be combined with these attributes.
 
-The checkboxes and radios tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
+The checkboxes, radios and date input tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
 
 ```razor
 <govuk-checkboxes for="ContactPreferences">
@@ -47,7 +47,19 @@ The checkboxes and radios tag helpers now support short tag name syntax, as the 
 </govuk-checkboxes>
 ```
 
-`<legend>`, `<hint>`, `<error-message>`, `<item>`, `<divider>`, `<before-inputs>` and `<after-inputs>` go directly inside `<govuk-checkboxes>` or `<govuk-radios>`; `<hint>` and `<conditional>` go inside an `<item>`. The `govuk-` prefixed names continue to work everywhere they did before, and remain the only spelling accepted inside a `<govuk-checkboxes-fieldset>` or `<govuk-radios-fieldset>` — the short names pair with the fieldset that the root element generates for a `<legend>` of its own.
+`<legend>`, `<hint>`, `<error-message>`, `<item>`, `<divider>`, `<before-inputs>` and `<after-inputs>` go directly inside `<govuk-checkboxes>` or `<govuk-radios>`; `<hint>` and `<conditional>` go inside an `<item>`. The date input takes the same `<legend>`, `<hint>`, `<error-message>`, `<before-inputs>` and `<after-inputs>`, along with `<day>`, `<month>` and `<year>`, each of which takes a `<label>`:
+
+```razor
+<govuk-date-input for="PassportIssued">
+    <legend>When was your passport issued?</legend>
+    <hint>For example, 27 3 2007</hint>
+    <day><label>Dydd</label></day>
+    <month><label>Mis</label></month>
+    <year><label>Blwyddyn</label></year>
+</govuk-date-input>
+```
+
+The `govuk-` prefixed names continue to work everywhere they did before, and remain the only spelling accepted inside a `<govuk-checkboxes-fieldset>`, `<govuk-radios-fieldset>` or `<govuk-date-input-fieldset>` — the short names pair with the fieldset that the root element generates for a `<legend>` of its own.
 
 `TabsOptions.Title` is now `string?` rather than `TemplateString?`. It only ever comes from the `title` attribute, so it is always text.
 

--- a/docs/components/date-input.md
+++ b/docs/components/date-input.md
@@ -19,9 +19,9 @@
 
 ```razor
 <govuk-date-input id="passport-issued" name-prefix="passport-issued" error-message-prefix="Your passport issue date">
-    <govuk-date-input-error-message>
+    <error-message>
         The date your passport was issued must be in the past
-    </govuk-date-input-error-message>
+    </error-message>
 </govuk-date-input>
 ```
 
@@ -31,15 +31,15 @@
 
 ```razor
 <govuk-date-input id="passport-issued" name-prefix="passport-issued" error-message-prefix="Your passport issue date">
-    <govuk-date-input-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
+    <legend is-page-heading="true" class="govuk-fieldset__legend--l">
         When was your passport issued?
-    </govuk-date-input-fieldset-legend>
-    <govuk-date-input-hint>
+    </legend>
+    <hint>
         For example, 27 3 2007
-    </govuk-date-input-hint>
-    <govuk-date-input-error-message>
+    </hint>
+    <error-message>
         The date your passport was issued must be in the past
-    </govuk-date-input-error-message>
+    </error-message>
 </govuk-date-input>
 ```
 
@@ -57,15 +57,15 @@
 
 ```razor
 <govuk-date-input for="PassportIssued">
-    <govuk-date-input-day>
-        <govuk-date-input-day-label>Dydd</govuk-date-input-day-label>
-    </govuk-date-input-day>
-    <govuk-date-input-month>
-        <govuk-date-input-month-label>Mis</govuk-date-input-month-label>
-    </govuk-date-input-month>
-    <govuk-date-input-year>
-        <govuk-date-input-year-label>Blwyddyn</govuk-date-input-year-label>
-    </govuk-date-input-year>
+    <day>
+        <label>Dydd</label>
+    </day>
+    <month>
+        <label>Mis</label>
+    </month>
+    <year>
+        <label>Blwyddyn</label>
+    </year>
 </govuk-date-input>
 ```
 
@@ -75,9 +75,9 @@
 
 ```razor
 <govuk-date-input for="PassportIssued" error-message-prefix="Your passport issue date">
-    <govuk-date-input-day value="1" />
-    <govuk-date-input-month value="4" />
-    <govuk-date-input-year value="2022" />
+    <day value="1" />
+    <month value="4" />
+    <year value="2022" />
 </govuk-date-input>
 ```
 
@@ -87,7 +87,7 @@
 
 ```razor
 <govuk-date-input for="Birthday" item-types="DateInputItemTypes.DayAndMonth" error-message-prefix="Your birthday">
-    <govuk-date-input-fieldset-legend>What is your birthday?</govuk-date-input-fieldset-legend>
+    <legend>What is your birthday?</legend>
 </govuk-date-input>
 ```
 
@@ -97,7 +97,7 @@
 
 ```razor
 <govuk-date-input for="DateMovedIn" item-types="DateInputItemTypes.MonthAndYear" error-message-prefix="The date you moved into this property">
-    <govuk-date-input-fieldset-legend>When did you move into this property?</govuk-date-input-fieldset-legend>
+    <legend>When did you move into this property?</legend>
 </govuk-date-input>
 ```
 
@@ -126,7 +126,7 @@
 
 #### `<govuk-date-input-fieldset>`
 
-A container element used when the date input should be contained within a fieldset element. When used, every other child element must be placed inside this element rather than the root date input element.
+A container element used when the date input should be contained within a fieldset element. When used, every other child element must be placed inside this element rather than the root date input element, and each must use its govuk- prefixed name; the short names are only available directly inside the root date input element.
 
 Must be inside a `<govuk-date-input>` element.
 
@@ -135,7 +135,7 @@ Must be inside a `<govuk-date-input>` element.
 | `described-by` | `string` | One or more element IDs to add to the `aria-describedby` attribute. |
 
 
-#### `<govuk-date-input-fieldset-legend>`
+#### `<legend>` / `<govuk-date-input-fieldset-legend>`
 
 The content is the HTML to use within the legend. When this element is specified directly inside the root date input element a fieldset is generated automatically.
 
@@ -146,14 +146,14 @@ Must be inside a `<govuk-date-input>` or `<govuk-date-input-fieldset>` element.
 | `is-page-heading` | `bool?` | Whether the legend also acts as the heading for the page. The default is `false`. |
 
 
-#### `<govuk-date-input-hint>`
+#### `<hint>` / `<govuk-date-input-hint>`
 
 The content is the HTML to use within the component's hint.
 
 Must be inside a `<govuk-date-input>` or `<govuk-date-input-fieldset>` element.
 
 
-#### `<govuk-date-input-error-message>`
+#### `<error-message>` / `<govuk-date-input-error-message>`
 
 The content is the HTML to use within the component's error message.
 
@@ -165,14 +165,14 @@ Must be inside a `<govuk-date-input>` or `<govuk-date-input-fieldset>` element.
 | `visually-hidden-text` | `string` | A visually hidden prefix used before the error message. The default is `"Error"`. |
 
 
-#### `<govuk-date-input-before-inputs>`
+#### `<before-inputs>` / `<govuk-date-input-before-inputs>`
 
 The content is the HTML to use before the date input.
 
 Must be inside a `<govuk-date-input>` or `<govuk-date-input-fieldset>` element.
 
 
-#### `<govuk-date-input-day>`
+#### `<day>` / `<govuk-date-input-day>`
 
 Must be inside a `<govuk-date-input>` or `<govuk-date-input-fieldset>` element.
 
@@ -186,14 +186,14 @@ Must be inside a `<govuk-date-input>` or `<govuk-date-input-fieldset>` element.
 | `value` | `string` | The `value` attribute for the generated `input` element. This cannot be specified if the `Value` property on the parent is also specified. |
 
 
-#### `<govuk-date-input-day-label>`
+#### `<label>` / `<govuk-date-input-day-label>`
 
 The content is the HTML to use within the item's label.
 
-Must be inside a `<govuk-date-input-day>` element.
+Must be inside a `<day>` or `<govuk-date-input-day>` element.
 
 
-#### `<govuk-date-input-month>`
+#### `<month>` / `<govuk-date-input-month>`
 
 Must be inside a `<govuk-date-input>` or `<govuk-date-input-fieldset>` element.
 
@@ -207,14 +207,14 @@ Must be inside a `<govuk-date-input>` or `<govuk-date-input-fieldset>` element.
 | `value` | `string` | The `value` attribute for the generated `input` element. This cannot be specified if the `Value` property on the parent is also specified. |
 
 
-#### `<govuk-date-input-month-label>`
+#### `<label>` / `<govuk-date-input-month-label>`
 
 The content is the HTML to use within the item's label.
 
-Must be inside a `<govuk-date-input-month>` element.
+Must be inside a `<month>` or `<govuk-date-input-month>` element.
 
 
-#### `<govuk-date-input-year>`
+#### `<year>` / `<govuk-date-input-year>`
 
 Must be inside a `<govuk-date-input>` or `<govuk-date-input-fieldset>` element.
 
@@ -228,14 +228,14 @@ Must be inside a `<govuk-date-input>` or `<govuk-date-input-fieldset>` element.
 | `value` | `string` | The `value` attribute for the generated `input` element. This cannot be specified if the `Value` property on the parent is also specified. |
 
 
-#### `<govuk-date-input-year-label>`
+#### `<label>` / `<govuk-date-input-year-label>`
 
 The content is the HTML to use within the item's label.
 
-Must be inside a `<govuk-date-input-year>` element.
+Must be inside a `<year>` or `<govuk-date-input-year>` element.
 
 
-#### `<govuk-date-input-after-inputs>`
+#### `<after-inputs>` / `<govuk-date-input-after-inputs>`
 
 The content is the HTML to use after the date input.
 

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithCustomItemLabelsExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithCustomItemLabelsExample.cshtml
@@ -3,14 +3,14 @@
 
 <example>
     <govuk-date-input for="PassportIssued">
-        <govuk-date-input-day>
-            <govuk-date-input-day-label>Dydd</govuk-date-input-day-label>
-        </govuk-date-input-day>
-        <govuk-date-input-month>
-            <govuk-date-input-month-label>Mis</govuk-date-input-month-label>
-        </govuk-date-input-month>
-        <govuk-date-input-year>
-            <govuk-date-input-year-label>Blwyddyn</govuk-date-input-year-label>
-        </govuk-date-input-year>
+        <day>
+            <label>Dydd</label>
+        </day>
+        <month>
+            <label>Mis</label>
+        </month>
+        <year>
+            <label>Blwyddyn</label>
+        </year>
     </govuk-date-input>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithCustomItemValuesExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithCustomItemValuesExample.cshtml
@@ -3,8 +3,8 @@
 
 <example>
     <govuk-date-input for="PassportIssued" error-message-prefix="Your passport issue date">
-        <govuk-date-input-day value="1" />
-        <govuk-date-input-month value="4" />
-        <govuk-date-input-year value="2022" />
+        <day value="1" />
+        <month value="4" />
+        <year value="2022" />
     </govuk-date-input>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithDayAndMonthOnlyExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithDayAndMonthOnlyExample.cshtml
@@ -3,6 +3,6 @@
 
 <example>
     <govuk-date-input for="Birthday" item-types="DateInputItemTypes.DayAndMonth" error-message-prefix="Your birthday">
-        <govuk-date-input-fieldset-legend>What is your birthday?</govuk-date-input-fieldset-legend>
+        <legend>What is your birthday?</legend>
     </govuk-date-input>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithErrorMessageExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithErrorMessageExample.cshtml
@@ -2,8 +2,8 @@
 
 <example>
     <govuk-date-input id="passport-issued" name-prefix="passport-issued" error-message-prefix="Your passport issue date">
-        <govuk-date-input-error-message>
+        <error-message>
             The date your passport was issued must be in the past
-        </govuk-date-input-error-message>
+        </error-message>
     </govuk-date-input>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithFieldsetExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithFieldsetExample.cshtml
@@ -2,14 +2,14 @@
 
 <example>
     <govuk-date-input id="passport-issued" name-prefix="passport-issued" error-message-prefix="Your passport issue date">
-        <govuk-date-input-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
+        <legend is-page-heading="true" class="govuk-fieldset__legend--l">
             When was your passport issued?
-        </govuk-date-input-fieldset-legend>
-        <govuk-date-input-hint>
+        </legend>
+        <hint>
             For example, 27 3 2007
-        </govuk-date-input-hint>
-        <govuk-date-input-error-message>
+        </hint>
+        <error-message>
             The date your passport was issued must be in the past
-        </govuk-date-input-error-message>
+        </error-message>
     </govuk-date-input>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithMonthAndYearOnlyExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/DateInput/DateInputWithMonthAndYearOnlyExample.cshtml
@@ -3,6 +3,6 @@
 
 <example>
     <govuk-date-input for="DateMovedIn" item-types="DateInputItemTypes.MonthAndYear" error-message-prefix="The date you moved into this property">
-        <govuk-date-input-fieldset-legend>When did you move into this property?</govuk-date-input-fieldset-legend>
+        <legend>When did you move into this property?</legend>
     </govuk-date-input>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Templates/components/date-input.liquid
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Templates/components/date-input.liquid
@@ -59,7 +59,7 @@
 
 {{ tag_helper_api("DateInputFieldsetTagHelper") }}
 
-{{ tag_helper_api("FormGroupFieldsetLegendTagHelper", "govuk-date-input-fieldset-legend") }}
+{{ tag_helper_api("FormGroupFieldsetLegendTagHelper", "govuk-date-input-fieldset-legend", "legend") }}
 
 {{ tag_helper_api("DateInputHintTagHelper") }}
 

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputAfterInputsTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputAfterInputsTagHelper.cs
@@ -7,21 +7,17 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the content after the inputs in a GDS date input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = DateInputTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = DateInputTagHelper.TagName)]
 [HtmlTargetElement(TagName, ParentTag = DateInputFieldsetTagHelper.TagName)]
-#if SHORT_TAG_NAMES
-[HtmlTargetElement(TagName, ParentTag = DateInputFieldsetTagHelper.ShortTagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use after the date input.")]
 public class DateInputAfterInputsTagHelper : TagHelper
 {
     private readonly ILogger<DateInputAfterInputsTagHelper> _logger;
 
     internal const string TagName = "govuk-date-input-after-inputs";
+    internal const string ShortTagName = ShortTagNames.AfterInputs;
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = new[]
-    {
-        TagName
-    };
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <summary>
     /// Creates a new <see cref="DateInputAfterInputsTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputBeforeInputsTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputBeforeInputsTagHelper.cs
@@ -7,21 +7,17 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the content before the inputs in a GDS date input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = DateInputTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = DateInputTagHelper.TagName)]
 [HtmlTargetElement(TagName, ParentTag = DateInputFieldsetTagHelper.TagName)]
-#if SHORT_TAG_NAMES
-[HtmlTargetElement(TagName, ParentTag = DateInputFieldsetTagHelper.ShortTagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use before the date input.")]
 public class DateInputBeforeInputsTagHelper : TagHelper
 {
     private readonly ILogger<DateInputBeforeInputsTagHelper> _logger;
 
     internal const string TagName = "govuk-date-input-before-inputs";
+    internal const string ShortTagName = ShortTagNames.BeforeInputs;
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = new[]
-    {
-        TagName
-    };
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <summary>
     /// Creates a new <see cref="DateInputBeforeInputsTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputContext.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputContext.cs
@@ -30,13 +30,11 @@ internal class DateInputContext(bool haveExplicitValue, ModelExpression? @for) :
 
     public IHtmlContent? AfterInputs => _afterInputs?.Content;
 
-    protected override IReadOnlyCollection<string> ErrorMessageTagNames { get; } =
-        [/*, DateInputErrorMessageTagHelper.ShortTagName, */DateInputErrorMessageTagHelper.TagName];
+    protected override IReadOnlyCollection<string> ErrorMessageTagNames { get; } = DateInputErrorMessageTagHelper.AllTagNames;
 
     public string FieldsetTagName { get; } = DateInputFieldsetTagHelper.TagName;
 
-    protected override IReadOnlyCollection<string> HintTagNames { get; } =
-        [/*DateInputHintTagHelper.ShortTagName, */DateInputHintTagHelper.TagName];
+    protected override IReadOnlyCollection<string> HintTagNames { get; } = DateInputHintTagHelper.AllTagNames;
 
     protected override IReadOnlyCollection<string> LabelTagNames => throw new NotSupportedException();
 

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputDayLabelTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputDayLabelTagHelper.cs
@@ -6,6 +6,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the label in the day item of a GDS date input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = DateInputDayTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = DateInputDayTagHelper.ShortTagName)]
 public class DateInputDayLabelTagHelper : DateInputItemLabelTagHelperBase
 {
     internal const string TagName = "govuk-date-input-day-label";

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputDayTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputDayTagHelper.cs
@@ -6,11 +6,13 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the day item in a GDS date input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = DateInputTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = DateInputTagHelper.TagName)]
 [HtmlTargetElement(TagName, ParentTag = DateInputFieldsetTagHelper.TagName)]
-[RestrictChildren(DateInputDayLabelTagHelper.TagName)]
+[RestrictChildren(DateInputDayLabelTagHelper.TagName, DateInputDayLabelTagHelper.ShortTagName)]
 public class DateInputDayTagHelper : DateInputItemTagHelperBase
 {
     internal const string TagName = "govuk-date-input-day";
+    internal const string ShortTagName = ShortTagNames.Day;
 
     /// <summary>
     /// Creates a <see cref="DateInputDayTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputErrorMessageTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputErrorMessageTagHelper.cs
@@ -5,15 +5,8 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 
 /// <inheritdoc/>
 [HtmlTargetElement(TagName, ParentTag = DateInputTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = DateInputTagHelper.TagName)]
-#endif
 [HtmlTargetElement(TagName, ParentTag = DateInputFieldsetTagHelper.TagName)]
-#if SHORT_TAG_NAMES
-[HtmlTargetElement(ShortTagName, ParentTag = DateInputFieldsetTagHelper.TagName)]
-[HtmlTargetElement(TagName, ParentTag = DateInputFieldsetTagHelper.ShortTagName)]
-[HtmlTargetElement(ShortTagName, ParentTag = DateInputFieldsetTagHelper.ShortTagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's error message.")]
 public class DateInputErrorMessageTagHelper : FormGroupErrorMessageTagHelperBase
 {
@@ -21,13 +14,7 @@ public class DateInputErrorMessageTagHelper : FormGroupErrorMessageTagHelperBase
 
     private const string ErrorItemsAttributeName = "error-items";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <summary>
     /// The components of the date that have errors (day, month and/or year).

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputFieldsetTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputFieldsetTagHelper.cs
@@ -6,9 +6,6 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the fieldset in a GDS date input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = DateInputTagHelper.TagName)]
-#if SHORT_TAG_NAMES
-[HtmlTargetElement(ShortTagName, ParentTag = DateInputTagHelper.TagName)]
-#endif
 [RestrictChildren(
     FormGroupFieldsetLegendTagHelper.DateInputTagName,
     DateInputHintTagHelper.TagName,
@@ -18,24 +15,13 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
     DateInputYearTagHelper.TagName,
     DateInputBeforeInputsTagHelper.TagName,
     DateInputAfterInputsTagHelper.TagName
-#if SHORT_TAG_NAMES
-    ,
-    FormGroupHintTagHelperBase.ShortTagName,
-    FormGroupErrorMessageTagHelperBase.ShortTagName
-#endif
     )]
-[TagHelperDocumentation(ContentDescription = "A container element used when the date input should be contained within a fieldset element. When used, every other child element must be placed inside this element rather than the root date input element.")]
+[TagHelperDocumentation(ContentDescription = "A container element used when the date input should be contained within a fieldset element. When used, every other child element must be placed inside this element rather than the root date input element, and each must use its govuk- prefixed name; the short names are only available directly inside the root date input element.")]
 public class DateInputFieldsetTagHelper : FormGroupFieldsetTagHelperBase
 {
     internal const string TagName = "govuk-date-input-fieldset";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName];
 
     /// <summary>
     /// Creates a <see cref="DateInputFieldsetTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputHintTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputHintTagHelper.cs
@@ -6,23 +6,12 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the hint in a GDS date input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = DateInputTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = DateInputTagHelper.TagName)]
-#endif
 [HtmlTargetElement(TagName, ParentTag = DateInputFieldsetTagHelper.TagName)]
-#if SHORT_TAG_NAMES
-[HtmlTargetElement(ShortTagName, ParentTag = DateInputFieldsetTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's hint.")]
 public class DateInputHintTagHelper : FormGroupHintTagHelperBase
 {
     internal const string TagName = "govuk-date-input-hint";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputItemLabelTagHelperBase.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputItemLabelTagHelperBase.cs
@@ -9,6 +9,8 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the item's label.")]
 public abstract class DateInputItemLabelTagHelperBase : TagHelper
 {
+    internal const string ShortTagName = ShortTagNames.Label;
+
     /// <summary>
     /// Creates a <see cref="DateInputItemLabelTagHelperBase"/>.
     /// </summary>

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputItemTagHelperBase.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputItemTagHelperBase.cs
@@ -98,7 +98,14 @@ public abstract class DateInputItemTagHelperBase : TagHelper
     /// <inheritdoc/>
     public override void Init(TagHelperContext context)
     {
-        context.SetContextItem(new DateInputItemContext(ItemTagName, _labelTagName));
+        ArgumentNullException.ThrowIfNull(context);
+
+        // The label pairs with the item it is inside, so a short-named item takes the short-named label
+        var labelTagName = context.TagName == ItemTagName ?
+            _labelTagName :
+            DateInputItemLabelTagHelperBase.ShortTagName;
+
+        context.SetContextItem(new DateInputItemContext(context.TagName, labelTagName));
     }
 
     /// <inheritdoc/>

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputMonthLabelTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputMonthLabelTagHelper.cs
@@ -6,6 +6,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the label in the month item of a GDS date input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = DateInputMonthTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = DateInputMonthTagHelper.ShortTagName)]
 public class DateInputMonthLabelTagHelper : DateInputItemLabelTagHelperBase
 {
     internal const string TagName = "govuk-date-input-month-label";

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputMonthTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputMonthTagHelper.cs
@@ -6,11 +6,13 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the month item in a GDS date input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = DateInputTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = DateInputTagHelper.TagName)]
 [HtmlTargetElement(TagName, ParentTag = DateInputFieldsetTagHelper.TagName)]
-[RestrictChildren(DateInputMonthLabelTagHelper.TagName)]
+[RestrictChildren(DateInputMonthLabelTagHelper.TagName, DateInputMonthLabelTagHelper.ShortTagName)]
 public class DateInputMonthTagHelper : DateInputItemTagHelperBase
 {
     internal const string TagName = "govuk-date-input-month";
+    internal const string ShortTagName = ShortTagNames.Month;
 
     /// <summary>
     /// Creates a <see cref="DateInputMonthTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputTagHelper.cs
@@ -20,18 +20,21 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 [RestrictChildren(
     DateInputFieldsetTagHelper.TagName,
     FormGroupFieldsetLegendTagHelper.DateInputTagName,
+    FormGroupFieldsetLegendTagHelper.ShortTagName,
     DateInputHintTagHelper.TagName,
+    DateInputHintTagHelper.ShortTagName,
     DateInputErrorMessageTagHelper.TagName,
+    DateInputErrorMessageTagHelper.ShortTagName,
     DateInputDayTagHelper.TagName,
+    DateInputDayTagHelper.ShortTagName,
     DateInputMonthTagHelper.TagName,
+    DateInputMonthTagHelper.ShortTagName,
     DateInputYearTagHelper.TagName,
+    DateInputYearTagHelper.ShortTagName,
     DateInputBeforeInputsTagHelper.TagName,
-    DateInputAfterInputsTagHelper.TagName
-#if SHORT_TAG_NAMES
-    ,
-    FormGroupHintTagHelperBase.ShortTagName,
-    FormGroupErrorMessageTagHelperBase.ShortTagName
-#endif
+    DateInputBeforeInputsTagHelper.ShortTagName,
+    DateInputAfterInputsTagHelper.TagName,
+    DateInputAfterInputsTagHelper.ShortTagName
     )]
 [OutputElementHint(DefaultComponentGenerator.ComponentElementTypes.FormGroup)]
 public class DateInputTagHelper : TagHelper

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputYearLabelTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputYearLabelTagHelper.cs
@@ -6,6 +6,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the label in the year item of a GDS date input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = DateInputYearTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = DateInputYearTagHelper.ShortTagName)]
 public class DateInputYearLabelTagHelper : DateInputItemLabelTagHelperBase
 {
     internal const string TagName = "govuk-date-input-year-label";

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputYearTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DateInputYearTagHelper.cs
@@ -6,11 +6,13 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the year item in a GDS date input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = DateInputTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = DateInputTagHelper.TagName)]
 [HtmlTargetElement(TagName, ParentTag = DateInputFieldsetTagHelper.TagName)]
-[RestrictChildren(DateInputYearLabelTagHelper.TagName)]
+[RestrictChildren(DateInputYearLabelTagHelper.TagName, DateInputYearLabelTagHelper.ShortTagName)]
 public class DateInputYearTagHelper : DateInputItemTagHelperBase
 {
     internal const string TagName = "govuk-date-input-year";
+    internal const string ShortTagName = ShortTagNames.Year;
 
     /// <summary>
     /// Creates a <see cref="DateInputYearTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupFieldsetLegendTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupFieldsetLegendTagHelper.cs
@@ -11,6 +11,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 [HtmlTargetElement(ShortTagName, ParentTag = CheckboxesTagHelper.TagName)]
 [HtmlTargetElement(DateInputTagName, ParentTag = DateInputFieldsetTagHelper.TagName)]
 [HtmlTargetElement(DateInputTagName, ParentTag = DateInputTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = DateInputTagHelper.TagName)]
 [HtmlTargetElement(RadiosTagName, ParentTag = RadiosFieldsetTagHelper.TagName)]
 [HtmlTargetElement(RadiosTagName, ParentTag = RadiosTagHelper.TagName)]
 [HtmlTargetElement(ShortTagName, ParentTag = RadiosTagHelper.TagName)]

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupFieldsetTagHelperBase.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupFieldsetTagHelperBase.cs
@@ -10,10 +10,6 @@ public abstract class FormGroupFieldsetTagHelperBase : TagHelper
 {
     private const string DescribedByAttributeName = "described-by";
 
-#if SHORT_TAG_NAMES
-    internal const string ShortTagName = ShortTagNames.Fieldset;
-#endif
-
     private protected FormGroupFieldsetTagHelperBase()
     {
     }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/ShortTagNames.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/ShortTagNames.cs
@@ -15,7 +15,6 @@ internal static class ShortTagNames
     public const string Divider = "divider";
     public const string End = "end";
     public const string ErrorMessage = "error-message";
-    public const string Fieldset = "fieldset";
     public const string Hint = "hint";
     public const string Item = "item";
     public const string Key = "key";

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
@@ -10,6 +10,8 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
     [InlineData("Checkboxes", "short-error-message", "long-error-message")]
     [InlineData("Radios", "short", "long")]
     [InlineData("Radios", "short-error-message", "long-error-message")]
+    [InlineData("DateInput", "short", "long")]
+    [InlineData("DateInput", "short-error-message", "long-error-message")]
     public async Task ShortTagNames_GenerateTheSameMarkupAsTheGovUkPrefixedNames(
         string component,
         string shortTestId,
@@ -24,7 +26,7 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
 
         // Guards against both containers being empty, which would make the comparison vacuous
         Assert.NotNull(shortContainer.QuerySelector("fieldset > legend"));
-        Assert.NotEmpty(shortContainer.QuerySelectorAll("input[type='checkbox'], input[type='radio']"));
+        Assert.NotEmpty(shortContainer.QuerySelectorAll("input"));
 
         // An unrecognised element is written out as-is, so a short name that never bound to a tag
         // helper would show up here as, say, an <item> element outside the fieldset
@@ -91,6 +93,9 @@ public class ShortTagNamesTestsController : Controller
 
     [HttpGet("Radios")]
     public IActionResult GetRadios() => View("Radios", new ShortTagNamesTestsModel());
+
+    [HttpGet("DateInput")]
+    public IActionResult GetDateInput() => View("DateInput", new ShortTagNamesTestsModel());
 }
 
 public class ShortTagNamesTestsModel
@@ -104,4 +109,7 @@ public class ShortTagNamesTestsModel
     public string? PhoneNumber { get; set; }
 
     public string? MobilePhoneNumber { get; set; }
+
+    [DateInput(ErrorMessagePrefix = "Your date of birth")]
+    public DateOnly? DateOfBirth { get; set; }
 }

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/DateInput.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/DateInput.cshtml
@@ -1,0 +1,66 @@
+@model GovUk.Frontend.AspNetCore.IntegrationTests.ShortTagNamesTestsModel
+
+@* The same component written with the short tag names and with the govuk- prefixed ones;
+   the two must generate identical markup *@
+
+<div data-testid="short">
+    <govuk-date-input for="DateOfBirth">
+        <legend>The legend</legend>
+
+        <hint>
+            For example, 31 3 1980
+        </hint>
+
+        <before-inputs>Before inputs</before-inputs>
+
+        <day>
+            <label>Diwrnod</label>
+        </day>
+        <month>
+            <label>Mis</label>
+        </month>
+        <year>
+            <label>Blwyddyn</label>
+        </year>
+
+        <after-inputs>After inputs</after-inputs>
+    </govuk-date-input>
+</div>
+
+<div data-testid="long">
+    <govuk-date-input for="DateOfBirth">
+        <govuk-date-input-fieldset-legend>The legend</govuk-date-input-fieldset-legend>
+
+        <govuk-date-input-hint>
+            For example, 31 3 1980
+        </govuk-date-input-hint>
+
+        <govuk-date-input-before-inputs>Before inputs</govuk-date-input-before-inputs>
+
+        <govuk-date-input-day>
+            <govuk-date-input-day-label>Diwrnod</govuk-date-input-day-label>
+        </govuk-date-input-day>
+        <govuk-date-input-month>
+            <govuk-date-input-month-label>Mis</govuk-date-input-month-label>
+        </govuk-date-input-month>
+        <govuk-date-input-year>
+            <govuk-date-input-year-label>Blwyddyn</govuk-date-input-year-label>
+        </govuk-date-input-year>
+
+        <govuk-date-input-after-inputs>After inputs</govuk-date-input-after-inputs>
+    </govuk-date-input>
+</div>
+
+<div data-testid="short-error-message">
+    <govuk-date-input id="with-error" name-prefix="WithError" error-message-prefix="Your date of birth">
+        <legend>The legend</legend>
+        <error-message>Enter your date of birth</error-message>
+    </govuk-date-input>
+</div>
+
+<div data-testid="long-error-message">
+    <govuk-date-input id="with-error" name-prefix="WithError" error-message-prefix="Your date of birth">
+        <govuk-date-input-fieldset-legend>The legend</govuk-date-input-fieldset-legend>
+        <govuk-date-input-error-message>Enter your date of birth</govuk-date-input-error-message>
+    </govuk-date-input>
+</div>


### PR DESCRIPTION
Stacked on #530, which is stacked on #529; the diff will narrow to the date input as those merge.

```razor
<govuk-date-input for="PassportIssued">
    <legend is-page-heading="true" class="govuk-fieldset__legend--l">When was your passport issued?</legend>
    <hint>For example, 27 3 2007</hint>
    <day><label>Dydd</label></day>
    <month><label>Mis</label></month>
    <year><label>Blwyddyn</label></year>
</govuk-date-input>
```

| Element | Short name | Where |
| --- | --- | --- |
| `govuk-date-input-fieldset-legend` | `legend` | in `<govuk-date-input>` |
| `govuk-date-input-hint` | `hint` | in `<govuk-date-input>` |
| `govuk-date-input-error-message` | `error-message` | in `<govuk-date-input>` |
| `govuk-date-input-day` / `-month` / `-year` | `day` / `month` / `year` | in `<govuk-date-input>` |
| `govuk-date-input-before-inputs` / `-after-inputs` | `before-inputs` / `after-inputs` | in `<govuk-date-input>` |
| `govuk-date-input-day-label` / `-month-label` / `-year-label` | `label` | in `<day>` / `<month>` / `<year>` |

The three `<label>` targets don't collide: each pairs with its own item, so `("label", "day")`, `("label", "month")` and `("label", "year")` are distinct. Nothing merges here, unlike the item hint in #530.

Short names are not accepted inside a `<govuk-date-input-fieldset>`, matching the other two components, and `RestrictChildren` lists only the `govuk-` prefixed names there so a short one is a build error rather than markup that silently fails to bind.

### The `<fieldset>` alias is gone

The date input was the last component still declaring `<fieldset>` as a short alias, inside the dead `#if SHORT_TAG_NAMES`. Removing it leaves `FormGroupFieldsetTagHelperBase.ShortTagName` unreferenced, so that and `ShortTagNames.Fieldset` go too — no component's fieldset element has a short name now, which is the rule the three PRs have settled on.

### Error messages

`DateInputItemTagHelperBase` builds the item's context from the tag name the item was written with, and gives it the label name that pairs with it, so a duplicate label reports `<label>` and `<day>` rather than their prefixed names. The date input already recorded item tag names, so nothing else needed the treatment `CheckboxesContext` and `RadiosContext` got.

`DateInputContext` now takes its hint and error message tag name lists from `AllTagNames`, replacing two commented-out short names left over from the `#if` work.

### Docs

The eight date input examples use the short names and the API tables pick up both spellings. All eight example pages render byte-identical HTML to this branch's parent, so no screenshots need regenerating, and `just publish-docs` on the committed tree is clean.

### Testing

- `ShortTagNamesTests` gains a date input view — the component in both spellings, asserted to generate identical markup, including a `<label>` inside each item.
- The unit tests expand per tag name target, so the existing date input tests now run under the short names too.
- 1763 unit tests and 83 integration tests pass; Release build and `dotnet format --verify-no-changes` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)