### PR TITLE
Add short tag name support to the select tag helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Both elements can now generate their `formaction` attribute from the `asp-` attr
 
 As per the guidance, the first page, the pages either side of the current page and the last page are shown, with an ellipsis wherever pages have been skipped, plus Previous and Next links where there is a page to go to. Nothing is rendered at all when there is only one page. Child elements cannot be combined with these attributes.
 
-The checkboxes, radios, date input, text input, textarea, file upload and password input tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
+The checkboxes, radios, date input, text input, textarea, file upload, password input and select tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
 
 ```razor
 <govuk-checkboxes for="ContactPreferences">
@@ -59,7 +59,7 @@ The checkboxes, radios, date input, text input, textarea, file upload and passwo
 </govuk-date-input>
 ```
 
-The text input takes `<label>`, `<hint>`, `<error-message>`, `<before-input>`, `<prefix>`, `<suffix>` and `<after-input>`; the textarea takes the same, with `<value>` in place of the prefix and suffix, and the file upload and password input take `<label>`, `<hint>`, `<error-message>`, `<before-input>` and `<after-input>`.
+The text input takes `<label>`, `<hint>`, `<error-message>`, `<before-input>`, `<prefix>`, `<suffix>` and `<after-input>`; the textarea takes the same, with `<value>` in place of the prefix and suffix, the file upload and password input take `<label>`, `<hint>`, `<error-message>`, `<before-input>` and `<after-input>`; and the select takes those plus `<item>`.
 
 The `govuk-` prefixed names continue to work everywhere they did before, and remain the only spelling accepted inside a `<govuk-checkboxes-fieldset>`, `<govuk-radios-fieldset>` or `<govuk-date-input-fieldset>` — the short names pair with the fieldset that the root element generates for a `<legend>` of its own.
 

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -11,11 +11,11 @@
 
 ```razor
 <govuk-select for="SortBy">
-    <govuk-select-label>Sort by</govuk-select-label>
-    <govuk-select-item value="published">Recently published</govuk-select-item>
-    <govuk-select-item value="updated">Recently updated</govuk-select-item>
-    <govuk-select-item value="views">Most views</govuk-select-item>
-    <govuk-select-item value="comments">Most comments</govuk-select-item>
+    <label>Sort by</label>
+    <item value="published">Recently published</item>
+    <item value="updated">Recently updated</item>
+    <item value="views">Most views</item>
+    <item value="comments">Most comments</item>
 </govuk-select>
 ```
 
@@ -36,7 +36,7 @@
 | `select-*` |  | Additional attributes to add to the generated `select` element. |
 
 
-#### `<govuk-select-label>`
+#### `<label>` / `<govuk-select-label>`
 
 The content is the HTML to use within the component's label.
 
@@ -47,14 +47,14 @@ Must be inside a `<govuk-select>` element.
 | `is-page-heading` | `bool?` | Whether the label also acts as the heading for the page. |
 
 
-#### `<govuk-select-hint>`
+#### `<hint>` / `<govuk-select-hint>`
 
 The content is the HTML to use within the component's hint.
 
 Must be inside a `<govuk-select>` element.
 
 
-#### `<govuk-select-error-message>`
+#### `<error-message>` / `<govuk-select-error-message>`
 
 The content is the HTML to use within the component's error message.
 
@@ -65,21 +65,21 @@ Must be inside a `<govuk-select>` element.
 | `visually-hidden-text` | `string` | A visually hidden prefix used before the error message. The default is `"Error"`. |
 
 
-#### `<govuk-select-before-input>`
+#### `<before-input>` / `<govuk-select-before-input>`
 
 The content is the HTML to use before the generated select element.
 
 Must be inside a `<govuk-select>` element.
 
 
-#### `<govuk-select-after-input>`
+#### `<after-input>` / `<govuk-select-after-input>`
 
 The content is the HTML to use after the generated select element.
 
 Must be inside a `<govuk-select>` element.
 
 
