### PR TITLE
Add short tag name support to the character count tag helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Both elements can now generate their `formaction` attribute from the `asp-` attr
 
 As per the guidance, the first page, the pages either side of the current page and the last page are shown, with an ellipsis wherever pages have been skipped, plus Previous and Next links where there is a page to go to. Nothing is rendered at all when there is only one page. Child elements cannot be combined with these attributes.
 
-The checkboxes, radios, date input, text input, textarea, file upload, password input and select tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
+The checkboxes, radios, date input, text input, textarea, file upload, password input, select and character count tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
 
 ```razor
 <govuk-checkboxes for="ContactPreferences">
@@ -59,7 +59,7 @@ The checkboxes, radios, date input, text input, textarea, file upload, password 
 </govuk-date-input>
 ```
 
-The text input takes `<label>`, `<hint>`, `<error-message>`, `<before-input>`, `<prefix>`, `<suffix>` and `<after-input>`; the textarea takes the same, with `<value>` in place of the prefix and suffix, the file upload and password input take `<label>`, `<hint>`, `<error-message>`, `<before-input>` and `<after-input>`; and the select takes those plus `<item>`.
+The text input takes `<label>`, `<hint>`, `<error-message>`, `<before-input>`, `<prefix>`, `<suffix>` and `<after-input>`. The file upload and password input take the same without the prefix and suffix; the textarea and character count take that set plus `<value>`; and the select takes it plus `<item>`.
 
 The `govuk-` prefixed names continue to work everywhere they did before, and remain the only spelling accepted inside a `<govuk-checkboxes-fieldset>`, `<govuk-radios-fieldset>` or `<govuk-date-input-fieldset>` — the short names pair with the fieldset that the root element generates for a `<legend>` of its own.
 

--- a/docs/components/character-count.md
+++ b/docs/components/character-count.md
@@ -13,12 +13,12 @@ Check out the [max words validator](../validation/maxwords.md) for adding server
 
 ```razor
 <govuk-character-count for="MoreDetail" max-length="200">
-    <govuk-character-count-label class="govuk-label--l" is-page-heading="true">
+    <label class="govuk-label--l" is-page-heading="true">
         Can you provide more detail?
-    </govuk-character-count-label>
-    <govuk-character-count-hint>
+    </label>
+    <hint>
         Do not include personal or financial information like your National Insurance number or credit card details.
-    </govuk-character-count-hint>
+    </hint>
 </govuk-character-count>
 ```
 
@@ -47,7 +47,7 @@ Check out the [max words validator](../validation/maxwords.md) for adding server
 | `threshold` | `decimal?` | The percentage value of the limit at which point the count message is displayed. If this is specified the count message will be hidden by default. |
 
 
-#### `<govuk-character-count-label>`
+#### `<label>` / `<govuk-character-count-label>`
 
 The content is the HTML to use within the component's label.
 
@@ -58,14 +58,14 @@ Must be inside a `<govuk-character-count>` element.
 | `is-page-heading` | `bool?` | Whether the label also acts as the heading for the page. |
 
 
-#### `<govuk-character-count-hint>`
+#### `<hint>` / `<govuk-character-count-hint>`
 
 The content is the HTML to use within the component's hint.
 
 Must be inside a `<govuk-character-count>` element.
 
 
-#### `<govuk-character-count-error-message>`
+#### `<error-message>` / `<govuk-character-count-error-message>`
 
 The content is the HTML to use within the component's error message.
 
@@ -76,21 +76,21 @@ Must be inside a `<govuk-character-count>` element.
 | `visually-hidden-text` | `string` | A visually hidden prefix used before the error message. The default is `"Error"`. |
 
 
-#### `<govuk-character-count-before-input>`
+#### `<before-input>` / `<govuk-character-count-before-input>`
 
 The content is the HTML to use before the generated textarea element.
 
 Must be inside a `<govuk-character-count>` element.
 
 
-#### `<govuk-character-count-value>`
+#### `<value>` / `<govuk-character-count-value>`
 
 The content is the HTML to use within the generated textarea.
 
 Must be inside a `<govuk-character-count>` element.
 
 
-#### `<govuk-character-count-after-input>`
+#### `<after-input>` / `<govuk-character-count-after-input>`
 
 The content is the HTML to use after the generated textarea element.
 

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/CharacterCount/CharacterCountExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/CharacterCount/CharacterCountExample.cshtml
@@ -3,11 +3,11 @@
 
 <example>
     <govuk-character-count for="MoreDetail" max-length="200">
-        <govuk-character-count-label class="govuk-label--l" is-page-heading="true">
+        <label class="govuk-label--l" is-page-heading="true">
             Can you provide more detail?
