### PR TITLE
Add short tag name support to the fieldset tag helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Both elements can now generate their `formaction` attribute from the `asp-` attr
 
 As per the guidance, the first page, the pages either side of the current page and the last page are shown, with an ellipsis wherever pages have been skipped, plus Previous and Next links where there is a page to go to. Nothing is rendered at all when there is only one page. Child elements cannot be combined with these attributes.
 
-The checkboxes, radios, date input, text input, textarea, file upload, password input, select, character count, accordion, breadcrumbs and service navigation tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
+The checkboxes, radios, date input, text input, textarea, file upload, password input, select, character count, accordion, breadcrumbs, service navigation and fieldset tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
 
 ```razor
 <govuk-checkboxes for="ContactPreferences">
@@ -100,6 +100,14 @@ The service navigation takes `<start>`, `<nav>` and `<end>` inside `<govuk-servi
 ```
 
 Its two spellings cannot be mixed. The navigation's children pair with the spelling of the `<nav>` they are in, as the accordion item's children do, and mixing the spellings of the `<govuk-service-navigation>`'s own children — which all have the same parent element, so cannot be paired up that way — throws.
+
+The fieldset takes the same `<legend>` inside `<govuk-fieldset>` that the checkboxes, radios and date input take:
+
+```razor
+<govuk-fieldset>
+    <legend is-page-heading="true" class="govuk-fieldset__legend--l">What is your address?</legend>
+</govuk-fieldset>
+```
 
 The `govuk-` prefixed names continue to work everywhere they did before, and remain the only spelling accepted inside a `<govuk-checkboxes-fieldset>`, `<govuk-radios-fieldset>` or `<govuk-date-input-fieldset>` — the short names pair with the fieldset that the root element generates for a `<legend>` of its own.
 

--- a/docs/components/fieldset.md
+++ b/docs/components/fieldset.md
@@ -11,7 +11,7 @@
 
 ```razor
 <govuk-fieldset>
