### PR TITLE
Add short tag name support to the accordion tag helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Both elements can now generate their `formaction` attribute from the `asp-` attr
 
 As per the guidance, the first page, the pages either side of the current page and the last page are shown, with an ellipsis wherever pages have been skipped, plus Previous and Next links where there is a page to go to. Nothing is rendered at all when there is only one page. Child elements cannot be combined with these attributes.
 
-The checkboxes, radios, date input, text input, textarea, file upload, password input, select and character count tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
+The checkboxes, radios, date input, text input, textarea, file upload, password input, select, character count and accordion tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
 
 ```razor
 <govuk-checkboxes for="ContactPreferences">
@@ -60,6 +60,22 @@ The checkboxes, radios, date input, text input, textarea, file upload, password 
 ```
 
 The text input takes `<label>`, `<hint>`, `<error-message>`, `<before-input>`, `<prefix>`, `<suffix>` and `<after-input>`. The file upload and password input take the same without the prefix and suffix; the textarea and character count take that set plus `<value>`; and the select takes it plus `<select-item>`.
+
+The accordion takes `<accordion-item>` inside `<govuk-accordion>`, each with a `<heading>`, an optional `<summary>` and a `<content>`:
+
+```razor
+<govuk-accordion id="agile-delivery">
+    <accordion-item expanded="true">
+        <heading>Understanding agile project management</heading>
+        <summary>Introductions, methods, core features.</summary>
+        <content>
+            <p class="govuk-body">Agile and government services: an introduction</p>
+        </content>
+    </accordion-item>
+</govuk-accordion>
+```
+
+The item's children pair with the spelling of the item they are in, as the summary list's row children do: `<heading>`, `<summary>` and `<content>` go inside an `<accordion-item>`, and the `govuk-` prefixed names go inside a `<govuk-accordion-item>`.
 
 The `govuk-` prefixed names continue to work everywhere they did before, and remain the only spelling accepted inside a `<govuk-checkboxes-fieldset>`, `<govuk-radios-fieldset>` or `<govuk-date-input-fieldset>` — the short names pair with the fieldset that the root element generates for a `<legend>` of its own.
 

--- a/docs/components/accordion.md
+++ b/docs/components/accordion.md
@@ -11,10 +11,10 @@
 
 ```razor
 <govuk-accordion id="accordion-with-summary-sections" heading-level="3">
-    <govuk-accordion-item expanded="true">
-        <govuk-accordion-item-heading>Understanding agile project management</govuk-accordion-item-heading>
-        <govuk-accordion-item-summary>Introductions, methods, core features.</govuk-accordion-item-summary>
-        <govuk-accordion-item-content>
+    <accordion-item expanded="true">
+        <heading>Understanding agile project management</heading>
+        <summary>Introductions, methods, core features.</summary>
+        <content>
             <ul class="govuk-list">
                 <li>
                     <a class="govuk-link" href="#">Agile and government services: an introduction</a>
@@ -26,12 +26,12 @@
                     <a class="govuk-link" href="#">Core principles of agile</a>
                 </li>
             </ul>
-        </govuk-accordion-item-content>
-    </govuk-accordion-item>
-    <govuk-accordion-item>
-        <govuk-accordion-item-heading>Working with agile methods</govuk-accordion-item-heading>
-        <govuk-accordion-item-summary>Workspaces, tools and techniques, user stories, planning.</govuk-accordion-item-summary>
-        <govuk-accordion-item-content>
+        </content>
+    </accordion-item>
+    <accordion-item>
+        <heading>Working with agile methods</heading>
+        <summary>Workspaces, tools and techniques, user stories, planning.</summary>
+        <content>
             <ul class="govuk-list">
                 <li>
                     <a class="govuk-link" href="#">Creating an agile working environment</a>
@@ -55,12 +55,12 @@
                     <a class="govuk-link" href="#">Developing a roadmap</a>
                 </li>
             </ul>
-        </govuk-accordion-item-content>
-    </govuk-accordion-item>
-    <govuk-accordion-item>
-        <govuk-accordion-item-heading>Governing agile services</govuk-accordion-item-heading>
-        <govuk-accordion-item-summary>Principles, measuring progress, spending money.</govuk-accordion-item-summary>
-        <govuk-accordion-item-content>
+        </content>
+    </accordion-item>
+    <accordion-item>
+        <heading>Governing agile services</heading>
+        <summary>Principles, measuring progress, spending money.</summary>
+        <content>
             <ul class="govuk-list">
                 <li>
                     <a class="govuk-link" href="#">Governance principles for agile service delivery</a>
@@ -81,12 +81,12 @@
                     <a class="govuk-link" href="#">Working across organisational boundaries</a>
                 </li>
             </ul>
-        </govuk-accordion-item-content>
-    </govuk-accordion-item>
-    <govuk-accordion-item>
-        <govuk-accordion-item-heading>Phases of an agile project</govuk-accordion-item-heading>
-        <govuk-accordion-item-summary>Discovery, alpha, beta, live and retirement.</govuk-accordion-item-summary>
-        <govuk-accordion-item-content>
+        </content>
+    </accordion-item>
+    <accordion-item>
+        <heading>Phases of an agile project</heading>
+        <summary>Discovery, alpha, beta, live and retirement.</summary>
+        <content>
             <ul class="govuk-list">
                 <li>
                     <a class="govuk-link" href="#">How the discovery phase works</a>
@@ -104,8 +104,8 @@
                     <a class="govuk-link" href="#">Retiring your service</a>
                 </li>
             </ul>
-        </govuk-accordion-item-content>
-    </govuk-accordion-item>
+        </content>
+    </accordion-item>
 </govuk-accordion>
 ```
 
