### PR TITLE
Add short tag name support to the tabs tag helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Both elements can now generate their `formaction` attribute from the `asp-` attr
 
 As per the guidance, the first page, the pages either side of the current page and the last page are shown, with an ellipsis wherever pages have been skipped, plus Previous and Next links where there is a page to go to. Nothing is rendered at all when there is only one page. Child elements cannot be combined with these attributes.
 
-The checkboxes, radios, date input, text input, textarea, file upload, password input, select, character count, accordion, breadcrumbs, service navigation, fieldset, generic header, footer, notification banner, pagination and phase banner tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
+The checkboxes, radios, date input, text input, textarea, file upload, password input, select, character count, accordion, breadcrumbs, service navigation, fieldset, generic header, footer, notification banner, pagination, phase banner and tabs tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
 
 ```razor
 <govuk-checkboxes for="ContactPreferences">
@@ -171,6 +171,19 @@ The phase banner takes `<tag>` inside `<govuk-phase-banner>`:
     <tag>Alpha</tag>
     This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.
 </govuk-phase-banner>
+```
+
+The tabs take `<tabs-item>` inside `<govuk-tabs>`:
+
+```razor
+<govuk-tabs id-prefix="views">
+    <tabs-item label="Past day">
+        <h2 class="govuk-heading-l">Past day</h2>
+    </tabs-item>
+    <tabs-item label="Past week">
+        <h2 class="govuk-heading-l">Past week</h2>
+    </tabs-item>
+</govuk-tabs>
 ```
 
 The `govuk-` prefixed names continue to work everywhere they did before, and remain the only spelling accepted inside a `<govuk-checkboxes-fieldset>`, `<govuk-radios-fieldset>` or `<govuk-date-input-fieldset>` — the short names pair with the fieldset that the root element generates for a `<legend>` of its own.

--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -11,18 +11,18 @@
 
 ```razor
 <govuk-tabs>
-    <govuk-tabs-item id="past-day" label="Past day">
+    <tabs-item id="past-day" label="Past day">
         <h2 class="govuk-heading-l">Past day</h2>
-    </govuk-tabs-item>
-    <govuk-tabs-item id="past-week" label="Past week">
+    </tabs-item>
+    <tabs-item id="past-week" label="Past week">
         <h2 class="govuk-heading-l">Past week</h2>
-    </govuk-tabs-item>
-    <govuk-tabs-item id="past-month" label="Past month">
+    </tabs-item>
+    <tabs-item id="past-month" label="Past month">
         <h2 class="govuk-heading-l">Past month</h2>
-    </govuk-tabs-item>
-    <govuk-tabs-item id="past-year" label="Past year">
+    </tabs-item>
+    <tabs-item id="past-year" label="Past year">
         <h2 class="govuk-heading-l">Past year</h2>
-    </govuk-tabs-item>
+    </tabs-item>
 </govuk-tabs>
 ```
 
@@ -38,7 +38,7 @@
 | `title` | `string` | The title for the tabs table of contents. The default is 'Contents'. |
 
 
-#### `<govuk-tabs-item>`
+#### `<tabs-item>` / `<govuk-tabs-item>`
 
 The content is the HTML of the panel.
 

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Tabs/TabsExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Tabs/TabsExample.cshtml
@@ -2,17 +2,17 @@
 
 <example>
     <govuk-tabs>
-        <govuk-tabs-item id="past-day" label="Past day">
+        <tabs-item id="past-day" label="Past day">
             <h2 class="govuk-heading-l">Past day</h2>
-        </govuk-tabs-item>
-        <govuk-tabs-item id="past-week" label="Past week">
+        </tabs-item>
+        <tabs-item id="past-week" label="Past week">
             <h2 class="govuk-heading-l">Past week</h2>
-        </govuk-tabs-item>
-        <govuk-tabs-item id="past-month" label="Past month">
+        </tabs-item>
+        <tabs-item id="past-month" label="Past month">
             <h2 class="govuk-heading-l">Past month</h2>
-        </govuk-tabs-item>
-        <govuk-tabs-item id="past-year" label="Past year">
+        </tabs-item>
+        <tabs-item id="past-year" label="Past year">
             <h2 class="govuk-heading-l">Past year</h2>
-        </govuk-tabs-item>
+        </tabs-item>
     </govuk-tabs>
 </example>

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/ShortTagNames.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/ShortTagNames.cs
@@ -49,6 +49,7 @@ internal static class ShortTagNames
     public const string Start = "start";
     public const string Suffix = "suffix";
     public const string Summary = "summary";
