### PR TITLE
Add short tag name support to the generic header tag helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Both elements can now generate their `formaction` attribute from the `asp-` attr
 
 As per the guidance, the first page, the pages either side of the current page and the last page are shown, with an ellipsis wherever pages have been skipped, plus Previous and Next links where there is a page to go to. Nothing is rendered at all when there is only one page. Child elements cannot be combined with these attributes.
 
-The checkboxes, radios, date input, text input, textarea, file upload, password input, select, character count, accordion, breadcrumbs, service navigation and fieldset tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
+The checkboxes, radios, date input, text input, textarea, file upload, password input, select, character count, accordion, breadcrumbs, service navigation, fieldset and generic header tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
 
 ```razor
 <govuk-checkboxes for="ContactPreferences">
@@ -107,6 +107,14 @@ The fieldset takes the same `<legend>` inside `<govuk-fieldset>` that the checkb
 <govuk-fieldset>
     <legend is-page-heading="true" class="govuk-fieldset__legend--l">What is your address?</legend>
 </govuk-fieldset>
+```
+
+The generic header takes `<logo>` inside `<govuk-generic-header>`:
+
+```razor
+<govuk-generic-header home-page-url="https://my.service.gov.uk">
+    <logo>My service</logo>
+</govuk-generic-header>
 ```
 
 The `govuk-` prefixed names continue to work everywhere they did before, and remain the only spelling accepted inside a `<govuk-checkboxes-fieldset>`, `<govuk-radios-fieldset>` or `<govuk-date-input-fieldset>` — the short names pair with the fieldset that the root element generates for a `<legend>` of its own.

--- a/docs/components/generic-header.md
+++ b/docs/components/generic-header.md
@@ -11,9 +11,9 @@
 
 ```razor
 <govuk-generic-header home-page-url="https://my.service.gov.uk">
-    <govuk-generic-header-logo>
+    <logo>
         My service
-    </govuk-generic-header-logo>
+    </logo>
 </govuk-generic-header>
 ```
 
@@ -30,7 +30,7 @@ The content is the HTML to use after the logo.
 | `home-page-url` | `string` | The URL of the homepage link. If not specified, `/` will be used. |
 
 