-        </govuk-character-count-label>
-        <govuk-character-count-hint>
+        </label>
+        <hint>
             Do not include personal or financial information like your National Insurance number or credit card details.
-        </govuk-character-count-hint>
+        </hint>
     </govuk-character-count>
 </example>

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CharacterCountAfterInputTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CharacterCountAfterInputTagHelper.cs
@@ -7,27 +7,16 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the content after the input in a GDS character count component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = CharacterCountTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = CharacterCountTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use after the generated textarea element.")]
 public class CharacterCountAfterInputTagHelper : TagHelper
 {
     private readonly ILogger<CharacterCountAfterInputTagHelper> _logger;
 
     internal const string TagName = "govuk-character-count-after-input";
-#if SHORT_TAG_NAMES
     internal const string ShortTagName = ShortTagNames.AfterInput;
-#endif
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = new[]
-    {
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    };
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <summary>
     /// Creates a new <see cref="CharacterCountAfterInputTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CharacterCountBeforeInputTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CharacterCountBeforeInputTagHelper.cs
@@ -7,27 +7,16 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the content before the input in a GDS character count component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = CharacterCountTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = CharacterCountTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use before the generated textarea element.")]
 public class CharacterCountBeforeInputTagHelper : TagHelper
 {
     private readonly ILogger<CharacterCountBeforeInputTagHelper> _logger;
 
     internal const string TagName = "govuk-character-count-before-input";
-#if SHORT_TAG_NAMES
     internal const string ShortTagName = ShortTagNames.BeforeInput;
-#endif
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = new[]
-    {
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    };
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <summary>
     /// Creates a new <see cref="CharacterCountBeforeInputTagHelper"/>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CharacterCountContext.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CharacterCountContext.cs
@@ -7,15 +7,13 @@ internal class CharacterCountContext : FormGroupContext3
 {
     private (IHtmlContent Content, string TagName)? _beforeInput;
     private (IHtmlContent Content, string TagName)? _afterInput;
+    private string? _valueTagName;
 
-    protected override IReadOnlyCollection<string> ErrorMessageTagNames { get; } =
-        [/*CharacterCountErrorMessageTagHelper.ShortTagName, */CharacterCountErrorMessageTagHelper.TagName];
+    protected override IReadOnlyCollection<string> ErrorMessageTagNames { get; } = CharacterCountErrorMessageTagHelper.AllTagNames;
 
-    protected override IReadOnlyCollection<string> HintTagNames { get; } =
-        [/*CharacterCountHintTagHelper.ShortTagName, */CharacterCountHintTagHelper.TagName];
+    protected override IReadOnlyCollection<string> HintTagNames { get; } = CharacterCountHintTagHelper.AllTagNames;
 
-    protected override IReadOnlyCollection<string> LabelTagNames { get; } =
-        [/*CharacterCountLabelTagHelper.ShortTagName, */CharacterCountLabelTagHelper.TagName];
+    protected override IReadOnlyCollection<string> LabelTagNames { get; } = CharacterCountLabelTagHelper.AllTagNames;
 
     protected override string RootTagName { get; } = CharacterCountTagHelper.TagName;
 
@@ -24,6 +22,10 @@ internal class CharacterCountContext : FormGroupContext3
     public IHtmlContent? AfterInput => _afterInput?.Content;
 
     public IHtmlContent? Value { get; private set; }
+
+    // Messages about a value that has already been set name it as it was written in the view,
+    // which may be either the govuk- prefixed name or the short one
+    private string ValueTagName => _valueTagName ?? CharacterCountValueTagHelper.TagName;
 
     private IReadOnlyCollection<string> BeforeInputTagNames => CharacterCountBeforeInputTagHelper.AllTagNames;
 
@@ -53,7 +55,7 @@ internal class CharacterCountContext : FormGroupContext3
         {
             throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(
                 tagName,
-                CharacterCountValueTagHelper.TagName);
+                ValueTagName);
         }
 
         base.SetErrorMessage(visuallyHiddenText, attributes, html, tagName);
@@ -79,7 +81,7 @@ internal class CharacterCountContext : FormGroupContext3
         {
             throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(
                 tagName,
-                CharacterCountValueTagHelper.TagName);
+                ValueTagName);
         }
 
         base.SetHint(attributes, html, tagName);
@@ -109,7 +111,7 @@ internal class CharacterCountContext : FormGroupContext3
         {
             throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(
                 tagName,
-                CharacterCountValueTagHelper.TagName);
+                ValueTagName);
         }
 
         base.SetLabel(isPageHeading, attributes, html, tagName);
