### PR TITLE
Add short tag name support to the notification banner tag helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Both elements can now generate their `formaction` attribute from the `asp-` attr
 
 As per the guidance, the first page, the pages either side of the current page and the last page are shown, with an ellipsis wherever pages have been skipped, plus Previous and Next links where there is a page to go to. Nothing is rendered at all when there is only one page. Child elements cannot be combined with these attributes.
 
-The checkboxes, radios, date input, text input, textarea, file upload, password input, select, character count, accordion, breadcrumbs, service navigation, fieldset, generic header and footer tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
+The checkboxes, radios, date input, text input, textarea, file upload, password input, select, character count, accordion, breadcrumbs, service navigation, fieldset, generic header, footer and notification banner tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
 
 ```razor
 <govuk-checkboxes for="ContactPreferences">
@@ -139,6 +139,15 @@ The footer takes `<nav>`, `<meta>`, `<content-licence>` and `<copyright>` inside
 ```
 
 As with the service navigation, the footer's two spellings cannot be mixed. Each section's children pair with the spelling of the section they are in, and mixing the spellings of the `<govuk-footer>`'s own children — which all have the same parent element, so cannot be paired up that way — throws.
+
+The notification banner takes `<title>` inside `<govuk-notification-banner>`, the same short name the summary card and the footer's nav sections take for their titles:
+
+```razor
+<govuk-notification-banner type="NotificationBannerType.Success">
+    <title heading-level="3">Important information</title>
+    <p class="govuk-notification-banner__heading">You have 7 days left to send your application.</p>
+</govuk-notification-banner>
+```
 
 The `govuk-` prefixed names continue to work everywhere they did before, and remain the only spelling accepted inside a `<govuk-checkboxes-fieldset>`, `<govuk-radios-fieldset>` or `<govuk-date-input-fieldset>` — the short names pair with the fieldset that the root element generates for a `<legend>` of its own.
 