+    public const string TabsItem = "tabs-item";
     public const string Tag = "tag";
     public const string Title = "title";
     public const string Value = "value";

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/TabsItemTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/TabsItemTagHelper.cs
@@ -8,10 +8,12 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents an item in a GDS tabs component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = TabsTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = TabsTagHelper.TagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML of the panel.")]
 public class TabsItemTagHelper : TagHelper
 {
     internal const string TagName = "govuk-tabs-item";
+    internal const string ShortTagName = ShortTagNames.TabsItem;
     internal const string IdAttributeName = "id";
 
     private const string LabelAttributeName = "label";

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/TabsTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/TabsTagHelper.cs
@@ -7,7 +7,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Generates a GDS tabs component.
 /// </summary>
 [HtmlTargetElement(TagName)]
-[RestrictChildren(TabsItemTagHelper.TagName)]
+[RestrictChildren(TabsItemTagHelper.TagName, TabsItemTagHelper.ShortTagName)]
 [OutputElementHint(DefaultComponentGenerator.ComponentElementTypes.Tabs)]
 public class TabsTagHelper : TagHelper
 {

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
@@ -34,6 +34,7 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
     [InlineData("NotificationBanner", "short", "long", ".govuk-notification-banner__title")]
     [InlineData("Pagination", "short", "long", ".govuk-pagination__link")]
     [InlineData("PhaseBanner", "short", "long", ".govuk-phase-banner__content__tag")]
+    [InlineData("Tabs", "short", "long", ".govuk-tabs__tab")]
     public async Task ShortTagNames_GenerateTheSameMarkupAsTheGovUkPrefixedNames(
         string component,
         string shortTestId,
@@ -219,6 +220,9 @@ public class ShortTagNamesTestsController : Controller
 
     [HttpGet("PhaseBanner")]
     public IActionResult GetPhaseBanner() => View("PhaseBanner", new ShortTagNamesTestsModel());
+
+    [HttpGet("Tabs")]
+    public IActionResult GetTabs() => View("Tabs", new ShortTagNamesTestsModel());
 
     [HttpGet("ServiceNavigationMixed")]
     public IActionResult GetServiceNavigationMixed() => View("ServiceNavigationMixed", new ShortTagNamesTestsModel());

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/Tabs.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/Tabs.cshtml
@@ -1,0 +1,26 @@
+@model GovUk.Frontend.AspNetCore.IntegrationTests.ShortTagNamesTestsModel
+
+@* The same component written with the short tag names and with the govuk- prefixed ones;
+   the two must generate identical markup *@
+
+<div data-testid="short">
+    <govuk-tabs id="tabs" title="Views">
+        <tabs-item id="past-day" label="Past day" link-data-track="past-day">
+            <h2 class="govuk-heading-l">Past day</h2>
+        </tabs-item>
+        <tabs-item id="past-week" label="Past week">
+            <h2 class="govuk-heading-l">Past week</h2>
+        </tabs-item>
+    </govuk-tabs>
+</div>
+
+<div data-testid="long">
+    <govuk-tabs id="tabs" title="Views">
+        <govuk-tabs-item id="past-day" label="Past day" link-data-track="past-day">
+            <h2 class="govuk-heading-l">Past day</h2>
+        </govuk-tabs-item>
+        <govuk-tabs-item id="past-week" label="Past week">
+            <h2 class="govuk-heading-l">Past week</h2>
+        </govuk-tabs-item>
+    </govuk-tabs>
+</div>


### PR DESCRIPTION
`<tabs-item>` goes directly inside `<govuk-tabs>`. The item is named after its component, as the checkboxes, radios and breadcrumbs items are:

```razor
<govuk-tabs id-prefix="views">
    <tabs-item label="Past day">
        <h2 class="govuk-heading-l">Past day</h2>
    </tabs-item>
    <tabs-item label="Past week">
        <h2 class="govuk-heading-l">Past week</h2>
    </tabs-item>
</govuk-tabs>
```

There is one repeatable child and nothing else, so the two spellings need no guard: unlike the footer's or the pagination's children, there is no sibling slot for a spelling to disagree with, and both spellings of the one element generate the same markup. The breadcrumbs item is registered the same way.

Nothing names the element in a message — the item's two errors name its `label` and `id` attributes — so there is no `AllTagNames` to add. The item takes no `href` of its own either, so it stays off `AnchorTagHelper`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)