### PR TITLE
Add short tag name support to the phase banner tag helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Both elements can now generate their `formaction` attribute from the `asp-` attr
 
 As per the guidance, the first page, the pages either side of the current page and the last page are shown, with an ellipsis wherever pages have been skipped, plus Previous and Next links where there is a page to go to. Nothing is rendered at all when there is only one page. Child elements cannot be combined with these attributes.
 
-The checkboxes, radios, date input, text input, textarea, file upload, password input, select, character count, accordion, breadcrumbs, service navigation, fieldset, generic header, footer, notification banner and pagination tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
+The checkboxes, radios, date input, text input, textarea, file upload, password input, select, character count, accordion, breadcrumbs, service navigation, fieldset, generic header, footer, notification banner, pagination and phase banner tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
 
 ```razor
 <govuk-checkboxes for="ContactPreferences">
@@ -163,6 +163,15 @@ The pagination takes `<previous>`, `<pagination-item>`, `<ellipsis>` and `<next>
 ```
 
 Its children also all share the same parent element, so, as with the footer and the service navigation, the two spellings cannot be mixed.
+
+The phase banner takes `<tag>` inside `<govuk-phase-banner>`:
+
+```razor
+<govuk-phase-banner>
+    <tag>Alpha</tag>
+    This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.
+</govuk-phase-banner>
+```
 
 The `govuk-` prefixed names continue to work everywhere they did before, and remain the only spelling accepted inside a `<govuk-checkboxes-fieldset>`, `<govuk-radios-fieldset>` or `<govuk-date-input-fieldset>` — the short names pair with the fieldset that the root element generates for a `<legend>` of its own.
 

--- a/docs/components/phase-banner.md
+++ b/docs/components/phase-banner.md
@@ -9,7 +9,7 @@
 
 ```razor
 <govuk-phase-banner>