--- a/docs/components/notification-banner.md
+++ b/docs/components/notification-banner.md
@@ -37,9 +37,9 @@
 
 ```razor
 <govuk-notification-banner>
-    <govuk-notification-banner-title heading-level="2" id="banner-title">
+    <title heading-level="2" id="banner-title">
         Important information
-    </govuk-notification-banner-title>
+    </title>
     <p class="govuk-notification-banner__heading">
         You have 7 days left to send your application.
         <a class="govuk-notification-banner__link" href="#">View application</a>.
@@ -61,7 +61,7 @@ The content is the HTML to use within the notification banner.
 | `type` | `GovUk.Frontend.AspNetCore.NotificationBannerType?` | The type of notification. |
 
 
-#### `<govuk-notification-banner-title>`
+#### `<title>` / `<govuk-notification-banner-title>`
 
 The content is the HTML to use within the notification banner's title. Use a self-closing tag to keep the default content.
 

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/NotificationBanner/NotificationBannerWithOverriddenTitleExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/NotificationBanner/NotificationBannerWithOverriddenTitleExample.cshtml
@@ -2,9 +2,9 @@
 
 <example>
     <govuk-notification-banner>
-        <govuk-notification-banner-title heading-level="2" id="banner-title">
+        <title heading-level="2" id="banner-title">
             Important information
-        </govuk-notification-banner-title>
+        </title>
         <p class="govuk-notification-banner__heading">
             You have 7 days left to send your application.
             <a class="govuk-notification-banner__link" href="#">View application</a>.

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/NotificationBannerContext.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/NotificationBannerContext.cs
@@ -11,7 +11,7 @@ internal class NotificationBannerContext
         if (Title is not null)
         {
             throw ExceptionHelper.OnlyOneElementIsPermittedIn(
-                NotificationBannerTitleTagHelper.TagName,
+                NotificationBannerTitleTagHelper.AllTagNames,
                 NotificationBannerTagHelper.TagName);
         }
 

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/NotificationBannerTitleTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/NotificationBannerTitleTagHelper.cs
@@ -6,10 +6,14 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the title in a GDS notification banner component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = NotificationBannerTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = NotificationBannerTagHelper.TagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the notification banner's title. Use a self-closing tag to keep the default content.")]
 public class NotificationBannerTitleTagHelper : TagHelper
 {
     internal const string TagName = "govuk-notification-banner-title";
+    internal const string ShortTagName = ShortTagNames.Title;
+
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     private const string HeadingLevelAttributeName = "heading-level";
     private const string IdAttributeName = "id";

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
@@ -31,6 +31,7 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
     [InlineData("Fieldset", "short", "long")]
     [InlineData("GenericHeader", "short", "long", ".govuk-generic-header__homepage-link")]
     [InlineData("Footer", "short", "long", ".govuk-footer__link")]
+    [InlineData("NotificationBanner", "short", "long", ".govuk-notification-banner__title")]
     public async Task ShortTagNames_GenerateTheSameMarkupAsTheGovUkPrefixedNames(
         string component,
         string shortTestId,
@@ -188,6 +189,9 @@ public class ShortTagNamesTestsController : Controller
 
     [HttpGet("FooterMixed")]
     public IActionResult GetFooterMixed() => View("FooterMixed", new ShortTagNamesTestsModel());
+
+    [HttpGet("NotificationBanner")]
+    public IActionResult GetNotificationBanner() => View("NotificationBanner", new ShortTagNamesTestsModel());
 
     [HttpGet("ServiceNavigationMixed")]
     public IActionResult GetServiceNavigationMixed() => View("ServiceNavigationMixed", new ShortTagNamesTestsModel());

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/NotificationBanner.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/NotificationBanner.cshtml
@@ -1,0 +1,24 @@
+@model GovUk.Frontend.AspNetCore.IntegrationTests.ShortTagNamesTestsModel
+
+@* The same component written with the short tag names and with the govuk- prefixed ones;
+   the two must generate identical markup *@
+
+<div data-testid="short">
+    <govuk-notification-banner type="GovUk.Frontend.AspNetCore.NotificationBannerType.Success" disable-auto-focus="true">
+        <title heading-level="3" id="banner-title">Important information</title>
+        <p class="govuk-notification-banner__heading">
+            You have 7 days left to send your application.
+            <a class="govuk-notification-banner__link" href="/">View application</a>.
+        </p>
+    </govuk-notification-banner>
+</div>
+
+<div data-testid="long">
+    <govuk-notification-banner type="GovUk.Frontend.AspNetCore.NotificationBannerType.Success" disable-auto-focus="true">
+        <govuk-notification-banner-title heading-level="3" id="banner-title">Important information</govuk-notification-banner-title>
+        <p class="govuk-notification-banner__heading">
+            You have 7 days left to send your application.
+            <a class="govuk-notification-banner__link" href="/">View application</a>.
+        </p>
+    </govuk-notification-banner>
+</div>

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/NotificationBannerContextTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/NotificationBannerContextTests.cs
@@ -17,6 +17,9 @@ public class NotificationBannerContextTests
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal("Only one <govuk-notification-banner-title> element is permitted within each <govuk-notification-banner>.", ex.Message);
+        Assert.Equal(
+            $"Only one <{NotificationBannerTitleTagHelper.TagName}> or <{NotificationBannerTitleTagHelper.ShortTagName}> " +
+                $"element is permitted within each <{NotificationBannerTagHelper.TagName}>.",
+            ex.Message);
     }
 }


### PR DESCRIPTION
`<title>` goes inside `<govuk-notification-banner>`, the same short name the summary card and the footer's nav sections already take for their titles:

```razor
<govuk-notification-banner type="NotificationBannerType.Success">
    <title heading-level="3">Important information</title>
    <p class="govuk-notification-banner__heading">You have 7 days left to send your application.</p>
</govuk-notification-banner>
```

There is only one child element and only one of it is permitted, so there is no spelling to pair with and nothing to mix. The title is optional, so the only message to change is `NotificationBannerContext`'s "only one element is permitted", which now names both spellings.

Its test builds the context directly rather than going through the tag helper, so it is not fanned out over the tag names the way the tag helper tests are and names both spellings itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)