### PR TITLE
Add short tag name support to the file upload tag helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Both elements can now generate their `formaction` attribute from the `asp-` attr
 
 As per the guidance, the first page, the pages either side of the current page and the last page are shown, with an ellipsis wherever pages have been skipped, plus Previous and Next links where there is a page to go to. Nothing is rendered at all when there is only one page. Child elements cannot be combined with these attributes.
 
-The checkboxes, radios, date input, text input and textarea tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
+The checkboxes, radios, date input, text input, textarea and file upload tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
 
 ```razor
 <govuk-checkboxes for="ContactPreferences">
@@ -59,7 +59,7 @@ The checkboxes, radios, date input, text input and textarea tag helpers now supp
 </govuk-date-input>
 ```
 
-The text input takes `<label>`, `<hint>`, `<error-message>`, `<before-input>`, `<prefix>`, `<suffix>` and `<after-input>`; the textarea takes the same, with `<value>` in place of the prefix and suffix.
+The text input takes `<label>`, `<hint>`, `<error-message>`, `<before-input>`, `<prefix>`, `<suffix>` and `<after-input>`; the textarea takes the same, with `<value>` in place of the prefix and suffix, and the file upload takes `<label>`, `<hint>`, `<error-message>`, `<before-input>` and `<after-input>`.
 
 The `govuk-` prefixed names continue to work everywhere they did before, and remain the only spelling accepted inside a `<govuk-checkboxes-fieldset>`, `<govuk-radios-fieldset>` or `<govuk-date-input-fieldset>` — the short names pair with the fieldset that the root element generates for a `<legend>` of its own.
 

--- a/docs/components/file-upload.md
+++ b/docs/components/file-upload.md
@@ -11,7 +11,7 @@
 
 ```razor
 <govuk-file-upload for="Document">
-    <govuk-file-upload-label>Upload a file</govuk-file-upload-label>
+    <label>Upload a file</label>
 </govuk-file-upload>
 ```
 
@@ -21,8 +21,8 @@
 
 ```razor
 <govuk-file-upload name="FileUpload1">
-    <govuk-file-upload-label>Upload a file</govuk-file-upload-label>
-    <govuk-file-upload-error-message>The CSV must be smaller than 2MB</govuk-file-upload-error-message>
+    <label>Upload a file</label>
+    <error-message>The CSV must be smaller than 2MB</error-message>
 </govuk-file-upload>
 ```
 
@@ -32,7 +32,7 @@
 
 ```razor
 <govuk-file-upload for="Document" javascript-enhancements="true">
-    <govuk-file-upload-label>Upload a file</govuk-file-upload-label>
+    <label>Upload a file</label>
 </govuk-file-upload>
 ```
 
@@ -63,7 +63,7 @@
 | `wrapper-*` |  | Additional attributes to add to the Javascript enhanced component's wrapper element. |
 
 
-#### `<govuk-file-upload-label>`
+#### `<label>` / `<govuk-file-upload-label>`
 
 The content is the HTML to use within the component's label.
 
@@ -74,14 +74,14 @@ Must be inside a `<govuk-file-upload>` element.
 | `is-page-heading` | `bool?` | Whether the label also acts as the heading for the page. |
 
 
-#### `<govuk-file-upload-hint>`
+#### `<hint>` / `<govuk-file-upload-hint>`
 
 The content is the HTML to use within the component's hint.
 
 Must be inside a `<govuk-file-upload>` element.
 
 
-#### `<govuk-file-upload-error-message>`
+#### `<error-message>` / `<govuk-file-upload-error-message>`
 
 The content is the HTML to use within the component's error message.
 
@@ -92,14 +92,14 @@ Must be inside a `<govuk-file-upload>` element.
 | `visually-hidden-text` | `string` | A visually hidden prefix used before the error message. The default is `"Error"`. |
 
 
-#### `<govuk-file-upload-before-input>`
+#### `<before-input>` / `<govuk-file-upload-before-input>`
 
 The content is the HTML to use before the generated input element.
 
 Must be inside a `<govuk-file-upload>` element.
 
 
-#### `<govuk-file-upload-after-input>`
+#### `<after-input>` / `<govuk-file-upload-after-input>`
 
 The content is the HTML to use after the generated input element.
 

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/FileUpload/FileUploadExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/FileUpload/FileUploadExample.cshtml
@@ -3,6 +3,6 @@
 
 <example>
     <govuk-file-upload for="Document">