-#### `<govuk-select-item>`
+#### `<item>` / `<govuk-select-item>`
 
 The content is the HTML to use within the generated option element.
 

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Select/SelectExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Select/SelectExample.cshtml
@@ -3,10 +3,10 @@
 
 <example>
     <govuk-select for="SortBy">
-        <govuk-select-label>Sort by</govuk-select-label>
-        <govuk-select-item value="published">Recently published</govuk-select-item>
-        <govuk-select-item value="updated">Recently updated</govuk-select-item>
-        <govuk-select-item value="views">Most views</govuk-select-item>
-        <govuk-select-item value="comments">Most comments</govuk-select-item>
+        <label>Sort by</label>
+        <item value="published">Recently published</item>
+        <item value="updated">Recently updated</item>
+        <item value="views">Most views</item>
+        <item value="comments">Most comments</item>
     </govuk-select>
 </example>

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/SelectAfterInputTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/SelectAfterInputTagHelper.cs
@@ -7,27 +7,16 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the content after the input in a GDS select component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = SelectTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = SelectTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use after the generated select element.")]
 public class SelectAfterInputTagHelper : TagHelper
 {
     private readonly ILogger<SelectAfterInputTagHelper> _logger;
 
     internal const string TagName = "govuk-select-after-input";
-#if SHORT_TAG_NAMES
     internal const string ShortTagName = ShortTagNames.AfterInput;
-#endif
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = new[]
-    {
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    };
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <summary>
     /// Creates a new <see cref="SelectAfterInputTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/SelectBeforeInputTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/SelectBeforeInputTagHelper.cs
@@ -7,27 +7,16 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the content before the input in a GDS select component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = SelectTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = SelectTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use before the generated select element.")]
 public class SelectBeforeInputTagHelper : TagHelper
 {
     private readonly ILogger<SelectBeforeInputTagHelper> _logger;
 
     internal const string TagName = "govuk-select-before-input";
-#if SHORT_TAG_NAMES
     internal const string ShortTagName = ShortTagNames.BeforeInput;
-#endif
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = new[]
-    {
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    };
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <summary>
     /// Creates a new <see cref="SelectBeforeInputTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/SelectContext.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/SelectContext.cs
@@ -7,6 +7,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 internal class SelectContext(ModelExpression? @for) : FormGroupContext3
 {
     private readonly List<SelectOptionsItem> _items = [];
+    private string? _firstItemTagName;
     private (IHtmlContent Content, string TagName)? _beforeInput;
     private (IHtmlContent Content, string TagName)? _afterInput;
 
@@ -30,10 +31,16 @@ internal class SelectContext(ModelExpression? @for) : FormGroupContext3
 
     protected override string RootTagName => SelectTagHelper.TagName;
 
-    public void AddItem(SelectOptionsItem item)
+    // Messages about an item that has already been added name it as it was written in the view,
+    // which may be either the govuk- prefixed name or the short one
+    private string ItemTagName => _firstItemTagName ?? SelectItemTagHelper.TagName;
+
+    public void AddItem(SelectOptionsItem item, string tagName)
     {
         ArgumentNullException.ThrowIfNull(item);
+        ArgumentNullException.ThrowIfNull(tagName);
 
+        _firstItemTagName ??= tagName;
         _items.Add(item);
     }
 
@@ -59,7 +66,7 @@ internal class SelectContext(ModelExpression? @for) : FormGroupContext3
 
         if (_items.Count != 0)
         {
-            throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(tagName, SelectItemTagHelper.TagName);
+            throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(tagName, ItemTagName);
         }
 
         base.SetErrorMessage(visuallyHiddenText, attributes, html, tagName);
@@ -86,7 +93,7 @@ internal class SelectContext(ModelExpression? @for) : FormGroupContext3
 
         if (_items.Count != 0)
         {
-            throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(tagName, SelectItemTagHelper.TagName);
+            throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(tagName, ItemTagName);
         }
 
         base.SetHint(attributes, html, tagName);
@@ -114,7 +121,7 @@ internal class SelectContext(ModelExpression? @for) : FormGroupContext3
 
         if (_items.Count != 0)
         {
-            throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(tagName, SelectItemTagHelper.TagName);
+            throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(tagName, ItemTagName);
         }
 
         base.SetLabel(isPageHeading, attributes, html, tagName);
@@ -141,7 +148,7 @@ internal class SelectContext(ModelExpression? @for) : FormGroupContext3
 
         if (_items.Count != 0)
         {
-            throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(tagName, SelectItemTagHelper.TagName);
+            throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(tagName, ItemTagName);
         }
 
         _beforeInput = (content, tagName);
@@ -161,7 +168,7 @@ internal class SelectContext(ModelExpression? @for) : FormGroupContext3
 
         if (_items.Count != 0)
         {
-            throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(tagName, SelectItemTagHelper.TagName);
+            throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(tagName, ItemTagName);
         }
 
         _afterInput = (content, tagName);

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/SelectErrorMessageTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/SelectErrorMessageTagHelper.cs
@@ -6,19 +6,11 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the error message in a GDS select component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = SelectTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = SelectTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's error message.")]
 public class SelectErrorMessageTagHelper : FormGroupErrorMessageTagHelperBase
 {
     internal const string TagName = "govuk-select-error-message";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/SelectHintTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/SelectHintTagHelper.cs
@@ -6,19 +6,11 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the hint in a GDS select component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = SelectTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = SelectTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's hint.")]
 public class SelectHintTagHelper : FormGroupHintTagHelperBase
 {
     internal const string TagName = "govuk-select-hint";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/SelectItemTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/SelectItemTagHelper.cs
@@ -11,10 +11,12 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents an item in a GDS select component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = SelectTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = SelectTagHelper.TagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the generated option element.")]
 public class SelectItemTagHelper : TagHelper
 {
     internal const string TagName = "govuk-select-item";
+    internal const string ShortTagName = ShortTagNames.Item;
 
     private const string DisabledAttributeName = "disabled";
     private const string SelectedAttributeName = "selected";
@@ -83,14 +85,16 @@ public class SelectItemTagHelper : TagHelper
 
         var selected = Selected ?? (selectContext.For is { } @for ? ItemMatchesModelValue(@for) : null);
 
-        selectContext.AddItem(new SelectOptionsItem
-        {
-            Attributes = new AttributeCollection(output.Attributes),
-            Text = new TemplateString(content),
-            Disabled = Disabled,
-            Selected = selected,
-            Value = Value
-        });
+        selectContext.AddItem(
+            new SelectOptionsItem
+            {
+                Attributes = new AttributeCollection(output.Attributes),
+                Text = new TemplateString(content),
+                Disabled = Disabled,
+                Selected = selected,
+                Value = Value
+            },
+            context.TagName);
 
         output.SuppressOutput();
     }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/SelectLabelTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/SelectLabelTagHelper.cs
@@ -6,19 +6,11 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the label in a GDS select component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = SelectTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = SelectTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's label.")]
 public class SelectLabelTagHelper : FormGroupLabelTagHelperBase
 {
     internal const string TagName = "govuk-select-label";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/SelectTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/SelectTagHelper.cs
@@ -14,19 +14,17 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 [HtmlTargetElement(TagName)]
 [RestrictChildren(
     SelectItemTagHelper.TagName,
+    SelectItemTagHelper.ShortTagName,
     SelectLabelTagHelper.TagName,
+    SelectLabelTagHelper.ShortTagName,
     SelectHintTagHelper.TagName,
+    SelectHintTagHelper.ShortTagName,
     SelectErrorMessageTagHelper.TagName,
+    SelectErrorMessageTagHelper.ShortTagName,
     SelectBeforeInputTagHelper.TagName,
-    SelectAfterInputTagHelper.TagName
-#if SHORT_TAG_NAMES
-    ,
-    FormGroupLabelTagHelperBase.ShortTagName,
-    FormGroupHintTagHelperBase.ShortTagName,
-    FormGroupErrorMessageTagHelperBase.ShortTagName,
-    ShortTagNames.BeforeInput,
-    ShortTagNames.AfterInput
-#endif
+    SelectBeforeInputTagHelper.ShortTagName,
+    SelectAfterInputTagHelper.TagName,
+    SelectAfterInputTagHelper.ShortTagName
 )]
 [OutputElementHint(DefaultComponentGenerator.ComponentElementTypes.FormGroup)]
 public class SelectTagHelper : TagHelper

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
@@ -20,6 +20,8 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
     [InlineData("FileUpload", "short-error-message", "long-error-message")]
     [InlineData("PasswordInput", "short", "long")]
     [InlineData("PasswordInput", "short-error-message", "long-error-message")]
+    [InlineData("Select", "short", "long")]
+    [InlineData("Select", "short-error-message", "long-error-message")]
     public async Task ShortTagNames_GenerateTheSameMarkupAsTheGovUkPrefixedNames(
         string component,
         string shortTestId,
@@ -116,6 +118,9 @@ public class ShortTagNamesTestsController : Controller
 
     [HttpGet("PasswordInput")]
     public IActionResult GetPasswordInput() => View("PasswordInput", new ShortTagNamesTestsModel());
+
+    [HttpGet("Select")]
+    public IActionResult GetSelect() => View("Select", new ShortTagNamesTestsModel());
 }
 
 public class ShortTagNamesTestsModel
@@ -138,4 +143,6 @@ public class ShortTagNamesTestsModel
     public IFormFile? Evidence { get; set; }
 
     public string? Password { get; set; }
+
+    public string? Sort { get; set; }
 }

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/Select.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/Select.cshtml
@@ -1,0 +1,54 @@
+@model GovUk.Frontend.AspNetCore.IntegrationTests.ShortTagNamesTestsModel
+
+@* The same component written with the short tag names and with the govuk- prefixed ones;
+   the two must generate identical markup *@
+
+<div data-testid="short">
+    <govuk-select for="Sort">
+        <label is-page-heading="true" class="govuk-label--l">The label</label>
+
+        <hint>
+            Choose how the results are ordered
+        </hint>
+
+        <before-input>Before input</before-input>
+        <after-input>After input</after-input>
+
+        <item value="published">Recently published</item>
+        <item value="updated" selected="true">Recently updated</item>
+        <item value="views" disabled="true">Most views</item>
+    </govuk-select>
+</div>
+
+<div data-testid="long">
+    <govuk-select for="Sort">
+        <govuk-select-label is-page-heading="true" class="govuk-label--l">The label</govuk-select-label>
+
+        <govuk-select-hint>
+            Choose how the results are ordered
+        </govuk-select-hint>
+
+        <govuk-select-before-input>Before input</govuk-select-before-input>
+        <govuk-select-after-input>After input</govuk-select-after-input>
+
+        <govuk-select-item value="published">Recently published</govuk-select-item>
+        <govuk-select-item value="updated" selected="true">Recently updated</govuk-select-item>
+        <govuk-select-item value="views" disabled="true">Most views</govuk-select-item>
+    </govuk-select>
+</div>
+
+<div data-testid="short-error-message">
+    <govuk-select name="WithError" id="with-error">
+        <label>The label</label>
+        <error-message>Select how to sort the results</error-message>
+        <item value="published">Recently published</item>
+    </govuk-select>
+</div>
+
+<div data-testid="long-error-message">
+    <govuk-select name="WithError" id="with-error">
+        <govuk-select-label>The label</govuk-select-label>
+        <govuk-select-error-message>Select how to sort the results</govuk-select-error-message>
+        <govuk-select-item value="published">Recently published</govuk-select-item>
+    </govuk-select>
+</div>

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SelectContextTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SelectContextTests.cs
@@ -15,7 +15,7 @@ public class SelectContextTests
         context.AddItem(new SelectOptionsItem()
         {
             Text = "Option"
-        });
+        }, SelectItemTagHelper.TagName);
 
         // Act
         var ex = Record.Exception(() => context.SetErrorMessage(null, [], new HtmlString("Error"), SelectErrorMessageTagHelper.TagName));
@@ -34,7 +34,7 @@ public class SelectContextTests
         context.AddItem(new SelectOptionsItem()
         {
             Text = "Option"
-        });
+        }, SelectItemTagHelper.TagName);
 
         // Act
         var ex = Record.Exception(() => context.SetHint([], new HtmlString("Error"), SelectHintTagHelper.TagName));
@@ -53,7 +53,7 @@ public class SelectContextTests
         context.AddItem(new SelectOptionsItem()
         {
             Text = "Option"
-        });
+        }, SelectItemTagHelper.TagName);
 
         // Act
         var ex = Record.Exception(() => context.SetLabel(false, [], new HtmlString("Error"), SelectLabelTagHelper.TagName));

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SelectTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/SelectTagHelperTests.cs
@@ -48,14 +48,14 @@ public class SelectTagHelperTests : TagHelperTestBase<SelectTagHelper>
                 selectContext.AddItem(new SelectOptionsItem()
                 {
                     Text = "First"
-                });
+                }, SelectItemTagHelper.TagName);
 
                 selectContext.AddItem(new SelectOptionsItem()
                 {
                     Text = "Second",
                     Value = "second",
                     Selected = true
-                });
+                }, SelectItemTagHelper.TagName);
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
@@ -166,7 +166,7 @@ public class SelectTagHelperTests : TagHelperTestBase<SelectTagHelper>
                 selectContext.AddItem(new SelectOptionsItem()
                 {
                     Text = "First"
-                });
+                }, SelectItemTagHelper.TagName);
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
@@ -227,13 +227,13 @@ public class SelectTagHelperTests : TagHelperTestBase<SelectTagHelper>
                 {
                     Text = "First",
                     Value = "1"
-                });
+                }, SelectItemTagHelper.TagName);
 
                 selectContext.AddItem(new SelectOptionsItem()
                 {
                     Text = "Second",
                     Value = modelStateValue
-                });
+                }, SelectItemTagHelper.TagName);
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);