-    <govuk-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">Legend as page heading</govuk-fieldset-legend>
+    <legend is-page-heading="true" class="govuk-fieldset__legend--l">Legend as page heading</legend>
 </govuk-fieldset>
 ```
 
@@ -26,7 +26,7 @@
 | `role` | `string` | The `role` attribute. |
 
 
-#### `<govuk-fieldset-legend>`
+#### `<legend>` / `<govuk-fieldset-legend>`
 
 The content is the HTML to use within the legend.
 

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Fieldset/FieldsetExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Fieldset/FieldsetExample.cshtml
@@ -2,6 +2,6 @@
 
 <example>
     <govuk-fieldset>
-        <govuk-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">Legend as page heading</govuk-fieldset-legend>
+        <legend is-page-heading="true" class="govuk-fieldset__legend--l">Legend as page heading</legend>
     </govuk-fieldset>
 </example>

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FieldsetContext.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FieldsetContext.cs
@@ -18,7 +18,7 @@ internal class FieldsetContext
         if (Legend is not null)
         {
             throw ExceptionHelper.OnlyOneElementIsPermittedIn(
-                FieldsetLegendTagHelper.TagName,
+                FieldsetLegendTagHelper.AllTagNames,
                 FieldsetTagHelper.TagName);
         }
 
@@ -29,7 +29,7 @@ internal class FieldsetContext
     {
         if (Legend is null)
         {
-            throw ExceptionHelper.AChildElementMustBeProvided(FieldsetLegendTagHelper.TagName);
+            throw ExceptionHelper.AChildElementMustBeProvided(FieldsetLegendTagHelper.AllTagNames);
         }
     }
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FieldsetLegendTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FieldsetLegendTagHelper.cs
@@ -7,10 +7,14 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the legend in a GDS fieldset component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = FieldsetTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = FieldsetTagHelper.TagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the legend.")]
 public class FieldsetLegendTagHelper : TagHelper
 {
     internal const string TagName = "govuk-fieldset-legend";
+    internal const string ShortTagName = ShortTagNames.Legend;
+
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     private const string IsPageHeadingAttributeName = "is-page-heading";
 

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
@@ -28,6 +28,7 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
     [InlineData("Accordion", "short", "long", ".govuk-accordion__section")]
     [InlineData("Breadcrumbs", "short", "long", ".govuk-breadcrumbs__list-item")]
     [InlineData("ServiceNavigation", "short", "long", ".govuk-service-navigation__item")]
+    [InlineData("Fieldset", "short", "long")]
     public async Task ShortTagNames_GenerateTheSameMarkupAsTheGovUkPrefixedNames(
         string component,
         string shortTestId,
@@ -157,6 +158,9 @@ public class ShortTagNamesTestsController : Controller
 
     [HttpGet("ServiceNavigation")]
     public IActionResult GetServiceNavigation() => View("ServiceNavigation", new ShortTagNamesTestsModel());
+
+    [HttpGet("Fieldset")]
+    public IActionResult GetFieldset() => View("Fieldset", new ShortTagNamesTestsModel());
 
     [HttpGet("ServiceNavigationMixed")]
     public IActionResult GetServiceNavigationMixed() => View("ServiceNavigationMixed", new ShortTagNamesTestsModel());

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/Fieldset.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/Fieldset.cshtml
@@ -1,0 +1,18 @@
+@model GovUk.Frontend.AspNetCore.IntegrationTests.ShortTagNamesTestsModel
+
+@* The same component written with the short tag names and with the govuk- prefixed ones;
+   the two must generate identical markup *@
+
+<div data-testid="short">
+    <govuk-fieldset described-by="hint" role="group">
+        <legend is-page-heading="true" class="govuk-fieldset__legend--l">What is your address?</legend>
+        <p id="hint" class="govuk-hint">We'll only use this to send you a confirmation.</p>
+    </govuk-fieldset>
+</div>
+
+<div data-testid="long">
+    <govuk-fieldset described-by="hint" role="group">
+        <govuk-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">What is your address?</govuk-fieldset-legend>
+        <p id="hint" class="govuk-hint">We'll only use this to send you a confirmation.</p>
+    </govuk-fieldset>
+</div>

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FieldsetLegendTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FieldsetLegendTagHelperTests.cs
@@ -67,6 +67,8 @@ public class FieldsetLegendTagHelperTests : TagHelperTestBase<FieldsetLegendTagH
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal("Only one <govuk-fieldset-legend> element is permitted within each <govuk-fieldset>.", ex.Message);
+        Assert.Equal(
+            $"Only one <{PrimaryTagName}> or <{ShortTagName}> element is permitted within each <{ParentTagName}>.",
+            ex.Message);
     }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FieldsetTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/FieldsetTagHelperTests.cs
@@ -143,7 +143,9 @@ public class FieldsetTagHelperTests : TagHelperTestBase<FieldsetTagHelper>
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal("A <govuk-fieldset-legend> element must be provided.", ex.Message);
+        Assert.Equal(
+            $"A <{FieldsetLegendTagHelper.TagName}> or <{FieldsetLegendTagHelper.ShortTagName}> element must be provided.",
+            ex.Message);
     }
 
     [Fact]


### PR DESCRIPTION
`<legend>` goes inside `<govuk-fieldset>`, the same short name the checkboxes, radios and date input already take for the legend of the fieldset they generate:

```razor
<govuk-fieldset>
    <legend is-page-heading="true" class="govuk-fieldset__legend--l">What is your address?</legend>
</govuk-fieldset>
```

`ShortTagNames.Legend` was already there for those components; this registers it on `FieldsetLegendTagHelper` too, scoped to a `<govuk-fieldset>` parent.

There is only one child element and only one of it is permitted, so there is no spelling to pair with and nothing to mix. `FieldsetContext`'s two messages now name both spellings, as every other component's do, rather than only the `govuk-` prefixed one.

This is the plain `<govuk-fieldset>`; the fieldsets that other components wrap their inputs in are untouched, and `<govuk-checkboxes-fieldset>`, `<govuk-radios-fieldset>` and `<govuk-date-input-fieldset>` still take only the `govuk-` prefixed legend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)