### PR TITLE
Add short tag name support to the text input tag helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Both elements can now generate their `formaction` attribute from the `asp-` attr
 
 As per the guidance, the first page, the pages either side of the current page and the last page are shown, with an ellipsis wherever pages have been skipped, plus Previous and Next links where there is a page to go to. Nothing is rendered at all when there is only one page. Child elements cannot be combined with these attributes.
 
-The checkboxes, radios and date input tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
+The checkboxes, radios, date input and text input tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
 
 ```razor
 <govuk-checkboxes for="ContactPreferences">
@@ -40,7 +40,7 @@ The checkboxes, radios and date input tag helpers now support short tag name syn
         Email
         <conditional>
             <govuk-input for="EmailAddress" type="email" input-class="govuk-!-width-one-third">
-                <govuk-input-label>Email address</govuk-input-label>
+                <label>Email address</label>
             </govuk-input>
         </conditional>
     </item>
@@ -58,6 +58,8 @@ The checkboxes, radios and date input tag helpers now support short tag name syn
     <year><label>Blwyddyn</label></year>
 </govuk-date-input>
 ```
+
+The text input takes `<label>`, `<hint>`, `<error-message>`, `<before-input>`, `<prefix>`, `<suffix>` and `<after-input>`.
 
 The `govuk-` prefixed names continue to work everywhere they did before, and remain the only spelling accepted inside a `<govuk-checkboxes-fieldset>`, `<govuk-radios-fieldset>` or `<govuk-date-input-fieldset>` — the short names pair with the fieldset that the root element generates for a `<legend>` of its own.
 

--- a/docs/components/checkboxes.md
+++ b/docs/components/checkboxes.md
@@ -70,7 +70,7 @@
         Email
         <conditional>
             <govuk-input for="EmailAddress" type="email" autocomplete="email" spellcheck="false" input-class="govuk-!-width-one-third">
-                <govuk-input-label>Email address</govuk-input-label>
+                <label>Email address</label>
             </govuk-input>
         </conditional>
     </item>
@@ -79,7 +79,7 @@
         Phone
         <conditional>
             <govuk-input for="PhoneNumber" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
-                <govuk-input-label>Phone number</govuk-input-label>
+                <label>Phone number</label>
             </govuk-input>
         </conditional>
     </item>
@@ -88,7 +88,7 @@
         Text message
         <conditional>
             <govuk-input for="MobilePhoneNumber" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
-                <govuk-input-label>Mobile phone number</govuk-input-label>
+                <label>Mobile phone number</label>
             </govuk-input>
         </conditional>
     </item>

--- a/docs/components/radios.md
+++ b/docs/components/radios.md
@@ -59,8 +59,8 @@
         Email
         <conditional>
             <govuk-input id="contact-by-email" name="contact-by-email" type="email" autocomplete="email" spellcheck="false" class="govuk-!-width-one-half">
-                <govuk-input-label>Email address</govuk-input-label>
-                <govuk-input-error-message>Email address cannot be blank</govuk-input-error-message>
+                <label>Email address</label>
+                <error-message>Email address cannot be blank</error-message>
             </govuk-input>
         </conditional>
     </item>
@@ -69,7 +69,7 @@
         Phone
         <conditional>
             <govuk-input for="PhoneNumber" type="tel" autocomplete="tel" class="govuk-!-width-one-third">
-                <govuk-input-label>Phone number</govuk-input-label>
+                <label>Phone number</label>
             </govuk-input>
         </conditional>
     </item>
@@ -78,7 +78,7 @@
         Text message
         <conditional>
             <govuk-input for="MobilePhoneNumber" type="tel" autocomplete="tel" class="govuk-!-width-one-third">
-                <govuk-input-label>Mobile phone number</govuk-input-label>
+                <label>Mobile phone number</label>
             </govuk-input>
         </conditional>
     </item>

--- a/docs/components/text-input.md
+++ b/docs/components/text-input.md
@@ -11,8 +11,8 @@
 
 ```razor
 <govuk-input for="AccountNumber" input-class="govuk-input--width-10" inputmode="numeric" pattern="[0-9]*" spellcheck="false">
-    <govuk-input-label is-page-heading="true" class="govuk-label--l">What is your account number?</govuk-input-label>
-    <govuk-input-hint>Must be between 6 and 8 digits long</govuk-input-hint>
+    <label is-page-heading="true" class="govuk-label--l">What is your account number?</label>
+    <hint>Must be between 6 and 8 digits long</hint>
 </govuk-input>
 ```
 