-    <govuk-phase-banner-tag>Alpha</govuk-phase-banner-tag>
+    <tag>Alpha</tag>
     This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.
 </govuk-phase-banner>
 ```
@@ -22,7 +22,7 @@
 The content is the HTML to use in the phase banner.
 
 
-#### `<govuk-phase-banner-tag>`
+#### `<tag>` / `<govuk-phase-banner-tag>`
 
 The content is the HTML to use for the tag in the phase banner.
 

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/PhaseBanner/PhaseBannerExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/PhaseBanner/PhaseBannerExample.cshtml
@@ -2,7 +2,7 @@
 
 <example>
     <govuk-phase-banner>
-        <govuk-phase-banner-tag>Alpha</govuk-phase-banner-tag>
+        <tag>Alpha</tag>
         This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.
     </govuk-phase-banner>
 </example>

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/PhaseBannerContext.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/PhaseBannerContext.cs
@@ -13,7 +13,9 @@ internal class PhaseBannerContext
 
         if (Tag is not null)
         {
-            throw ExceptionHelper.OnlyOneElementIsPermittedIn(tagName, PhaseBannerTagHelper.TagName);
+            throw ExceptionHelper.OnlyOneElementIsPermittedIn(
+                PhaseBannerTagTagHelper.AllTagNames,
+                PhaseBannerTagHelper.TagName);
         }
 
         Tag = (options, tagName);
@@ -23,7 +25,7 @@ internal class PhaseBannerContext
     {
         if (Tag is null)
         {
-            throw ExceptionHelper.AChildElementMustBeProvided(PhaseBannerTagTagHelper.TagName);
+            throw ExceptionHelper.AChildElementMustBeProvided(PhaseBannerTagTagHelper.AllTagNames);
         }
     }
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/PhaseBannerTagTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/PhaseBannerTagTagHelper.cs
@@ -7,10 +7,14 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the tag in a GDS phase banner component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = PhaseBannerTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = PhaseBannerTagHelper.TagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use for the tag in the phase banner.")]
 public class PhaseBannerTagTagHelper : TagHelper
 {
     internal const string TagName = "govuk-phase-banner-tag";
+    internal const string ShortTagName = ShortTagNames.Tag;
+
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <inheritdoc/>
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/ShortTagNames.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/ShortTagNames.cs
@@ -49,6 +49,7 @@ internal static class ShortTagNames
     public const string Start = "start";
     public const string Suffix = "suffix";
     public const string Summary = "summary";
+    public const string Tag = "tag";
     public const string Title = "title";
     public const string Value = "value";
     public const string Year = "year";

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
@@ -33,6 +33,7 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
     [InlineData("Footer", "short", "long", ".govuk-footer__link")]
     [InlineData("NotificationBanner", "short", "long", ".govuk-notification-banner__title")]
     [InlineData("Pagination", "short", "long", ".govuk-pagination__link")]
+    [InlineData("PhaseBanner", "short", "long", ".govuk-phase-banner__content__tag")]
     public async Task ShortTagNames_GenerateTheSameMarkupAsTheGovUkPrefixedNames(
         string component,
         string shortTestId,
@@ -215,6 +216,9 @@ public class ShortTagNamesTestsController : Controller
 
     [HttpGet("PaginationMixed")]
     public IActionResult GetPaginationMixed() => View("PaginationMixed", new ShortTagNamesTestsModel());
+
+    [HttpGet("PhaseBanner")]
+    public IActionResult GetPhaseBanner() => View("PhaseBanner", new ShortTagNamesTestsModel());
 
     [HttpGet("ServiceNavigationMixed")]
     public IActionResult GetServiceNavigationMixed() => View("ServiceNavigationMixed", new ShortTagNamesTestsModel());

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/PhaseBanner.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/PhaseBanner.cshtml
@@ -1,0 +1,18 @@
+@model GovUk.Frontend.AspNetCore.IntegrationTests.ShortTagNamesTestsModel
+
+@* The same component written with the short tag names and with the govuk- prefixed ones;
+   the two must generate identical markup *@
+
+<div data-testid="short">
+    <govuk-phase-banner class="app-phase-banner">
+        <tag class="govuk-tag--blue">Alpha</tag>
+        This is a new service - your <a href="/" class="govuk-link">feedback</a> will help us to improve it.
+    </govuk-phase-banner>
+</div>
+
+<div data-testid="long">
+    <govuk-phase-banner class="app-phase-banner">
+        <govuk-phase-banner-tag class="govuk-tag--blue">Alpha</govuk-phase-banner-tag>
+        This is a new service - your <a href="/" class="govuk-link">feedback</a> will help us to improve it.
+    </govuk-phase-banner>
+</div>

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PhaseBannerTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PhaseBannerTagHelperTests.cs
@@ -30,7 +30,7 @@ public class PhaseBannerTagHelperTests : TagHelperTestBase<PhaseBannerTagHelper>
             {
                 var phaseBannerContext = context.GetContextItem<PhaseBannerContext>();
 
-                phaseBannerContext.SetTag(tagOptions, PhaseBannerTagHelper.TagName);
+                phaseBannerContext.SetTag(tagOptions, PhaseBannerTagTagHelper.TagName);
 
                 TagHelperContent tagHelperContent = new DefaultTagHelperContent();
                 tagHelperContent.SetContent(content);
@@ -84,6 +84,8 @@ public class PhaseBannerTagHelperTests : TagHelperTestBase<PhaseBannerTagHelper>
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal($"A <{PhaseBannerTagTagHelper.TagName}> element must be provided.", ex.Message);
+        Assert.Equal(
+            $"A <{PhaseBannerTagTagHelper.TagName}> or <{PhaseBannerTagTagHelper.ShortTagName}> element must be provided.",
+            ex.Message);
     }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PhaseBannerTagTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/PhaseBannerTagTagHelperTests.cs
@@ -48,7 +48,7 @@ public class PhaseBannerTagTagHelperTests : TagHelperTestBase<PhaseBannerTagTagH
         // Arrange
         var content = "Tag";
         var phaseBannerContext = new PhaseBannerContext();
-        phaseBannerContext.SetTag(new TagOptions(), PhaseBannerTagHelper.TagName);
+        phaseBannerContext.SetTag(new TagOptions(), TagName);
 
         var context = CreateTagHelperContext(contexts: phaseBannerContext);
 
@@ -69,6 +69,8 @@ public class PhaseBannerTagTagHelperTests : TagHelperTestBase<PhaseBannerTagTagH
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal($"Only one <{TagName}> element is permitted within each <{ParentTagName}>.", ex.Message);
+        Assert.Equal(
+            $"Only one <{PrimaryTagName}> or <{ShortTagName}> element is permitted within each <{ParentTagName}>.",
+            ex.Message);
     }
 }


### PR DESCRIPTION
`<tag>` goes inside `<govuk-phase-banner>`. The name is new, so it joins `ShortTagNames`:

```razor
<govuk-phase-banner>
    <tag>Alpha</tag>
    This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.
</govuk-phase-banner>
```

There is only one child element and only one of it is permitted, so there is no spelling to pair with and nothing to mix. `PhaseBannerContext` already recorded the tag name the element was written with and named it in the "only one element is permitted" message; that message names both spellings now, as every other component's does, and the recorded name stays because it is what the context exposes for the element that was matched.

Two of the tests seeded the child's tag name with the parent element's name. They name the child now, which the second one has to since the spelling has to match the one under test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)