@@ -127,7 +127,7 @@
 | `show-section-text` | `string` | The text content of the "Show" button within each section of the accordion, which is visible when the section is collapsed. |
 
 
-#### `<govuk-accordion-item>`
+#### `<accordion-item>` / `<govuk-accordion-item>`
 
 Must be inside a `<govuk-accordion>` element.
 
@@ -136,23 +136,23 @@ Must be inside a `<govuk-accordion>` element.
 | `expanded` | `bool?` | Whether the section should be expanded upon initial load. The default is `false`. |
 
 
-#### `<govuk-accordion-item-heading>`
+#### `<heading>` / `<govuk-accordion-item-heading>`
 
 The content is the HTML of the header for each section which is used both as the title for each section, and as the button to open or close each section.
 
-Must be inside a `<govuk-accordion-item>` element.
+Must be inside an `<accordion-item>` or `<govuk-accordion-item>` element.
 
 
-#### `<govuk-accordion-item-summary>`
+#### `<summary>` / `<govuk-accordion-item-summary>`
 
 The content is the HTML for the summary line.
 
-Must be inside a `<govuk-accordion-item>` element.
+Must be inside an `<accordion-item>` or `<govuk-accordion-item>` element.
 
 
-#### `<govuk-accordion-item-content>`
+#### `<content>` / `<govuk-accordion-item-content>`
 
 The content is the HTML of the section, which is hidden when the section is closed.
 
-Must be inside a `<govuk-accordion-item>` element.
+Must be inside an `<accordion-item>` or `<govuk-accordion-item>` element.
 

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Accordion/AccordionExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Accordion/AccordionExample.cshtml
@@ -2,10 +2,10 @@
 
 <example>
     <govuk-accordion id="accordion-with-summary-sections" heading-level="3">
-        <govuk-accordion-item expanded="true">
-            <govuk-accordion-item-heading>Understanding agile project management</govuk-accordion-item-heading>
-            <govuk-accordion-item-summary>Introductions, methods, core features.</govuk-accordion-item-summary>
-            <govuk-accordion-item-content>
+        <accordion-item expanded="true">
+            <heading>Understanding agile project management</heading>
+            <summary>Introductions, methods, core features.</summary>
+            <content>
                 <ul class="govuk-list">
                     <li>
                         <a class="govuk-link" href="#">Agile and government services: an introduction</a>
@@ -17,12 +17,12 @@
                         <a class="govuk-link" href="#">Core principles of agile</a>
                     </li>
                 </ul>
-            </govuk-accordion-item-content>
-        </govuk-accordion-item>
-        <govuk-accordion-item>
-            <govuk-accordion-item-heading>Working with agile methods</govuk-accordion-item-heading>
-            <govuk-accordion-item-summary>Workspaces, tools and techniques, user stories, planning.</govuk-accordion-item-summary>
-            <govuk-accordion-item-content>
+            </content>
+        </accordion-item>
+        <accordion-item>
+            <heading>Working with agile methods</heading>
+            <summary>Workspaces, tools and techniques, user stories, planning.</summary>
+            <content>
                 <ul class="govuk-list">
                     <li>
                         <a class="govuk-link" href="#">Creating an agile working environment</a>
@@ -46,12 +46,12 @@
                         <a class="govuk-link" href="#">Developing a roadmap</a>
                     </li>
                 </ul>