-        <govuk-file-upload-label>Upload a file</govuk-file-upload-label>
+        <label>Upload a file</label>
     </govuk-file-upload>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/FileUpload/FileUploadWithErrorMessageExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/FileUpload/FileUploadWithErrorMessageExample.cshtml
@@ -2,7 +2,7 @@
 
 <example>
     <govuk-file-upload name="FileUpload1">
-        <govuk-file-upload-label>Upload a file</govuk-file-upload-label>
-        <govuk-file-upload-error-message>The CSV must be smaller than 2MB</govuk-file-upload-error-message>
+        <label>Upload a file</label>
+        <error-message>The CSV must be smaller than 2MB</error-message>
     </govuk-file-upload>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/FileUpload/FileUploadWithJavascriptEnhancementsExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/FileUpload/FileUploadWithJavascriptEnhancementsExample.cshtml
@@ -3,6 +3,6 @@
 
 <example>
     <govuk-file-upload for="Document" javascript-enhancements="true">
-        <govuk-file-upload-label>Upload a file</govuk-file-upload-label>
+        <label>Upload a file</label>
     </govuk-file-upload>
 </example>

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FileUploadAfterInputTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FileUploadAfterInputTagHelper.cs
@@ -7,27 +7,16 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the content after the input in a GDS file upload component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = FileUploadTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = FileUploadTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use after the generated input element.")]
 public class FileUploadAfterInputTagHelper : TagHelper
 {
     private readonly ILogger<FileUploadAfterInputTagHelper> _logger;
 
     internal const string TagName = "govuk-file-upload-after-input";
-#if SHORT_TAG_NAMES
     internal const string ShortTagName = ShortTagNames.AfterInput;
-#endif
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = new[]
-    {
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    };
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <summary>
     /// Creates a new <see cref="FileUploadAfterInputTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FileUploadBeforeInputTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FileUploadBeforeInputTagHelper.cs
@@ -7,27 +7,16 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the content before the input in a GDS file upload component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = FileUploadTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = FileUploadTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use before the generated input element.")]
 public class FileUploadBeforeInputTagHelper : TagHelper
 {
     private readonly ILogger<FileUploadBeforeInputTagHelper> _logger;
 
     internal const string TagName = "govuk-file-upload-before-input";
-#if SHORT_TAG_NAMES
     internal const string ShortTagName = ShortTagNames.BeforeInput;
-#endif
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = new[]
-    {
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    };
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <summary>
     /// Creates a new <see cref="FileUploadBeforeInputTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FileUploadErrorMessageTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FileUploadErrorMessageTagHelper.cs
@@ -6,19 +6,11 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the error message in a GDS file upload component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = FileUploadTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = FileUploadTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's error message.")]
 public class FileUploadErrorMessageTagHelper : FormGroupErrorMessageTagHelperBase
 {
     internal const string TagName = "govuk-file-upload-error-message";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FileUploadHintTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FileUploadHintTagHelper.cs
@@ -6,19 +6,11 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the hint in a GDS file upload component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = FileUploadTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = FileUploadTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's hint.")]
 public class FileUploadHintTagHelper : FormGroupHintTagHelperBase
 {
     internal const string TagName = "govuk-file-upload-hint";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = new[]
-    {
-        TagName
-#if SHORT_TAG_NAMES
-        , ShortTagName
-#endif
-    };
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FileUploadLabelTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FileUploadLabelTagHelper.cs
@@ -6,19 +6,11 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the label in a GDS file upload component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = FileUploadTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = FileUploadTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's label.")]
 public class FileUploadLabelTagHelper : FormGroupLabelTagHelperBase
 {
     internal const string TagName = "govuk-file-upload-label";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FileUploadTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FileUploadTagHelper.cs
@@ -14,18 +14,15 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 [HtmlTargetElement(TagName)]
 [RestrictChildren(
     FileUploadLabelTagHelper.TagName,
+    FileUploadLabelTagHelper.ShortTagName,
     FileUploadHintTagHelper.TagName,
+    FileUploadHintTagHelper.ShortTagName,
     FileUploadErrorMessageTagHelper.TagName,
+    FileUploadErrorMessageTagHelper.ShortTagName,
     FileUploadBeforeInputTagHelper.TagName,
-    FileUploadAfterInputTagHelper.TagName
-#if SHORT_TAG_NAMES
-    ,
-    FormGroupLabelTagHelperBase.ShortTagName,
-    FormGroupHintTagHelperBase.ShortTagName,
-    FormGroupErrorMessageTagHelperBase.ShortTagName,
     FileUploadBeforeInputTagHelper.ShortTagName,
+    FileUploadAfterInputTagHelper.TagName,
     FileUploadAfterInputTagHelper.ShortTagName
-#endif
     )]
 public class FileUploadTagHelper : TagHelper
 {

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
@@ -16,6 +16,8 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
     [InlineData("TextInput", "short-error-message", "long-error-message")]
     [InlineData("TextArea", "short", "long")]
     [InlineData("TextArea", "short-error-message", "long-error-message")]
+    [InlineData("FileUpload", "short", "long")]
+    [InlineData("FileUpload", "short-error-message", "long-error-message")]
     public async Task ShortTagNames_GenerateTheSameMarkupAsTheGovUkPrefixedNames(
         string component,
         string shortTestId,
@@ -106,6 +108,9 @@ public class ShortTagNamesTestsController : Controller
 
     [HttpGet("TextArea")]
     public IActionResult GetTextArea() => View("TextArea", new ShortTagNamesTestsModel());
+
+    [HttpGet("FileUpload")]
+    public IActionResult GetFileUpload() => View("FileUpload", new ShortTagNamesTestsModel());
 }
 
 public class ShortTagNamesTestsModel
@@ -124,4 +129,6 @@ public class ShortTagNamesTestsModel
     public DateOnly? DateOfBirth { get; set; }
 
     public string? MoreDetail { get; set; }
+
+    public IFormFile? Evidence { get; set; }
 }

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/FileUpload.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/FileUpload.cshtml
@@ -1,0 +1,44 @@
+@model GovUk.Frontend.AspNetCore.IntegrationTests.ShortTagNamesTestsModel
+
+@* The same component written with the short tag names and with the govuk- prefixed ones;
+   the two must generate identical markup *@
+
+<div data-testid="short">
+    <govuk-file-upload for="Evidence">
+        <label is-page-heading="true" class="govuk-label--l">The label</label>
+
+        <hint>
+            Your file may be a doc, docx, pdf or odt
+        </hint>
+
+        <before-input>Before input</before-input>
+        <after-input>After input</after-input>
+    </govuk-file-upload>
+</div>
+
+<div data-testid="long">
+    <govuk-file-upload for="Evidence">
+        <govuk-file-upload-label is-page-heading="true" class="govuk-label--l">The label</govuk-file-upload-label>
+
+        <govuk-file-upload-hint>
+            Your file may be a doc, docx, pdf or odt
+        </govuk-file-upload-hint>
+
+        <govuk-file-upload-before-input>Before input</govuk-file-upload-before-input>
+        <govuk-file-upload-after-input>After input</govuk-file-upload-after-input>
+    </govuk-file-upload>
+</div>
+
+<div data-testid="short-error-message">
+    <govuk-file-upload name="WithError" id="with-error">
+        <label>The label</label>
+        <error-message>Select a file</error-message>
+    </govuk-file-upload>
+</div>
+
+<div data-testid="long-error-message">
+    <govuk-file-upload name="WithError" id="with-error">
+        <govuk-file-upload-label>The label</govuk-file-upload-label>
+        <govuk-file-upload-error-message>Select a file</govuk-file-upload-error-message>
+    </govuk-file-upload>
+</div>


### PR DESCRIPTION
Stacked on #534, itself on #533, #532, #530 and #529; the diff will narrow to the file upload as those merge.

```razor
<govuk-file-upload for="Document">
    <label>Upload a file</label>
</govuk-file-upload>
```

| Element | Short name |
| --- | --- |
| `govuk-file-upload-label` | `label` |
| `govuk-file-upload-hint` | `hint` |
| `govuk-file-upload-error-message` | `error-message` |
| `govuk-file-upload-before-input` / `-after-input` | `before-input` / `after-input` |

All directly inside `<govuk-file-upload>`. No fieldset and no nesting, so this is purely a matter of taking the `SHORT_TAG_NAMES` guards off names that were already written — nothing new, and no context changes, since `FileUploadContext` already took its tag name lists from `AllTagNames`.

### Docs

The three file upload examples use the short names and the API table picks up both spellings. All three pages render byte-identical HTML to this branch's parent, so no screenshots need regenerating, and `just publish-docs` on the committed tree is clean.

### Testing

- `ShortTagNamesTests` gains a file upload view — the component in both spellings, asserted to generate identical markup.
- The unit tests expand per tag name target, so the existing file upload tests now run under the short names too.
- 1772 unit tests and 89 integration tests pass; Release build and `dotnet format --verify-no-changes` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)