### PR TITLE
Add short tag name support to the password input tag helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Both elements can now generate their `formaction` attribute from the `asp-` attr
 
 As per the guidance, the first page, the pages either side of the current page and the last page are shown, with an ellipsis wherever pages have been skipped, plus Previous and Next links where there is a page to go to. Nothing is rendered at all when there is only one page. Child elements cannot be combined with these attributes.
 
-The checkboxes, radios, date input, text input, textarea and file upload tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
+The checkboxes, radios, date input, text input, textarea, file upload and password input tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
 
 ```razor
 <govuk-checkboxes for="ContactPreferences">
@@ -59,7 +59,7 @@ The checkboxes, radios, date input, text input, textarea and file upload tag hel
 </govuk-date-input>
 ```
 
-The text input takes `<label>`, `<hint>`, `<error-message>`, `<before-input>`, `<prefix>`, `<suffix>` and `<after-input>`; the textarea takes the same, with `<value>` in place of the prefix and suffix, and the file upload takes `<label>`, `<hint>`, `<error-message>`, `<before-input>` and `<after-input>`.
+The text input takes `<label>`, `<hint>`, `<error-message>`, `<before-input>`, `<prefix>`, `<suffix>` and `<after-input>`; the textarea takes the same, with `<value>` in place of the prefix and suffix, and the file upload and password input take `<label>`, `<hint>`, `<error-message>`, `<before-input>` and `<after-input>`.
 
 The `govuk-` prefixed names continue to work everywhere they did before, and remain the only spelling accepted inside a `<govuk-checkboxes-fieldset>`, `<govuk-radios-fieldset>` or `<govuk-date-input-fieldset>` — the short names pair with the fieldset that the root element generates for a `<legend>` of its own.
 

--- a/docs/components/password-input.md
+++ b/docs/components/password-input.md
@@ -11,7 +11,7 @@
 
 ```razor
 <govuk-password-input for="Password">
-    <govuk-password-input-label>Password</govuk-password-input-label>
+    <label>Password</label>
 </govuk-password-input>
 ```
 
@@ -42,7 +42,7 @@
 | `value` | `string` | The `value` attribute for the generated `input` element. If not specified and `For` is not `null` then the value for the specified model expression will be used. |
 
 
-#### `<govuk-password-input-label>`
+#### `<label>` / `<govuk-password-input-label>`
 
 The content is the HTML to use within the component's label.
 
@@ -53,14 +53,14 @@ Must be inside a `<govuk-password-input>` element.
 | `is-page-heading` | `bool?` | Whether the label also acts as the heading for the page. |
 
 
-#### `<govuk-password-input-hint>`
+#### `<hint>` / `<govuk-password-input-hint>`
 
 The content is the HTML to use within the component's hint.
 
 Must be inside a `<govuk-password-input>` element.
 
 
-#### `<govuk-password-input-error-message>`
+#### `<error-message>` / `<govuk-password-input-error-message>`
 
 The content is the HTML to use within the component's error message.
 
@@ -71,14 +71,14 @@ Must be inside a `<govuk-password-input>` element.
 | `visually-hidden-text` | `string` | A visually hidden prefix used before the error message. The default is `"Error"`. |
 
 
-#### `<govuk-password-input-before-input>`
+#### `<before-input>` / `<govuk-password-input-before-input>`
 
 The content is the HTML to use before the generated <input> element.
 
 Must be inside a `<govuk-password-input>` element.
 
 
-#### `<govuk-password-input-after-input>`
+#### `<after-input>` / `<govuk-password-input-after-input>`
 
 The content is the HTML to use after the generated <input> element.
 

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/PasswordInput/PasswordInputExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/PasswordInput/PasswordInputExample.cshtml
@@ -3,6 +3,6 @@
 
 <example>
     <govuk-password-input for="Password">
