### PR TITLE
Add short tag name support to the textarea tag helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Both elements can now generate their `formaction` attribute from the `asp-` attr
 
 As per the guidance, the first page, the pages either side of the current page and the last page are shown, with an ellipsis wherever pages have been skipped, plus Previous and Next links where there is a page to go to. Nothing is rendered at all when there is only one page. Child elements cannot be combined with these attributes.
 
-The checkboxes, radios, date input and text input tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
+The checkboxes, radios, date input, text input and textarea tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
 
 ```razor
 <govuk-checkboxes for="ContactPreferences">
@@ -59,7 +59,7 @@ The checkboxes, radios, date input and text input tag helpers now support short 
 </govuk-date-input>
 ```
 
-The text input takes `<label>`, `<hint>`, `<error-message>`, `<before-input>`, `<prefix>`, `<suffix>` and `<after-input>`.
+The text input takes `<label>`, `<hint>`, `<error-message>`, `<before-input>`, `<prefix>`, `<suffix>` and `<after-input>`; the textarea takes the same, with `<value>` in place of the prefix and suffix.
 
 The `govuk-` prefixed names continue to work everywhere they did before, and remain the only spelling accepted inside a `<govuk-checkboxes-fieldset>`, `<govuk-radios-fieldset>` or `<govuk-date-input-fieldset>` — the short names pair with the fieldset that the root element generates for a `<legend>` of its own.
 

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -11,12 +11,12 @@
 
 ```razor
 <govuk-textarea for="MoreDetail">
-    <govuk-textarea-label class="govuk-label--l" is-page-heading="true">
+    <label class="govuk-label--l" is-page-heading="true">
         Can you provide more detail?
-    </govuk-textarea-label>
-    <govuk-textarea-hint>
+    </label>
+    <hint>
         Do not include personal or financial information like your National Insurance number or credit card details.
-    </govuk-textarea-hint>
+    </hint>
 </govuk-textarea>
 ```
 
@@ -41,7 +41,7 @@
 | `textarea-*` |  | Additional attributes to add to the generated `textarea` element. |
 
 
-#### `<govuk-textarea-label>`
+#### `<label>` / `<govuk-textarea-label>`
 
 The content is the HTML to use within the component's label.
 
@@ -52,14 +52,14 @@ Must be inside a `<govuk-textarea>` element.
 | `is-page-heading` | `bool?` | Whether the label also acts as the heading for the page. |
 
 
-#### `<govuk-textarea-hint>`
+#### `<hint>` / `<govuk-textarea-hint>`
 
 The content is the HTML to use within the component's hint.
 
 Must be inside a `<govuk-textarea>` element.
 
 
-#### `<govuk-textarea-error-message>`
+#### `<error-message>` / `<govuk-textarea-error-message>`
 
 The content is the HTML to use within the component's error message.
 
@@ -70,21 +70,21 @@ Must be inside a `<govuk-textarea>` element.
 | `visually-hidden-text` | `string` | A visually hidden prefix used before the error message. The default is `"Error"`. |
 
 
-#### `<govuk-textarea-before-input>`
+#### `<before-input>` / `<govuk-textarea-before-input>`
 
 The content is the HTML to use before the generated textarea element.
 
 Must be inside a `<govuk-textarea>` element.
 
 
-#### `<govuk-textarea-value>`
+#### `<value>` / `<govuk-textarea-value>`
 
 The content is the HTML to use within the generated textarea.
 
 Must be inside a `<govuk-textarea>` element.
 
 
-#### `<govuk-textarea-after-input>`
+#### `<after-input>` / `<govuk-textarea-after-input>`
 
 The content is the HTML to use after the generated textarea element.
 

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextArea/TextAreaExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/TextArea/TextAreaExample.cshtml
@@ -3,11 +3,11 @@
 
 <example>
     <govuk-textarea for="MoreDetail">
-        <govuk-textarea-label class="govuk-label--l" is-page-heading="true">
+        <label class="govuk-label--l" is-page-heading="true">
             Can you provide more detail?
-        </govuk-textarea-label>
-        <govuk-textarea-hint>
+        </label>
+        <hint>
             Do not include personal or financial information like your National Insurance number or credit card details.