@@ -22,9 +22,9 @@
 
 ```razor
 <govuk-input name="EventName">
-    <govuk-input-label is-page-heading="true" class="govuk-label--l">What is the name of the event?</govuk-input-label>
-    <govuk-input-hint>The name you’ll use on promotional material.</govuk-input-hint>
-    <govuk-input-error-message>Enter an event name</govuk-input-error-message>
+    <label is-page-heading="true" class="govuk-label--l">What is the name of the event?</label>
+    <hint>The name you’ll use on promotional material.</hint>
+    <error-message>Enter an event name</error-message>
 </govuk-input>
 ```
 
@@ -34,9 +34,9 @@
 
 ```razor
 <govuk-input for="CostPerItem" input-class="govuk-input--width-5" spellcheck="false">
-    <govuk-input-label is-page-heading="true" class="govuk-label--l">What is the cost per item, in pounds?</govuk-input-label>
-    <govuk-input-prefix>&pound;</govuk-input-prefix>
-    <govuk-input-suffix>per item</govuk-input-suffix>
+    <label is-page-heading="true" class="govuk-label--l">What is the cost per item, in pounds?</label>
+    <prefix>&pound;</prefix>
+    <suffix>per item</suffix>
 </govuk-input>
 ```
 
@@ -66,7 +66,7 @@
 | `value` | `string` | The `value` attribute for the generated `input` element. If not specified and `For` is not `null` then the value for the specified model expression will be used. |
 
 
-#### `<govuk-input-label>`
+#### `<label>` / `<govuk-input-label>`
 
 The content is the HTML to use within the component's label.
 
@@ -77,14 +77,14 @@ Must be inside a `<govuk-input>` element.
 | `is-page-heading` | `bool?` | Whether the label also acts as the heading for the page. |
 
 
-#### `<govuk-input-hint>`
+#### `<hint>` / `<govuk-input-hint>`
 
 The content is the HTML to use within the component's hint.
 
 Must be inside a `<govuk-input>` element.
 
 
-#### `<govuk-input-error-message>`
+#### `<error-message>` / `<govuk-input-error-message>`
 
 The content is the HTML to use within the component's error message.
 
@@ -95,28 +95,28 @@ Must be inside a `<govuk-input>` element.
 | `visually-hidden-text` | `string` | A visually hidden prefix used before the error message. The default is `"Error"`. |
 
 
-#### `<govuk-input-before-input>`
+#### `<before-input>` / `<govuk-input-before-input>`
 
 The content is the HTML to use before the generated input element.
 
 Must be inside a `<govuk-input>` element.
 
 
-#### `<govuk-input-prefix>`
+#### `<prefix>` / `<govuk-input-prefix>`
 
 The content is the HTML to use within the component's prefix.
 
 Must be inside a `<govuk-input>` element.
 
 
-#### `<govuk-input-suffix>`
+#### `<suffix>` / `<govuk-input-suffix>`
 
 The content is the HTML to use within the component's suffix.
 
 Must be inside a `<govuk-input>` element.
 
 
-#### `<govuk-input-after-input>`
+#### `<after-input>` / `<govuk-input-after-input>`
 
 The content is the HTML to use after the generated input element.
 

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithConditionalExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Checkboxes/CheckboxesWithConditionalExample.cshtml
@@ -15,7 +15,7 @@
             Email
             <conditional>
                 <govuk-input for="EmailAddress" type="email" autocomplete="email" spellcheck="false" input-class="govuk-!-width-one-third">
-                    <govuk-input-label>Email address</govuk-input-label>
+                    <label>Email address</label>
                 </govuk-input>
             </conditional>
         </item>
@@ -24,7 +24,7 @@
             Phone
             <conditional>
                 <govuk-input for="PhoneNumber" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
-                    <govuk-input-label>Phone number</govuk-input-label>
+                    <label>Phone number</label>
                 </govuk-input>
             </conditional>
         </item>
@@ -33,7 +33,7 @@
             Text message
             <conditional>
                 <govuk-input for="MobilePhoneNumber" type="tel" autocomplete="tel" input-class="govuk-!-width-one-third">
-                    <govuk-input-label>Mobile phone number</govuk-input-label>
+                    <label>Mobile phone number</label>
                 </govuk-input>
             </conditional>
         </item>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Radios/RadiosWithConditionalExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Radios/RadiosWithConditionalExample.cshtml
@@ -15,8 +15,8 @@
             Email
             <conditional>
                 <govuk-input id="contact-by-email" name="contact-by-email" type="email" autocomplete="email" spellcheck="false" class="govuk-!-width-one-half">