@@ -138,7 +140,7 @@ internal class CharacterCountContext : FormGroupContext3
         {
             throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(
                 tagName,
-                CharacterCountValueTagHelper.TagName);
+                ValueTagName);
         }
 
         _beforeInput = (content, tagName);
@@ -160,7 +162,7 @@ internal class CharacterCountContext : FormGroupContext3
         {
             throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(
                 tagName,
-                CharacterCountValueTagHelper.TagName);
+                ValueTagName);
         }
 
         _afterInput = (content, tagName);
@@ -168,11 +170,14 @@ internal class CharacterCountContext : FormGroupContext3
 
     public void SetValue(IHtmlContent html, string tagName)
     {
+        ArgumentNullException.ThrowIfNull(tagName);
+
         if (Value is not null)
         {
             throw ExceptionHelper.OnlyOneElementIsPermittedIn(tagName, RootTagName);
         }
 
+        _valueTagName = tagName;
         Value = html;
     }
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CharacterCountErrorMessageTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CharacterCountErrorMessageTagHelper.cs
@@ -6,19 +6,11 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the error message in a GDS character count component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = CharacterCountTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = CharacterCountTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's error message.")]
 public class CharacterCountErrorMessageTagHelper : FormGroupErrorMessageTagHelperBase
 {
     internal const string TagName = "govuk-character-count-error-message";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CharacterCountHintTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CharacterCountHintTagHelper.cs
@@ -6,19 +6,11 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the hint in a GDS character count component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = CharacterCountTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = CharacterCountTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's hint.")]
 public class CharacterCountHintTagHelper : FormGroupHintTagHelperBase
 {
     internal const string TagName = "govuk-character-count-hint";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CharacterCountLabelTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CharacterCountLabelTagHelper.cs
@@ -6,19 +6,11 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the label in a GDS character count component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = CharacterCountTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = CharacterCountTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the component's label.")]
 public class CharacterCountLabelTagHelper : FormGroupLabelTagHelperBase
 {
     internal const string TagName = "govuk-character-count-label";
 
-    internal static IReadOnlyCollection<string> AllTagNames { get; } = [
-        TagName
-#if SHORT_TAG_NAMES
-        ,
-        ShortTagName
-#endif
-    ];
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CharacterCountTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CharacterCountTagHelper.cs
@@ -14,20 +14,17 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 [HtmlTargetElement(TagName)]
 [RestrictChildren(
     CharacterCountLabelTagHelper.TagName,
+    CharacterCountLabelTagHelper.ShortTagName,
     CharacterCountHintTagHelper.TagName,
+    CharacterCountHintTagHelper.ShortTagName,
     CharacterCountErrorMessageTagHelper.TagName,
+    CharacterCountErrorMessageTagHelper.ShortTagName,
     CharacterCountBeforeInputTagHelper.TagName,
+    CharacterCountBeforeInputTagHelper.ShortTagName,
     CharacterCountAfterInputTagHelper.TagName,
-    CharacterCountValueTagHelper.TagName
-#if SHORT_TAG_NAMES
-    ,
-    FormGroupLabelTagHelperBase.ShortTagName,
-    FormGroupHintTagHelperBase.ShortTagName,
-    FormGroupErrorMessageTagHelperBase.ShortTagName,
-    ShortTagNames.BeforeInput,
-    ShortTagNames.AfterInput,
+    CharacterCountAfterInputTagHelper.ShortTagName,
+    CharacterCountValueTagHelper.TagName,
     CharacterCountValueTagHelper.ShortTagName
-#endif
     )]
 [OutputElementHint(DefaultComponentGenerator.ComponentElementTypes.CharacterCount)]
 public class CharacterCountTagHelper : TagHelper

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/CharacterCountValueTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/CharacterCountValueTagHelper.cs
@@ -6,16 +6,12 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the value of a GDS character count component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = CharacterCountTagHelper.TagName)]
-#if SHORT_TAG_NAMES
 [HtmlTargetElement(ShortTagName, ParentTag = CharacterCountTagHelper.TagName)]
-#endif
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the generated textarea.")]
 public class CharacterCountValueTagHelper : TagHelper
 {
     internal const string TagName = "govuk-character-count-value";
-#if SHORT_TAG_NAMES
     internal const string ShortTagName = ShortTagNames.Value;
-#endif
 
     /// <inheritdoc/>
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
@@ -22,6 +22,8 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
     [InlineData("PasswordInput", "short-error-message", "long-error-message")]
     [InlineData("Select", "short", "long")]
     [InlineData("Select", "short-error-message", "long-error-message")]
+    [InlineData("CharacterCount", "short", "long")]
+    [InlineData("CharacterCount", "short-error-message", "long-error-message")]
     public async Task ShortTagNames_GenerateTheSameMarkupAsTheGovUkPrefixedNames(
         string component,
         string shortTestId,
@@ -121,6 +123,9 @@ public class ShortTagNamesTestsController : Controller
 
     [HttpGet("Select")]
     public IActionResult GetSelect() => View("Select", new ShortTagNamesTestsModel());
+
+    [HttpGet("CharacterCount")]
+    public IActionResult GetCharacterCount() => View("CharacterCount", new ShortTagNamesTestsModel());
 }
 
 public class ShortTagNamesTestsModel

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/CharacterCount.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/CharacterCount.cshtml
@@ -1,0 +1,46 @@
+@model GovUk.Frontend.AspNetCore.IntegrationTests.ShortTagNamesTestsModel
+
+@* The same component written with the short tag names and with the govuk- prefixed ones;
+   the two must generate identical markup *@
+
+<div data-testid="short">
+    <govuk-character-count for="MoreDetail" max-length="200" rows="5">
+        <label is-page-heading="true" class="govuk-label--l">The label</label>
+
+        <hint>
+            Do not include personal or financial information
+        </hint>
+
+        <before-input>Before input</before-input>
+        <after-input>After input</after-input>
+        <value>Some existing content</value>
+    </govuk-character-count>
+</div>
+
+<div data-testid="long">
+    <govuk-character-count for="MoreDetail" max-length="200" rows="5">
+        <govuk-character-count-label is-page-heading="true" class="govuk-label--l">The label</govuk-character-count-label>
+
+        <govuk-character-count-hint>
+            Do not include personal or financial information
+        </govuk-character-count-hint>
+
+        <govuk-character-count-before-input>Before input</govuk-character-count-before-input>
+        <govuk-character-count-after-input>After input</govuk-character-count-after-input>
+        <govuk-character-count-value>Some existing content</govuk-character-count-value>
+    </govuk-character-count>
+</div>
+
+<div data-testid="short-error-message">
+    <govuk-character-count name="WithError" id="with-error" max-length="200">
+        <label>The label</label>
+        <error-message>Enter more detail</error-message>
+    </govuk-character-count>
+</div>
+
+<div data-testid="long-error-message">
+    <govuk-character-count name="WithError" id="with-error" max-length="200">
+        <govuk-character-count-label>The label</govuk-character-count-label>
+        <govuk-character-count-error-message>Enter more detail</govuk-character-count-error-message>
+    </govuk-character-count>
+</div>


### PR DESCRIPTION
Stacked on #537; the diff will narrow to the character count as the stack below it merges. This is the last component that generates an input — only the breadcrumbs and service navigation still have names behind the dead `#if SHORT_TAG_NAMES` after it.

```razor
<govuk-character-count for="MoreDetail" max-length="200">
    <label class="govuk-label--l" is-page-heading="true">Can you provide more detail?</label>
    <hint>Do not include personal or financial information.</hint>
</govuk-character-count>
```

| Element | Short name |
| --- | --- |
| `govuk-character-count-label` | `label` |
| `govuk-character-count-hint` | `hint` |
| `govuk-character-count-error-message` | `error-message` |
| `govuk-character-count-before-input` / `-after-input` | `before-input` / `after-input` |
| `govuk-character-count-value` | `value` |

All directly inside `<govuk-character-count>`. Every name was already written behind the guards, `<value>` included — this component is where the textarea's `<value>` name in #534 came from.

### Error messages

`CharacterCountContext` records the tag name the value was written with, so "`<after-input>` must be specified before `<value>`" names the element as it appears in the view. Its `ErrorMessageTagNames`, `HintTagNames` and `LabelTagNames` now come from `AllTagNames`, replacing three commented-out short names left over from the `#if` work.

That message is not hypothetical: it is what the component threw at me when I first wrote the test view with `<value>` before `<after-input>`. Both this component and the select require the before- and after-input elements ahead of the content, which I had not realised — the view was wrong, not the code, and the message named the short spelling correctly.

### Docs

The character count example uses the short names and the API table picks up both spellings. The example page renders byte-identical HTML to this branch's parent, so no screenshot needs regenerating, and `just publish-docs` on the committed tree is clean.

### Testing

- `ShortTagNamesTests` gains a character count view — the component in both spellings, asserted to generate identical markup.
- The unit tests expand per tag name target, so the existing character count tests now run under the short names too.
- 1788 unit tests and 95 integration tests pass; Release build and `dotnet format --verify-no-changes` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)