-#### `<govuk-generic-header-logo>`
+#### `<logo>` / `<govuk-generic-header-logo>`
 
 The content is the HTML to use within the logo's link.
 

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/GenericHeader/GenericHeaderExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/GenericHeader/GenericHeaderExample.cshtml
@@ -3,9 +3,9 @@
 @section GovUkHeader {
     <example>
         <govuk-generic-header home-page-url="https://my.service.gov.uk">
-            <govuk-generic-header-logo>
+            <logo>
                 My service
-            </govuk-generic-header-logo>
+            </logo>
         </govuk-generic-header>
     </example>
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/GenericHeaderContext.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/GenericHeaderContext.cs
@@ -19,7 +19,7 @@ internal class GenericHeaderContext
         if (Logo is not null)
         {
             throw ExceptionHelper.OnlyOneElementIsPermittedIn(
-                GenericHeaderLogoTagHelper.TagName,
+                GenericHeaderLogoTagHelper.AllTagNames,
                 GenericHeaderTagHelper.TagName);
         }
 
@@ -30,7 +30,7 @@ internal class GenericHeaderContext
     {
         if (Logo is null)
         {
-            throw ExceptionHelper.AChildElementMustBeProvided(GenericHeaderLogoTagHelper.TagName);
+            throw ExceptionHelper.AChildElementMustBeProvided(GenericHeaderLogoTagHelper.AllTagNames);
         }
     }
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/GenericHeaderLogoTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/GenericHeaderLogoTagHelper.cs
@@ -7,10 +7,14 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the logo in a GDS generic header component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = GenericHeaderTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = GenericHeaderTagHelper.TagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the logo's link.")]
 public class GenericHeaderLogoTagHelper : TagHelper
 {
     internal const string TagName = "govuk-generic-header-logo";
+    internal const string ShortTagName = ShortTagNames.Logo;
+
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     private const string LinkAttributesPrefix = "link-";
 

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/ShortTagNames.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/ShortTagNames.cs
@@ -24,6 +24,7 @@ internal static class ShortTagNames
     public const string Key = "key";
     public const string Label = "label";
     public const string Legend = "legend";
+    public const string Logo = "logo";
     public const string Month = "month";
     public const string Nav = "nav";
     public const string NavItem = "nav-item";

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
@@ -29,6 +29,7 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
     [InlineData("Breadcrumbs", "short", "long", ".govuk-breadcrumbs__list-item")]
     [InlineData("ServiceNavigation", "short", "long", ".govuk-service-navigation__item")]
     [InlineData("Fieldset", "short", "long")]
+    [InlineData("GenericHeader", "short", "long", ".govuk-generic-header__homepage-link")]
     public async Task ShortTagNames_GenerateTheSameMarkupAsTheGovUkPrefixedNames(
         string component,
         string shortTestId,
@@ -161,6 +162,9 @@ public class ShortTagNamesTestsController : Controller
 
     [HttpGet("Fieldset")]
     public IActionResult GetFieldset() => View("Fieldset", new ShortTagNamesTestsModel());
+
+    [HttpGet("GenericHeader")]
+    public IActionResult GetGenericHeader() => View("GenericHeader", new ShortTagNamesTestsModel());
 
     [HttpGet("ServiceNavigationMixed")]
     public IActionResult GetServiceNavigationMixed() => View("ServiceNavigationMixed", new ShortTagNamesTestsModel());

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/GenericHeader.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/GenericHeader.cshtml
@@ -1,0 +1,18 @@
+@model GovUk.Frontend.AspNetCore.IntegrationTests.ShortTagNamesTestsModel
+
+@* The same component written with the short tag names and with the govuk- prefixed ones;
+   the two must generate identical markup *@
+
+<div data-testid="short">
+    <govuk-generic-header home-page-url="https://my.service.gov.uk" container-class="app-width-container">
+        <logo link-aria-label="My service homepage">My service</logo>
+        <p class="govuk-body">After the logo</p>
+    </govuk-generic-header>
+</div>
+
+<div data-testid="long">
+    <govuk-generic-header home-page-url="https://my.service.gov.uk" container-class="app-width-container">
+        <govuk-generic-header-logo link-aria-label="My service homepage">My service</govuk-generic-header-logo>
+        <p class="govuk-body">After the logo</p>
+    </govuk-generic-header>
+</div>

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/GenericHeaderLogoTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/GenericHeaderLogoTagHelperTests.cs
@@ -80,6 +80,8 @@ public class GenericHeaderLogoTagHelperTests : TagHelperTestBase<GenericHeaderLo
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal("Only one <govuk-generic-header-logo> element is permitted within each <govuk-generic-header>.", ex.Message);
+        Assert.Equal(
+            $"Only one <{PrimaryTagName}> or <{ShortTagName}> element is permitted within each <{ParentTagName}>.",
+            ex.Message);
     }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/GenericHeaderTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/GenericHeaderTagHelperTests.cs
@@ -84,6 +84,8 @@ public class GenericHeaderTagHelperTests : TagHelperTestBase<GenericHeaderTagHel
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal("A <govuk-generic-header-logo> element must be provided.", ex.Message);
+        Assert.Equal(
+            $"A <{GenericHeaderLogoTagHelper.TagName}> or <{GenericHeaderLogoTagHelper.ShortTagName}> element must be provided.",
+            ex.Message);
     }
 }


### PR DESCRIPTION
`<logo>` goes inside `<govuk-generic-header>`:

```razor
<govuk-generic-header home-page-url="https://my.service.gov.uk">
    <logo>My service</logo>
</govuk-generic-header>
```

The name is new, so it joins `ShortTagNames`; `<govuk-header>` takes no children, so nothing else claims it.

As with the fieldset, there is only one child element and only one of it is permitted, so there is no spelling to pair with and nothing to mix. `GenericHeaderContext`'s two messages now name both spellings, as every other component's do, rather than only the `govuk-` prefixed one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)