-        </govuk-textarea-hint>
+        </hint>
     </govuk-textarea>
 </example>

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/TextAreaAfterInputTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/TextAreaAfterInputTagHelper.cs
@@ -7,27 +7,16 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the content after the textarea in a GDS textarea component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = TextAreaTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = TextAreaTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use after the generated textarea element.")]
 public class TextAreaAfterInputTagHelper : TagHelper
 {
     private readonly ILogger<TextAreaAfterInputTagHelper> _logger;
 
     internal const string TagName = "govuk-textarea-after-input";
-#if SHORT_TAG_NAMES
     internal const string ShortTagName = ShortTagNames.AfterInput;
-#endif
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = new[]
-    {
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    };
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <summary>
     /// Creates a new <see cref="TextAreaAfterInputTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/TextAreaBeforeInputTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/TextAreaBeforeInputTagHelper.cs
@@ -7,27 +7,16 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the content before the textarea in a GDS textarea component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = TextAreaTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = TextAreaTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use before the generated textarea element.")]
 public class TextAreaBeforeInputTagHelper : TagHelper
 {
     private readonly ILogger<TextAreaBeforeInputTagHelper> _logger;
 
     internal const string TagName = "govuk-textarea-before-input";
-#if SHORT_TAG_NAMES
     internal const string ShortTagName = ShortTagNames.BeforeInput;
-#endif
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = new[]
-    {
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    };
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <summary>
     /// Creates a new <see cref="TextAreaBeforeInputTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/TextAreaContext.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/TextAreaContext.cs
@@ -25,7 +25,7 @@ internal class TextAreaContext : FormGroupContext3
 
     private IReadOnlyCollection<string> AfterInputTagNames => TextAreaAfterInputTagHelper.AllTagNames;
 
-    private IReadOnlyCollection<string> ValueTagNames => [TextAreaValueTagHelper.TagName];
+    private IReadOnlyCollection<string> ValueTagNames => [TextAreaValueTagHelper.TagName, TextAreaValueTagHelper.ShortTagName];
 
     protected override string RootTagName => TextAreaTagHelper.TagName;
 

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/TextAreaErrorMessageTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/TextAreaErrorMessageTagHelper.cs
@@ -6,19 +6,11 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the error message in a GDS textarea component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = TextAreaTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = TextAreaTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's error message.")]
 public class TextAreaErrorMessageTagHelper : FormGroupErrorMessageTagHelperBase
 {
     internal const string TagName = "govuk-textarea-error-message";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/TextAreaHintTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/TextAreaHintTagHelper.cs
@@ -6,19 +6,11 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the hint in a GDS textarea component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = TextAreaTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = TextAreaTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's hint.")]
 public class TextAreaHintTagHelper : FormGroupHintTagHelperBase
 {
     internal const string TagName = "govuk-textarea-hint";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/TextAreaLabelTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/TextAreaLabelTagHelper.cs
@@ -6,19 +6,11 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the label in a GDS textarea component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = TextAreaTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = TextAreaTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's label.")]
 public class TextAreaLabelTagHelper : FormGroupLabelTagHelperBase
 {
     internal const string TagName = "govuk-textarea-label";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/TextAreaTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/TextAreaTagHelper.cs
@@ -14,19 +14,17 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 [HtmlTargetElement(TagName)]
 [RestrictChildren(
     TextAreaLabelTagHelper.TagName,
+    TextAreaLabelTagHelper.ShortTagName,
     TextAreaHintTagHelper.TagName,
+    TextAreaHintTagHelper.ShortTagName,
     TextAreaErrorMessageTagHelper.TagName,
+    TextAreaErrorMessageTagHelper.ShortTagName,
     TextAreaBeforeInputTagHelper.TagName,
-    TextAreaValueTagHelper.TagName,
-    TextAreaAfterInputTagHelper.TagName
-#if SHORT_TAG_NAMES
-    ,
-    FormGroupLabelTagHelperBase.ShortTagName,
-    FormGroupHintTagHelperBase.ShortTagName,
-    FormGroupErrorMessageTagHelperBase.ShortTagName,
     TextAreaBeforeInputTagHelper.ShortTagName,
+    TextAreaValueTagHelper.TagName,
+    TextAreaValueTagHelper.ShortTagName,
+    TextAreaAfterInputTagHelper.TagName,
     TextAreaAfterInputTagHelper.ShortTagName
-#endif
     )]
 [OutputElementHint(DefaultComponentGenerator.ComponentElementTypes.FormGroup)]
 public class TextAreaTagHelper : TagHelper

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/TextAreaValueTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/TextAreaValueTagHelper.cs
@@ -6,10 +6,12 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the value of a GDS textarea component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = TextAreaTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = TextAreaTagHelper.TagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the generated textarea.")]
 public class TextAreaValueTagHelper : TagHelper
 {
     internal const string TagName = "govuk-textarea-value";
+    internal const string ShortTagName = ShortTagNames.Value;
 
     /// <inheritdoc/>
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
@@ -14,6 +14,8 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
     [InlineData("DateInput", "short-error-message", "long-error-message")]
     [InlineData("TextInput", "short", "long")]
     [InlineData("TextInput", "short-error-message", "long-error-message")]
+    [InlineData("TextArea", "short", "long")]
+    [InlineData("TextArea", "short-error-message", "long-error-message")]
     public async Task ShortTagNames_GenerateTheSameMarkupAsTheGovUkPrefixedNames(
         string component,
         string shortTestId,
@@ -28,7 +30,7 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
 
         // Guards against both containers being empty, which would make the comparison vacuous
         Assert.NotEmpty(shortContainer.QuerySelectorAll("legend, label"));
-        Assert.NotEmpty(shortContainer.QuerySelectorAll("input"));
+        Assert.NotEmpty(shortContainer.QuerySelectorAll("input, textarea, select"));
 
         // An unrecognised element is written out as-is, so a short name that never bound to a tag
         // helper would show up here as, say, an <item> element outside the fieldset
@@ -101,6 +103,9 @@ public class ShortTagNamesTestsController : Controller
 
     [HttpGet("TextInput")]
     public IActionResult GetTextInput() => View("TextInput", new ShortTagNamesTestsModel());
+
+    [HttpGet("TextArea")]
+    public IActionResult GetTextArea() => View("TextArea", new ShortTagNamesTestsModel());
 }
 
 public class ShortTagNamesTestsModel
@@ -117,4 +122,6 @@ public class ShortTagNamesTestsModel
 
     [DateInput(ErrorMessagePrefix = "Your date of birth")]
     public DateOnly? DateOfBirth { get; set; }
+
+    public string? MoreDetail { get; set; }
 }

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/TextArea.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/TextArea.cshtml
@@ -1,0 +1,46 @@
+@model GovUk.Frontend.AspNetCore.IntegrationTests.ShortTagNamesTestsModel
+
+@* The same component written with the short tag names and with the govuk- prefixed ones;
+   the two must generate identical markup *@
+
+<div data-testid="short">
+    <govuk-textarea for="MoreDetail" rows="5">
+        <label is-page-heading="true" class="govuk-label--l">The label</label>
+
+        <hint>
+            Do not include personal or financial information
+        </hint>
+
+        <before-input>Before input</before-input>
+        <value>Some existing content</value>
+        <after-input>After input</after-input>
+    </govuk-textarea>
+</div>
+
+<div data-testid="long">
+    <govuk-textarea for="MoreDetail" rows="5">
+        <govuk-textarea-label is-page-heading="true" class="govuk-label--l">The label</govuk-textarea-label>
+
+        <govuk-textarea-hint>
+            Do not include personal or financial information
+        </govuk-textarea-hint>
+
+        <govuk-textarea-before-input>Before input</govuk-textarea-before-input>
+        <govuk-textarea-value>Some existing content</govuk-textarea-value>
+        <govuk-textarea-after-input>After input</govuk-textarea-after-input>
+    </govuk-textarea>
+</div>
+
+<div data-testid="short-error-message">
+    <govuk-textarea name="WithError" id="with-error">
+        <label>The label</label>
+        <error-message>Enter more detail</error-message>
+    </govuk-textarea>
+</div>
+
+<div data-testid="long-error-message">
+    <govuk-textarea name="WithError" id="with-error">
+        <govuk-textarea-label>The label</govuk-textarea-label>
+        <govuk-textarea-error-message>Enter more detail</govuk-textarea-error-message>
+    </govuk-textarea>
+</div>

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TextAreaContextTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TextAreaContextTests.cs
@@ -244,7 +244,7 @@ public class TextAreaContextTests
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
         Assert.Equal(
-            $"Only one <{valueTagName}> element is permitted within each <{TextAreaTagHelper.TagName}>.",
+            $"Only one <{valueTagName}> or <{TextAreaValueTagHelper.ShortTagName}> element is permitted within each <{TextAreaTagHelper.TagName}>.",
             ex.Message);
     }
 


### PR DESCRIPTION
Stacked on #533, itself on #532, #530 and #529; the diff will narrow to the textarea as those merge.

```razor
<govuk-textarea for="MoreDetail">
    <label class="govuk-label--l" is-page-heading="true">Can you provide more detail?</label>
    <hint>Do not include personal or financial information.</hint>
</govuk-textarea>
```

| Element | Short name |
| --- | --- |
| `govuk-textarea-label` | `label` |
| `govuk-textarea-hint` | `hint` |
| `govuk-textarea-error-message` | `error-message` |
| `govuk-textarea-before-input` / `-after-input` | `before-input` / `after-input` |
| `govuk-textarea-value` | `value` |

All directly inside `<govuk-textarea>`. Like the text input in #533 there is no fieldset and no nesting, so this mostly takes the `SHORT_TAG_NAMES` guards off names that were already written.

`<value>` is the exception — the guarded set skipped it, though the character count's equivalent element has had the name all along. Without it the terse style would have a hole in the middle of the component, so I have added it; say the word if you would rather it stayed prefixed-only.

`TextAreaContext.ValueTagNames` now lists both spellings, so "Only one `<govuk-textarea-value>` or `<value>` element is permitted…" reads like the other elements' messages. The rest of the context already used `AllTagNames`.

### Docs

The textarea example uses the short names and the API table picks up both spellings. The example page renders byte-identical HTML to this branch's parent, so no screenshot needs regenerating, and `just publish-docs` on the committed tree is clean.

### Testing

- `ShortTagNamesTests` gains a textarea view — the component in both spellings, asserted to generate identical markup. Its vacuity guard now looks for `input, textarea, select` rather than `input`.
- `TextAreaContextTests.SetValue_AlreadySet_ThrowsInvalidOperationException` expects both spellings in the message.
- The unit tests expand per tag name target, so the existing textarea tests now run under the short names too.
- 1770 unit tests and 87 integration tests pass; Release build and `dotnet format --verify-no-changes` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)