-            </govuk-accordion-item-content>
-        </govuk-accordion-item>
-        <govuk-accordion-item>
-            <govuk-accordion-item-heading>Governing agile services</govuk-accordion-item-heading>
-            <govuk-accordion-item-summary>Principles, measuring progress, spending money.</govuk-accordion-item-summary>
-            <govuk-accordion-item-content>
+            </content>
+        </accordion-item>
+        <accordion-item>
+            <heading>Governing agile services</heading>
+            <summary>Principles, measuring progress, spending money.</summary>
+            <content>
                 <ul class="govuk-list">
                     <li>
                         <a class="govuk-link" href="#">Governance principles for agile service delivery</a>
@@ -72,12 +72,12 @@
                         <a class="govuk-link" href="#">Working across organisational boundaries</a>
                     </li>
                 </ul>
-            </govuk-accordion-item-content>
-        </govuk-accordion-item>
-        <govuk-accordion-item>
-            <govuk-accordion-item-heading>Phases of an agile project</govuk-accordion-item-heading>
-            <govuk-accordion-item-summary>Discovery, alpha, beta, live and retirement.</govuk-accordion-item-summary>
-            <govuk-accordion-item-content>
+            </content>
+        </accordion-item>
+        <accordion-item>
+            <heading>Phases of an agile project</heading>
+            <summary>Discovery, alpha, beta, live and retirement.</summary>
+            <content>
                 <ul class="govuk-list">
                     <li>
                         <a class="govuk-link" href="#">How the discovery phase works</a>
@@ -95,7 +95,7 @@
                         <a class="govuk-link" href="#">Retiring your service</a>
                     </li>
                 </ul>
-            </govuk-accordion-item-content>
-        </govuk-accordion-item>
+            </content>
+        </accordion-item>
     </govuk-accordion>
 </example>

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/AccordionItemContentTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/AccordionItemContentTagHelper.cs
@@ -7,10 +7,14 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the content in a GDS accordion component item.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = AccordionItemTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = AccordionItemTagHelper.ShortTagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML of the section, which is hidden when the section is closed.")]
 public class AccordionItemContentTagHelper : TagHelper
 {
     internal const string TagName = "govuk-accordion-item-content";
+    internal const string ShortTagName = ShortTagNames.Content;
+
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <inheritdoc/>
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
@@ -29,7 +33,7 @@ public class AccordionItemContentTagHelper : TagHelper
 
         var attributes = new AttributeCollection(output.Attributes);
 
-        itemContext.SetContent(attributes, content.Snapshot());
+        itemContext.SetContent(attributes, content.Snapshot(), context.TagName);
 
         output.SuppressOutput();
     }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/AccordionItemContext.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/AccordionItemContext.cs
@@ -3,82 +3,94 @@ using Microsoft.AspNetCore.Html;
 
 namespace GovUk.Frontend.AspNetCore.TagHelpers;
 