-                    <govuk-input-label>Email address</govuk-input-label>
-                    <govuk-input-error-message>Email address cannot be blank</govuk-input-error-message>
+                    <label>Email address</label>
+                    <error-message>Email address cannot be blank</error-message>
                 </govuk-input>
             </conditional>
         </item>
@@ -25,7 +25,7 @@
             Phone
             <conditional>
                 <govuk-input for="PhoneNumber" type="tel" autocomplete="tel" class="govuk-!-width-one-third">
-                    <govuk-input-label>Phone number</govuk-input-label>
+                    <label>Phone number</label>
                 </govuk-input>
             </conditional>
         </item>
@@ -34,7 +34,7 @@
             Text message
             <conditional>
                 <govuk-input for="MobilePhoneNumber" type="tel" autocomplete="tel" class="govuk-!-width-one-third">
-                    <govuk-input-label>Mobile phone number</govuk-input-label>
+                    <label>Mobile phone number</label>
                 </govuk-input>
             </conditional>
         </item>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextInput/TextInputExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextInput/TextInputExample.cshtml
@@ -3,7 +3,7 @@
 
 <example>
     <govuk-input for="AccountNumber" input-class="govuk-input--width-10" inputmode="numeric" pattern="[0-9]*" spellcheck="false">
-        <govuk-input-label is-page-heading="true" class="govuk-label--l">What is your account number?</govuk-input-label>
-        <govuk-input-hint>Must be between 6 and 8 digits long</govuk-input-hint>
+        <label is-page-heading="true" class="govuk-label--l">What is your account number?</label>
+        <hint>Must be between 6 and 8 digits long</hint>
     </govuk-input>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextInput/TextInputWithErrorMessageExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextInput/TextInputWithErrorMessageExample.cshtml
@@ -2,8 +2,8 @@
 
 <example>
     <govuk-input name="EventName">
-        <govuk-input-label is-page-heading="true" class="govuk-label--l">What is the name of the event?</govuk-input-label>
-        <govuk-input-hint>The name you’ll use on promotional material.</govuk-input-hint>
-        <govuk-input-error-message>Enter an event name</govuk-input-error-message>
+        <label is-page-heading="true" class="govuk-label--l">What is the name of the event?</label>
+        <hint>The name you’ll use on promotional material.</hint>
+        <error-message>Enter an event name</error-message>
     </govuk-input>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextInput/TextInputWithPrefixAndSuffixExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextInput/TextInputWithPrefixAndSuffixExample.cshtml
@@ -3,8 +3,8 @@
 
 <example>
     <govuk-input for="CostPerItem" input-class="govuk-input--width-5" spellcheck="false">