-        <govuk-password-input-label>Password</govuk-password-input-label>
+        <label>Password</label>
     </govuk-password-input>
 </example>

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/PasswordInputAfterInputTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/PasswordInputAfterInputTagHelper.cs
@@ -7,27 +7,16 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the content after the input in a GDS password input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = PasswordInputTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = PasswordInputTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use after the generated <input> element.")]
 public class PasswordInputAfterInputTagHelper : TagHelper
 {
     private readonly ILogger<PasswordInputAfterInputTagHelper> _logger;
 
     internal const string TagName = "govuk-password-input-after-input";
-#if SHORT_TAG_NAMES
     internal const string ShortTagName = ShortTagNames.AfterInput;
-#endif
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = new[]
-    {
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    };
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <summary>
     /// Creates a new <see cref="PasswordInputAfterInputTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/PasswordInputBeforeInputTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/PasswordInputBeforeInputTagHelper.cs
@@ -7,27 +7,16 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the content before the input in a GDS password input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = PasswordInputTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = PasswordInputTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use before the generated <input> element.")]
 public class PasswordInputBeforeInputTagHelper : TagHelper
 {
     private readonly ILogger<PasswordInputBeforeInputTagHelper> _logger;
 
     internal const string TagName = "govuk-password-input-before-input";
-#if SHORT_TAG_NAMES
     internal const string ShortTagName = ShortTagNames.BeforeInput;
-#endif
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = new[]
-    {
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    };
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <summary>
     /// Creates a new <see cref="PasswordInputBeforeInputTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/PasswordInputErrorMessageTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/PasswordInputErrorMessageTagHelper.cs
@@ -6,19 +6,11 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the error message in a GDS password input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = PasswordInputTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = PasswordInputTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's error message.")]
 public class PasswordInputErrorMessageTagHelper : FormGroupErrorMessageTagHelperBase
 {
     internal const string TagName = "govuk-password-input-error-message";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/PasswordInputHintTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/PasswordInputHintTagHelper.cs
@@ -6,19 +6,11 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the hint in a GDS password input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = PasswordInputTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = PasswordInputTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's hint.")]
 public class PasswordInputHintTagHelper : FormGroupHintTagHelperBase
 {
     internal const string TagName = "govuk-password-input-hint";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/PasswordInputLabelTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/PasswordInputLabelTagHelper.cs
@@ -6,19 +6,11 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the label in a GDS password input component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = PasswordInputTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = PasswordInputTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's label.")]
 public class PasswordInputLabelTagHelper : FormGroupLabelTagHelperBase
 {
     internal const string TagName = "govuk-password-input-label";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/PasswordInputTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/PasswordInputTagHelper.cs
@@ -14,18 +14,15 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 [HtmlTargetElement(TagName)]
 [RestrictChildren(
     PasswordInputLabelTagHelper.TagName,
+    PasswordInputLabelTagHelper.ShortTagName,
     PasswordInputHintTagHelper.TagName,
+    PasswordInputHintTagHelper.ShortTagName,
     PasswordInputErrorMessageTagHelper.TagName,
+    PasswordInputErrorMessageTagHelper.ShortTagName,
     PasswordInputBeforeInputTagHelper.TagName,
-    PasswordInputAfterInputTagHelper.TagName
-#if SHORT_TAG_NAMES
-    ,
-    FormGroupLabelTagHelperBase.ShortTagName,
-    FormGroupHintTagHelperBase.ShortTagName,
-    FormGroupErrorMessageTagHelperBase.ShortTagName,
     PasswordInputBeforeInputTagHelper.ShortTagName,
+    PasswordInputAfterInputTagHelper.TagName,
     PasswordInputAfterInputTagHelper.ShortTagName
-#endif
     )]
 [OutputElementHint(DefaultComponentGenerator.ComponentElementTypes.FormGroup)]
 public class PasswordInputTagHelper : TagHelper

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
@@ -18,6 +18,8 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
     [InlineData("TextArea", "short-error-message", "long-error-message")]
     [InlineData("FileUpload", "short", "long")]
     [InlineData("FileUpload", "short-error-message", "long-error-message")]
+    [InlineData("PasswordInput", "short", "long")]
+    [InlineData("PasswordInput", "short-error-message", "long-error-message")]
     public async Task ShortTagNames_GenerateTheSameMarkupAsTheGovUkPrefixedNames(
         string component,
         string shortTestId,
@@ -111,6 +113,9 @@ public class ShortTagNamesTestsController : Controller
 
     [HttpGet("FileUpload")]
     public IActionResult GetFileUpload() => View("FileUpload", new ShortTagNamesTestsModel());
+
+    [HttpGet("PasswordInput")]
+    public IActionResult GetPasswordInput() => View("PasswordInput", new ShortTagNamesTestsModel());
 }
 
 public class ShortTagNamesTestsModel
@@ -131,4 +136,6 @@ public class ShortTagNamesTestsModel
     public string? MoreDetail { get; set; }
 
     public IFormFile? Evidence { get; set; }
+
+    public string? Password { get; set; }
 }

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/PasswordInput.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/PasswordInput.cshtml
@@ -1,0 +1,44 @@
+@model GovUk.Frontend.AspNetCore.IntegrationTests.ShortTagNamesTestsModel
+
+@* The same component written with the short tag names and with the govuk- prefixed ones;
+   the two must generate identical markup *@
+
+<div data-testid="short">
+    <govuk-password-input for="Password">
+        <label is-page-heading="true" class="govuk-label--l">The label</label>
+
+        <hint>
+            Must be at least 8 characters
+        </hint>
+
+        <before-input>Before input</before-input>
+        <after-input>After input</after-input>
+    </govuk-password-input>
+</div>
+
+<div data-testid="long">
+    <govuk-password-input for="Password">
+        <govuk-password-input-label is-page-heading="true" class="govuk-label--l">The label</govuk-password-input-label>
+
+        <govuk-password-input-hint>
+            Must be at least 8 characters
+        </govuk-password-input-hint>
+
+        <govuk-password-input-before-input>Before input</govuk-password-input-before-input>
+        <govuk-password-input-after-input>After input</govuk-password-input-after-input>
+    </govuk-password-input>
+</div>
+
+<div data-testid="short-error-message">
+    <govuk-password-input name="WithError" id="with-error">
+        <label>The label</label>
+        <error-message>Enter your password</error-message>
+    </govuk-password-input>
+</div>
+
+<div data-testid="long-error-message">
+    <govuk-password-input name="WithError" id="with-error">
+        <govuk-password-input-label>The label</govuk-password-input-label>
+        <govuk-password-input-error-message>Enter your password</govuk-password-input-error-message>
+    </govuk-password-input>
+</div>


### PR DESCRIPTION
Stacked on #535; the diff will narrow to the password input as the stack below it merges.

```razor
<govuk-password-input for="Password">
    <label>Password</label>
</govuk-password-input>
```

| Element | Short name |
| --- | --- |
| `govuk-password-input-label` | `label` |
| `govuk-password-input-hint` | `hint` |
| `govuk-password-input-error-message` | `error-message` |
| `govuk-password-input-before-input` / `-after-input` | `before-input` / `after-input` |

All directly inside `<govuk-password-input>`. No fieldset and no nesting, so this is guard removal only — `PasswordInputContext` already took its tag name lists from `AllTagNames`.

### Docs

The password input example uses the short names and the API table picks up both spellings. The example page renders byte-identical HTML to this branch's parent, so no screenshot needs regenerating, and `just publish-docs` on the committed tree is clean.

### Testing

- `ShortTagNamesTests` gains a password input view — the component in both spellings, asserted to generate identical markup.
- The unit tests expand per tag name target, so the existing password input tests now run under the short names too.
- 1774 unit tests and 91 integration tests pass; Release build and `dotnet format --verify-no-changes` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)