### PR DESCRIPTION
Stacked on #536; the diff will narrow to the select as the stack below it merges. This is the last of the form components with names still behind the dead `#if SHORT_TAG_NAMES` — only the breadcrumbs, character count and service navigation are left after it.

```razor
<govuk-select for="SortBy">
    <label>Sort by</label>
    <item value="published">Recently published</item>
    <item value="updated">Recently updated</item>
    <item value="views">Most views</item>
</govuk-select>
```

| Element | Short name |
| --- | --- |
| `govuk-select-label` | `label` |
| `govuk-select-hint` | `hint` |
| `govuk-select-error-message` | `error-message` |
| `govuk-select-item` | `item` |
| `govuk-select-before-input` / `-after-input` | `before-input` / `after-input` |

All directly inside `<govuk-select>`.

`<item>` is new — the guarded set skipped it, as it skipped the textarea's `<value>` in #534, and without it the terse style would have a hole exactly where the options go. It does not collide with the checkboxes and radios items from #529 and #530: those target `<govuk-checkboxes>` and `<govuk-radios>`, this one targets `<govuk-select>`. Say the word if you would rather it stayed prefixed-only.

### Error messages

`SelectContext.AddItem` now takes the tag name the item was written with and records the first one, matching `CheckboxesContext` and `RadiosContext`, so "`<after-input>` must be specified before `<item>`" names the element as it appears in the view rather than always saying `<govuk-select-item>`.

### Docs

The select example uses the short names and the API table picks up both spellings. The example page renders byte-identical HTML to this branch's parent, so no screenshot needs regenerating, and `just publish-docs` on the committed tree is clean.

### Testing

- `ShortTagNamesTests` gains a select view — the component in both spellings, asserted to generate identical markup, including the items and a selected and a disabled option.
- The unit tests expand per tag name target, so the existing select tests now run under the short names too.
- 1785 unit tests and 93 integration tests pass; Release build and `dotnet format --verify-no-changes` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)