-        <govuk-input-label is-page-heading="true" class="govuk-label--l">What is the cost per item, in pounds?</govuk-input-label>
-        <govuk-input-prefix>&pound;</govuk-input-prefix>
-        <govuk-input-suffix>per item</govuk-input-suffix>
+        <label is-page-heading="true" class="govuk-label--l">What is the cost per item, in pounds?</label>
+        <prefix>&pound;</prefix>
+        <suffix>per item</suffix>
     </govuk-input>
 </example>

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupLabelTagHelperBase.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FormGroupLabelTagHelperBase.cs
@@ -10,9 +10,7 @@ public abstract class FormGroupLabelTagHelperBase : TagHelper
 {
     private const string IsPageHeadingAttributeName = "is-page-heading";
 
-#if SHORT_TAG_NAMES
     internal const string ShortTagName = ShortTagNames.Label;
-#endif
 
     private protected FormGroupLabelTagHelperBase()
     {

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/TextInputAfterInputTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/TextInputAfterInputTagHelper.cs
@@ -7,27 +7,16 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the content after the input in a GDS text input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = TextInputTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = TextInputTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use after the generated input element.")]
 public class TextInputAfterInputTagHelper : TagHelper
 {
     private readonly ILogger<TextInputAfterInputTagHelper> _logger;
 
     internal const string TagName = "govuk-input-after-input";
-#if SHORT_TAG_NAMES
     internal const string ShortTagName = ShortTagNames.AfterInput;
-#endif
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = new[]
-    {
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    };
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <summary>
     /// Creates a new <see cref="TextInputAfterInputTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/TextInputBeforeInputTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/TextInputBeforeInputTagHelper.cs
@@ -7,27 +7,16 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the content before the input in a GDS text input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = TextInputTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = TextInputTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use before the generated input element.")]
 public class TextInputBeforeInputTagHelper : TagHelper
 {
     private readonly ILogger<TextInputBeforeInputTagHelper> _logger;
 
     internal const string TagName = "govuk-input-before-input";
-#if SHORT_TAG_NAMES
     internal const string ShortTagName = ShortTagNames.BeforeInput;
-#endif
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = new[]
-    {
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    };
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <summary>
     /// Creates a new <see cref="TextInputBeforeInputTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/TextInputErrorMessageTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/TextInputErrorMessageTagHelper.cs
@@ -6,19 +6,11 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the error message in a GDS text input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = TextInputTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = TextInputTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's error message.")]
 public class TextInputErrorMessageTagHelper : FormGroupErrorMessageTagHelperBase
 {
     internal const string TagName = "govuk-input-error-message";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/TextInputHintTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/TextInputHintTagHelper.cs
@@ -6,19 +6,11 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the hint in a GDS text input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = TextInputTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = TextInputTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's hint.")]
 public class TextInputHintTagHelper : FormGroupHintTagHelperBase
 {
     internal const string TagName = "govuk-input-hint";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/TextInputLabelTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/TextInputLabelTagHelper.cs
@@ -6,19 +6,11 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the label in a GDS text input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = TextInputTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = TextInputTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's label.")]
 public class TextInputLabelTagHelper : FormGroupLabelTagHelperBase
 {
     internal const string TagName = "govuk-input-label";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/TextInputPrefixTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/TextInputPrefixTagHelper.cs
@@ -7,25 +7,14 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the prefix element in a GDS text input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = TextInputTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = TextInputTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's prefix.")]
 public class TextInputPrefixTagHelper : TagHelper
 {
     internal const string TagName = "govuk-input-prefix";
-#if SHORT_TAG_NAMES
     internal const string ShortTagName = ShortTagNames.Prefix;
-#endif
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = new[]
-    {
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    };
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <inheritdoc/>
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/TextInputSuffixTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/TextInputSuffixTagHelper.cs
@@ -7,25 +7,14 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the suffix element in a GDS text input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = TextInputTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = TextInputTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's suffix.")]
 public class TextInputSuffixTagHelper : TagHelper
 {
     internal const string TagName = "govuk-input-suffix";
-#if SHORT_TAG_NAMES
     internal const string ShortTagName = ShortTagNames.Suffix;
-#endif
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = new[]
-    {
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    };
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <inheritdoc/>
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/TextInputTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/TextInputTagHelper.cs
@@ -14,22 +14,19 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 [HtmlTargetElement(TagName)]
 [RestrictChildren(
     TextInputLabelTagHelper.TagName,
+    TextInputLabelTagHelper.ShortTagName,
     TextInputHintTagHelper.TagName,
+    TextInputHintTagHelper.ShortTagName,
     TextInputErrorMessageTagHelper.TagName,
+    TextInputErrorMessageTagHelper.ShortTagName,
     TextInputBeforeInputTagHelper.TagName,
-    TextInputPrefixTagHelper.TagName,
-    TextInputSuffixTagHelper.TagName,
-    TextInputAfterInputTagHelper.TagName
-#if SHORT_TAG_NAMES
-    ,
-    FormGroupLabelTagHelperBase.ShortTagName,
-    FormGroupHintTagHelperBase.ShortTagName,
-    FormGroupErrorMessageTagHelperBase.ShortTagName,
     TextInputBeforeInputTagHelper.ShortTagName,
+    TextInputPrefixTagHelper.TagName,
     TextInputPrefixTagHelper.ShortTagName,
+    TextInputSuffixTagHelper.TagName,
     TextInputSuffixTagHelper.ShortTagName,
+    TextInputAfterInputTagHelper.TagName,
     TextInputAfterInputTagHelper.ShortTagName
-#endif
     )]
 [OutputElementHint(DefaultComponentGenerator.ComponentElementTypes.FormGroup)]
 public class TextInputTagHelper : TagHelper

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
@@ -12,6 +12,8 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
     [InlineData("Radios", "short-error-message", "long-error-message")]
     [InlineData("DateInput", "short", "long")]
     [InlineData("DateInput", "short-error-message", "long-error-message")]
+    [InlineData("TextInput", "short", "long")]
+    [InlineData("TextInput", "short-error-message", "long-error-message")]
     public async Task ShortTagNames_GenerateTheSameMarkupAsTheGovUkPrefixedNames(
         string component,
         string shortTestId,
@@ -25,7 +27,7 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
         var longContainer = GetContainer(document, longTestId);
 
         // Guards against both containers being empty, which would make the comparison vacuous
-        Assert.NotNull(shortContainer.QuerySelector("fieldset > legend"));
+        Assert.NotEmpty(shortContainer.QuerySelectorAll("legend, label"));
         Assert.NotEmpty(shortContainer.QuerySelectorAll("input"));
 
         // An unrecognised element is written out as-is, so a short name that never bound to a tag
@@ -96,6 +98,9 @@ public class ShortTagNamesTestsController : Controller
 
     [HttpGet("DateInput")]
     public IActionResult GetDateInput() => View("DateInput", new ShortTagNamesTestsModel());
+
+    [HttpGet("TextInput")]
+    public IActionResult GetTextInput() => View("TextInput", new ShortTagNamesTestsModel());
 }
 
 public class ShortTagNamesTestsModel

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/TextInput.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/TextInput.cshtml
@@ -1,0 +1,48 @@
+@model GovUk.Frontend.AspNetCore.IntegrationTests.ShortTagNamesTestsModel
+
+@* The same component written with the short tag names and with the govuk- prefixed ones;
+   the two must generate identical markup *@
+
+<div data-testid="short">
+    <govuk-input for="EmailAddress" type="email" autocomplete="email" spellcheck="false" input-class="govuk-!-width-one-third">
+        <label is-page-heading="true" class="govuk-label--l">The label</label>
+
+        <hint>
+            We'll only use this to contact you about your application
+        </hint>
+
+        <before-input>Before input</before-input>
+        <prefix>&pound;</prefix>
+        <suffix>per week</suffix>
+        <after-input>After input</after-input>
+    </govuk-input>
+</div>
+
+<div data-testid="long">
+    <govuk-input for="EmailAddress" type="email" autocomplete="email" spellcheck="false" input-class="govuk-!-width-one-third">
+        <govuk-input-label is-page-heading="true" class="govuk-label--l">The label</govuk-input-label>
+
+        <govuk-input-hint>
+            We'll only use this to contact you about your application
+        </govuk-input-hint>
+
+        <govuk-input-before-input>Before input</govuk-input-before-input>
+        <govuk-input-prefix>&pound;</govuk-input-prefix>
+        <govuk-input-suffix>per week</govuk-input-suffix>
+        <govuk-input-after-input>After input</govuk-input-after-input>
+    </govuk-input>
+</div>
+
+<div data-testid="short-error-message">
+    <govuk-input name="WithError" id="with-error">
+        <label>The label</label>
+        <error-message>Enter an email address</error-message>
+    </govuk-input>
+</div>
+
+<div data-testid="long-error-message">
+    <govuk-input name="WithError" id="with-error">
+        <govuk-input-label>The label</govuk-input-label>
+        <govuk-input-error-message>Enter an email address</govuk-input-error-message>
+    </govuk-input>
+</div>


### PR DESCRIPTION
Stacked on #532, which is stacked on #530 and #529; the diff will narrow to the text input as those merge.

```razor
<govuk-input for="CostPerItem" input-class="govuk-input--width-5" spellcheck="false">
    <label is-page-heading="true" class="govuk-label--l">What is the cost per item, in pounds?</label>
    <prefix>&pound;</prefix>
    <suffix>per item</suffix>
</govuk-input>
```

| Element | Short name |
| --- | --- |
| `govuk-input-label` | `label` |
| `govuk-input-hint` | `hint` |
| `govuk-input-error-message` | `error-message` |
| `govuk-input-before-input` / `-after-input` | `before-input` / `after-input` |
| `govuk-input-prefix` / `-suffix` | `prefix` / `suffix` |

All of them sit directly inside `<govuk-input>`. The text input has no fieldset and no nested items, so there is none of the pairing the previous three PRs needed — the names were already written behind `SHORT_TAG_NAMES`, which is not defined for the library, and this takes the guards off. `TextInputContext` already took its tag name lists from `AllTagNames`, so the messages pick up both spellings with no further change.

`<label>` does not collide with the date input's `<label>` from #532: those target `<day>`, `<month>` and `<year>`, this one targets `<govuk-input>`.

### Docs

The three text input examples use the short names and the API tables pick up both spellings.

The `<govuk-input>` nested inside the checkboxes and radios conditional-reveal examples uses them too, so those examples read as one style throughout rather than switching spelling at the conditional. That is why `docs/components/checkboxes.md` and `radios.md` appear in the diff.

Every example page touched renders byte-identical HTML to this branch's parent, so no screenshots need regenerating, and `just publish-docs` on the committed tree is clean.

### Testing

- `ShortTagNamesTests` gains a text input view — the component in both spellings, asserted to generate identical markup. Its guard assertion is now `legend, label` rather than `fieldset > legend`, since the text input has no fieldset.
- The unit tests expand per tag name target, so the existing text input tests now run under the short names too.
- 1767 unit tests and 85 integration tests pass; Release build and `dotnet format --verify-no-changes` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)