-internal class AccordionItemContext
+internal class AccordionItemContext(string itemTagName)
 {
-    public (AttributeCollection Attributes, IHtmlContent Content)? Heading { get; private set; }
-    public (AttributeCollection Attributes, IHtmlContent Content)? Summary { get; private set; }
-    public (AttributeCollection Attributes, IHtmlContent Content)? Content { get; private set; }
+    private (AttributeCollection Attributes, IHtmlContent Content, string TagName)? _heading;
+    private (AttributeCollection Attributes, IHtmlContent Content, string TagName)? _summary;
+    private (AttributeCollection Attributes, IHtmlContent Content, string TagName)? _content;
 
-    public void SetHeading(AttributeCollection attributes, IHtmlContent content)
+    public (AttributeCollection Attributes, IHtmlContent Content)? Heading =>
+        _heading is var (attributes, content, _) ? (attributes, content) : null;
+
+    public (AttributeCollection Attributes, IHtmlContent Content)? Summary =>
+        _summary is var (attributes, content, _) ? (attributes, content) : null;
+
+    public (AttributeCollection Attributes, IHtmlContent Content)? Content =>
+        _content is var (attributes, content, _) ? (attributes, content) : null;
+
+    public void SetHeading(AttributeCollection attributes, IHtmlContent content, string tagName)
     {
         ArgumentNullException.ThrowIfNull(attributes);
         ArgumentNullException.ThrowIfNull(content);
+        ArgumentNullException.ThrowIfNull(tagName);
 
-        if (Heading is not null)
+        if (_heading is not null)
         {
-            throw new InvalidOperationException(
-                $"Only one <{AccordionItemHeadingTagHelper.TagName}> is permitted for each <{AccordionItemTagHelper.TagName}>.");
+            throw ExceptionHelper.OnlyOneElementIsPermittedIn(
+                AccordionItemHeadingTagHelper.AllTagNames,
+                itemTagName);
         }
 
-        if (Summary is not null)
+        if (_summary is var (_, _, summaryTagName))
         {
-            throw new InvalidOperationException(
-                $"<{AccordionItemHeadingTagHelper.TagName}> must be specified before <{AccordionItemSummaryTagHelper.TagName}>.");
+            throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(tagName, summaryTagName);
         }
 
-        if (Content is not null)
+        if (_content is var (_, _, contentTagName))
         {
-            throw new InvalidOperationException(
-                $"<{AccordionItemHeadingTagHelper.TagName}> must be specified before <{AccordionItemContentTagHelper.TagName}>.");
+            throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(tagName, contentTagName);
         }
 
-        Heading = (attributes, content);
+        _heading = (attributes, content, tagName);
     }
 
-    public void SetSummary(AttributeCollection attributes, IHtmlContent content)
+    public void SetSummary(AttributeCollection attributes, IHtmlContent content, string tagName)
     {
         ArgumentNullException.ThrowIfNull(attributes);
         ArgumentNullException.ThrowIfNull(content);
+        ArgumentNullException.ThrowIfNull(tagName);
 
-        if (Summary is not null)
+        if (_summary is not null)
         {
-            throw new InvalidOperationException(
-                $"Only one <{AccordionItemSummaryTagHelper.TagName}> is permitted for each <{AccordionItemTagHelper.TagName}>.");
+            throw ExceptionHelper.OnlyOneElementIsPermittedIn(
+                AccordionItemSummaryTagHelper.AllTagNames,
+                itemTagName);
         }
 
-        if (Content is not null)
+        if (_content is var (_, _, contentTagName))
         {
-            throw new InvalidOperationException(
-                $"<{AccordionItemSummaryTagHelper.TagName}> must be specified before <{AccordionItemContentTagHelper.TagName}>.");
+            throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(tagName, contentTagName);
         }
 
-        Summary = (attributes, content);
+        _summary = (attributes, content, tagName);
     }
 
-    public void SetContent(AttributeCollection attributes, IHtmlContent content)
+    public void SetContent(AttributeCollection attributes, IHtmlContent content, string tagName)
     {
         ArgumentNullException.ThrowIfNull(attributes);
         ArgumentNullException.ThrowIfNull(content);
+        ArgumentNullException.ThrowIfNull(tagName);
 
-        if (Content is not null)
+        if (_content is not null)
         {
-            throw new InvalidOperationException(
-                $"Only one <{AccordionItemContentTagHelper.TagName}> is permitted for each <{AccordionItemTagHelper.TagName}>.");
+            throw ExceptionHelper.OnlyOneElementIsPermittedIn(
+                AccordionItemContentTagHelper.AllTagNames,
+                itemTagName);
         }
 
-        Content = (attributes, content);
+        _content = (attributes, content, tagName);
     }
 
     public void ThrowIfIncomplete()
     {
-        if (Heading is null)
+        if (_heading is null)
         {
-            throw ExceptionHelper.AChildElementMustBeProvided(AccordionItemHeadingTagHelper.TagName);
+            throw ExceptionHelper.AChildElementMustBeProvided(AccordionItemHeadingTagHelper.AllTagNames);
         }
 
-        if (Content is null)
+        if (_content is null)
         {
-            throw ExceptionHelper.AChildElementMustBeProvided(AccordionItemContentTagHelper.TagName);
+            throw ExceptionHelper.AChildElementMustBeProvided(AccordionItemContentTagHelper.AllTagNames);
         }
     }
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/AccordionItemHeadingTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/AccordionItemHeadingTagHelper.cs
@@ -7,10 +7,14 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the heading in a GDS accordion component item.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = AccordionItemTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = AccordionItemTagHelper.ShortTagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML of the header for each section which is used both as the title for each section, and as the button to open or close each section.")]
 public class AccordionItemHeadingTagHelper : TagHelper
 {
     internal const string TagName = "govuk-accordion-item-heading";
+    internal const string ShortTagName = ShortTagNames.Heading;
+
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <inheritdoc/>
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
@@ -29,7 +33,7 @@ public class AccordionItemHeadingTagHelper : TagHelper
 
         var attributes = new AttributeCollection(output.Attributes);
 
-        itemContext.SetHeading(attributes, content.Snapshot());
+        itemContext.SetHeading(attributes, content.Snapshot(), context.TagName);
 
         output.SuppressOutput();
     }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/AccordionItemSummaryTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/AccordionItemSummaryTagHelper.cs
@@ -7,10 +7,14 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the summary in a GDS accordion component item.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = AccordionItemTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = AccordionItemTagHelper.ShortTagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML for the summary line.")]
 public class AccordionItemSummaryTagHelper : TagHelper
 {
     internal const string TagName = "govuk-accordion-item-summary";
+    internal const string ShortTagName = ShortTagNames.Summary;
+
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <inheritdoc/>
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
@@ -29,7 +33,7 @@ public class AccordionItemSummaryTagHelper : TagHelper
 
         var attributes = new AttributeCollection(output.Attributes);
 
-        itemContext.SetSummary(attributes, content.Snapshot());
+        itemContext.SetSummary(attributes, content.Snapshot(), context.TagName);
 
         output.SuppressOutput();
     }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/AccordionItemTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/AccordionItemTagHelper.cs
@@ -7,10 +7,18 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents an item in a GDS accordion component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = AccordionTagHelper.TagName)]
-[RestrictChildren(AccordionItemHeadingTagHelper.TagName, AccordionItemSummaryTagHelper.TagName, AccordionItemContentTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = AccordionTagHelper.TagName)]
+[RestrictChildren(
+    AccordionItemHeadingTagHelper.TagName,
+    AccordionItemHeadingTagHelper.ShortTagName,
+    AccordionItemSummaryTagHelper.TagName,
+    AccordionItemSummaryTagHelper.ShortTagName,
+    AccordionItemContentTagHelper.TagName,
+    AccordionItemContentTagHelper.ShortTagName)]
 public class AccordionItemTagHelper : TagHelper
 {
     internal const string TagName = "govuk-accordion-item";
+    internal const string ShortTagName = ShortTagNames.AccordionItem;
 
     private const string ExpandedAttributeName = "expanded";
 
@@ -26,7 +34,9 @@ public class AccordionItemTagHelper : TagHelper
     /// <inheritdoc/>
     public override void Init(TagHelperContext context)
     {
-        context.SetContextItem(new AccordionItemContext());
+        ArgumentNullException.ThrowIfNull(context);
+
+        context.SetContextItem(new AccordionItemContext(context.TagName));
     }
 
     /// <inheritdoc/>

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/AccordionTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/AccordionTagHelper.cs
@@ -8,7 +8,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// </summary>
 [HtmlTargetElement(TagName)]
 [OutputElementHint(DefaultComponentGenerator.ComponentElementTypes.Accordion)]
-[RestrictChildren(AccordionItemTagHelper.TagName)]
+[RestrictChildren(AccordionItemTagHelper.TagName, AccordionItemTagHelper.ShortTagName)]
 public class AccordionTagHelper : TagHelper
 {
     internal const string TagName = "govuk-accordion";

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/ShortTagNames.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/ShortTagNames.cs
@@ -2,6 +2,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 
 internal static class ShortTagNames
 {
+    public const string AccordionItem = "accordion-item";
     public const string Action = "action";
     public const string ActionButton = "action-button";
     public const string ActionLink = "action-link";
@@ -13,10 +14,12 @@ internal static class ShortTagNames
     public const string CardActions = "card-actions";
     public const string CheckboxesItem = "checkboxes-item";
     public const string Conditional = "conditional";
+    public const string Content = "content";
     public const string Day = "day";
     public const string Divider = "divider";
     public const string End = "end";
     public const string ErrorMessage = "error-message";
+    public const string Heading = "heading";
     public const string Hint = "hint";
     public const string Key = "key";
     public const string Label = "label";
@@ -34,6 +37,7 @@ internal static class ShortTagNames
     public const string SelectItem = "select-item";
     public const string Start = "start";
     public const string Suffix = "suffix";
+    public const string Summary = "summary";
     public const string Title = "title";
     public const string Value = "value";
     public const string Year = "year";

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
@@ -24,10 +24,14 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
     [InlineData("Select", "short-error-message", "long-error-message")]
     [InlineData("CharacterCount", "short", "long")]
     [InlineData("CharacterCount", "short-error-message", "long-error-message")]
+    [InlineData("Accordion", "short", "long", ".govuk-accordion__section")]
     public async Task ShortTagNames_GenerateTheSameMarkupAsTheGovUkPrefixedNames(
         string component,
         string shortTestId,
-        string longTestId)
+        string longTestId,
+        // What the component generates from the children written with the short names; the default
+        // covers the components built around a form field
+        string contentSelector = "legend, label, input, textarea, select")
     {
         // Act
         var document = await GetDocumentAsync(component);
@@ -37,8 +41,7 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
         var longContainer = GetContainer(document, longTestId);
 
         // Guards against both containers being empty, which would make the comparison vacuous
-        Assert.NotEmpty(shortContainer.QuerySelectorAll("legend, label"));
-        Assert.NotEmpty(shortContainer.QuerySelectorAll("input, textarea, select"));
+        Assert.NotEmpty(shortContainer.QuerySelectorAll(contentSelector));
 
         // An unrecognised element is written out as-is, so a short name that never bound to a tag
         // helper would show up here as, say, a <radios-item> element outside the fieldset
@@ -126,6 +129,9 @@ public class ShortTagNamesTestsController : Controller
 
     [HttpGet("CharacterCount")]
     public IActionResult GetCharacterCount() => View("CharacterCount", new ShortTagNamesTestsModel());
+
+    [HttpGet("Accordion")]
+    public IActionResult GetAccordion() => View("Accordion", new ShortTagNamesTestsModel());
 }
 
 public class ShortTagNamesTestsModel

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/Accordion.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/Accordion.cshtml
@@ -1,0 +1,42 @@
+@model GovUk.Frontend.AspNetCore.IntegrationTests.ShortTagNamesTestsModel
+
+@* The same component written with the short tag names and with the govuk- prefixed ones;
+   the two must generate identical markup *@
+
+<div data-testid="short">
+    <govuk-accordion id="accordion" heading-level="3">
+        <accordion-item expanded="true">
+            <heading>Understanding agile project management</heading>
+            <summary>Introductions, methods, core features.</summary>
+            <content>
+                <p class="govuk-body">Agile and government services: an introduction</p>
+            </content>
+        </accordion-item>
+
+        <accordion-item>
+            <heading>Working with agile methods</heading>
+            <content>
+                <p class="govuk-body">Creating an agile working environment</p>
+            </content>
+        </accordion-item>
+    </govuk-accordion>
+</div>
+
+<div data-testid="long">
+    <govuk-accordion id="accordion" heading-level="3">
+        <govuk-accordion-item expanded="true">
+            <govuk-accordion-item-heading>Understanding agile project management</govuk-accordion-item-heading>
+            <govuk-accordion-item-summary>Introductions, methods, core features.</govuk-accordion-item-summary>
+            <govuk-accordion-item-content>
+                <p class="govuk-body">Agile and government services: an introduction</p>
+            </govuk-accordion-item-content>
+        </govuk-accordion-item>
+
+        <govuk-accordion-item>
+            <govuk-accordion-item-heading>Working with agile methods</govuk-accordion-item-heading>
+            <govuk-accordion-item-content>
+                <p class="govuk-body">Creating an agile working environment</p>
+            </govuk-accordion-item-content>
+        </govuk-accordion-item>
+    </govuk-accordion>
+</div>

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/AccordionItemContentTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/AccordionItemContentTagHelperTests.cs
@@ -11,7 +11,7 @@ public class AccordionItemContentTagHelperTests : TagHelperTestBase<AccordionIte
     {
         // Arrange
         var accordionContext = new AccordionContext();
-        var itemContext = new AccordionItemContext();
+        var itemContext = new AccordionItemContext(ParentTagName!);
 
         var context = CreateTagHelperContext(contexts: [accordionContext, itemContext]);
 
@@ -38,8 +38,8 @@ public class AccordionItemContentTagHelperTests : TagHelperTestBase<AccordionIte
     {
         // Arrange
         var accordionContext = new AccordionContext();
-        var itemContext = new AccordionItemContext();
-        itemContext.SetContent(new AttributeCollection(), content: new TemplateString("Existing content"));
+        var itemContext = new AccordionItemContext(ParentTagName!);
+        itemContext.SetContent(new AttributeCollection(), content: new TemplateString("Existing content"), TagName);
 
         var context = CreateTagHelperContext(contexts: [accordionContext, itemContext]);
 
@@ -58,6 +58,8 @@ public class AccordionItemContentTagHelperTests : TagHelperTestBase<AccordionIte
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal("Only one <govuk-accordion-item-content> is permitted for each <govuk-accordion-item>.", ex.Message);
+        Assert.Equal(
+            $"Only one <{PrimaryTagName}> or <{ShortTagName}> element is permitted within each <{ParentTagName}>.",
+            ex.Message);
     }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/AccordionItemHeadingTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/AccordionItemHeadingTagHelperTests.cs
@@ -11,7 +11,7 @@ public class AccordionItemHeadingTagHelperTests : TagHelperTestBase<AccordionIte
     {
         // Arrange
         var accordionContext = new AccordionContext();
-        var itemContext = new AccordionItemContext();
+        var itemContext = new AccordionItemContext(ParentTagName!);
 
         var context = CreateTagHelperContext(contexts: [accordionContext, itemContext]);
 
@@ -38,8 +38,8 @@ public class AccordionItemHeadingTagHelperTests : TagHelperTestBase<AccordionIte
     {
         // Arrange
         var accordionContext = new AccordionContext();
-        var itemContext = new AccordionItemContext();
-        itemContext.SetHeading(new AttributeCollection(), content: new TemplateString("Existing heading"));
+        var itemContext = new AccordionItemContext(ParentTagName!);
+        itemContext.SetHeading(new AttributeCollection(), content: new TemplateString("Existing heading"), TagName);
 
         var context = CreateTagHelperContext(contexts: [accordionContext, itemContext]);
 
@@ -58,16 +58,22 @@ public class AccordionItemHeadingTagHelperTests : TagHelperTestBase<AccordionIte
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal("Only one <govuk-accordion-item-heading> is permitted for each <govuk-accordion-item>.", ex.Message);
+        Assert.Equal(
+            $"Only one <{PrimaryTagName}> or <{ShortTagName}> element is permitted within each <{ParentTagName}>.",
+            ex.Message);
     }
 
     [Fact]
     public async Task ProcessAsync_ItemAlreadyHasSummary_ThrowsInvalidOperationException()
     {
         // Arrange
+        var summaryTagName = GetSiblingTagName(
+            AccordionItemSummaryTagHelper.TagName,
+            AccordionItemSummaryTagHelper.ShortTagName);
+
         var accordionContext = new AccordionContext();
-        var itemContext = new AccordionItemContext();
-        itemContext.SetSummary(attributes: new AttributeCollection(), content: new TemplateString("Summary"));
+        var itemContext = new AccordionItemContext(ParentTagName!);
+        itemContext.SetSummary(attributes: new AttributeCollection(), content: new TemplateString("Summary"), summaryTagName);
 
         var context = CreateTagHelperContext(contexts: [accordionContext, itemContext]);
 
@@ -86,6 +92,6 @@ public class AccordionItemHeadingTagHelperTests : TagHelperTestBase<AccordionIte
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal("<govuk-accordion-item-heading> must be specified before <govuk-accordion-item-summary>.", ex.Message);
+        Assert.Equal($"<{TagName}> must be specified before <{summaryTagName}>.", ex.Message);
     }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/AccordionItemSummaryTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/AccordionItemSummaryTagHelperTests.cs
@@ -11,7 +11,7 @@ public class AccordionItemSummaryTagHelperTests : TagHelperTestBase<AccordionIte
     {
         // Arrange
         var accordionContext = new AccordionContext();
-        var itemContext = new AccordionItemContext();
+        var itemContext = new AccordionItemContext(ParentTagName!);
 
         var context = CreateTagHelperContext(contexts: [accordionContext, itemContext]);
 
@@ -38,8 +38,8 @@ public class AccordionItemSummaryTagHelperTests : TagHelperTestBase<AccordionIte
     {
         // Arrange
         var accordionContext = new AccordionContext();
-        var itemContext = new AccordionItemContext();
-        itemContext.SetSummary(new AttributeCollection(), new TemplateString("Existing summary"));
+        var itemContext = new AccordionItemContext(ParentTagName!);
+        itemContext.SetSummary(new AttributeCollection(), new TemplateString("Existing summary"), TagName);
 
         var context = CreateTagHelperContext(contexts: [accordionContext, itemContext]);
 
@@ -58,6 +58,8 @@ public class AccordionItemSummaryTagHelperTests : TagHelperTestBase<AccordionIte
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal("Only one <govuk-accordion-item-summary> is permitted for each <govuk-accordion-item>.", ex.Message);
+        Assert.Equal(
+            $"Only one <{PrimaryTagName}> or <{ShortTagName}> element is permitted within each <{ParentTagName}>.",
+            ex.Message);
     }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/AccordionItemTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/AccordionItemTagHelperTests.cs
@@ -18,9 +18,9 @@ public class AccordionItemTagHelperTests : TagHelperTestBase<AccordionItemTagHel
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var itemContext = context.GetContextItem<AccordionItemContext>();
-                itemContext.SetHeading(new AttributeCollection(), new TemplateString("Heading"));
-                itemContext.SetSummary(new AttributeCollection(), new TemplateString("Summary"));
-                itemContext.SetContent(new AttributeCollection(), new TemplateString("Content"));
+                itemContext.SetHeading(new AttributeCollection(), new TemplateString("Heading"), AccordionItemHeadingTagHelper.TagName);
+                itemContext.SetSummary(new AttributeCollection(), new TemplateString("Summary"), AccordionItemSummaryTagHelper.TagName);
+                itemContext.SetContent(new AttributeCollection(), new TemplateString("Content"), AccordionItemContentTagHelper.TagName);
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
@@ -54,8 +54,8 @@ public class AccordionItemTagHelperTests : TagHelperTestBase<AccordionItemTagHel
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var itemContext = context.GetContextItem<AccordionItemContext>();
-                itemContext.SetSummary(new AttributeCollection(), new TemplateString("Summary"));
-                itemContext.SetContent(new AttributeCollection(), new TemplateString("Content"));
+                itemContext.SetSummary(new AttributeCollection(), new TemplateString("Summary"), AccordionItemSummaryTagHelper.TagName);
+                itemContext.SetContent(new AttributeCollection(), new TemplateString("Content"), AccordionItemContentTagHelper.TagName);
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
@@ -69,7 +69,9 @@ public class AccordionItemTagHelperTests : TagHelperTestBase<AccordionItemTagHel
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal("A <govuk-accordion-item-heading> element must be provided.", ex.Message);
+        Assert.Equal(
+            $"A <{AccordionItemHeadingTagHelper.TagName}> or <{AccordionItemHeadingTagHelper.ShortTagName}> element must be provided.",
+            ex.Message);
     }
 
     [Fact]
@@ -84,7 +86,7 @@ public class AccordionItemTagHelperTests : TagHelperTestBase<AccordionItemTagHel
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 var itemContext = context.GetContextItem<AccordionItemContext>();
-                itemContext.SetHeading(new AttributeCollection(), new TemplateString("Heading"));
+                itemContext.SetHeading(new AttributeCollection(), new TemplateString("Heading"), AccordionItemHeadingTagHelper.TagName);
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
@@ -98,6 +100,8 @@ public class AccordionItemTagHelperTests : TagHelperTestBase<AccordionItemTagHel
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal("A <govuk-accordion-item-content> element must be provided.", ex.Message);
+        Assert.Equal(
+            $"A <{AccordionItemContentTagHelper.TagName}> or <{AccordionItemContentTagHelper.ShortTagName}> element must be provided.",
+            ex.Message);
     }
 }


### PR DESCRIPTION
Continues the roll-out. The accordion is the first component in the series that isn't built around a form field.

```razor
<govuk-accordion id="agile-delivery" heading-level="3">
    <accordion-item expanded="true">
        <heading>Understanding agile project management</heading>
        <summary>Introductions, methods, core features.</summary>
        <content>
            <p class="govuk-body">Agile and government services: an introduction</p>
        </content>
    </accordion-item>
</govuk-accordion>
```

| Element | Short name |
| --- | --- |
| `govuk-accordion-item` | `accordion-item` |
| `govuk-accordion-item-heading` | `heading` |
| `govuk-accordion-item-summary` | `summary` |
| `govuk-accordion-item-content` | `content` |

`accordion-item` follows #539 rather than being a bare `item`. The three children are scoped to the item, so they can keep the plain names — `<summary>` and `<content>` collide with HTML element names only in a position where no HTML element of that name would be valid anyway.

### Pairing

The item's children pair with the spelling of the item they sit in, the way the summary list's `<key>`, `<value>` and `<row-actions>` pair with its `<row>`: `<heading>` binds inside an `<accordion-item>`, `<govuk-accordion-item-heading>` inside a `<govuk-accordion-item>`. Mixing spellings leaves the child unbound, so it is dropped along with the rest of the item's child content — the same trade-off the summary list and panel already make, and `RestrictChildren` can't distinguish the two parents because one tag helper class serves both.

### Error messages

`AccordionItemContext` now takes the item's tag name and records the tag name each child was written with, so "`<heading>` must be specified before `<summary>`" reads as the view does. Its hand-rolled messages are gone in favour of the `ExceptionHelper` ones the rest of the library uses, which changes the wording slightly and names both spellings where the element is missing entirely:

- `Only one <govuk-accordion-item-summary> is permitted for each <govuk-accordion-item>.` → `Only one <govuk-accordion-item-summary> or <summary> element is permitted within each <govuk-accordion-item>.`
- `A <govuk-accordion-item-heading> element must be provided.` → `A <govuk-accordion-item-heading> or <heading> element must be provided.`

### Testing

- `ShortTagNamesTests` gains an accordion view — the component in both spellings, asserted to generate identical markup. Its guard against a vacuous comparison asserted a label and an input were present, which no accordion generates; the selector is a parameter now, defaulting to what the form components produce.
- The unit tests expand per tag name target, so the existing accordion tests (17) now run under the short names too (34).
- Verified end-to-end against the running Docs app: the example page renders four `govuk-accordion__section-summary` elements and no literal `<heading>`, `<summary>`, `<content>` or `<accordion-item>`.
- 1800 unit tests and 96 integration tests pass; Release build and `dotnet format --verify-no-changes` are clean, and `just publish-docs` on the committed tree is clean — the example generates the same HTML as before, so no screenshot needed regenerating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
