### PR TITLE
Add short tag name support to the details tag helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Both elements can now generate their `formaction` attribute from the `asp-` attr
 
 As per the guidance, the first page, the pages either side of the current page and the last page are shown, with an ellipsis wherever pages have been skipped, plus Previous and Next links where there is a page to go to. Nothing is rendered at all when there is only one page. Child elements cannot be combined with these attributes.
 
-The checkboxes, radios, date input, text input, textarea, file upload, password input, select, character count, accordion, breadcrumbs, service navigation, fieldset, generic header, footer, notification banner, pagination, phase banner, tabs and error summary tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
+The checkboxes, radios, date input, text input, textarea, file upload, password input, select, character count, accordion, breadcrumbs, service navigation, fieldset, generic header, footer, notification banner, pagination, phase banner, tabs, error summary and details tag helpers now support short tag name syntax, as the panel and summary list tag helpers already do:
 
 ```razor
 <govuk-checkboxes for="ContactPreferences">
@@ -197,6 +197,17 @@ The error summary takes `<title>`, `<description>` and `<error-summary-item>` in
 ```
 
 Its children also all share the same parent element, so, as with the pagination and the footer, the two spellings cannot be mixed.
+
+The details takes `<summary>` and `<text>` inside `<govuk-details>`:
+
+```razor
+<govuk-details>
+    <summary>Help with nationality</summary>
+    <text>We need to know your nationality so we can work out which elections you're entitled to vote in.</text>
+</govuk-details>
+```
+
+Both children share the same parent element, so, as with the error summary and the pagination, the two spellings cannot be mixed.
 
 The `govuk-` prefixed names continue to work everywhere they did before, and remain the only spelling accepted inside a `<govuk-checkboxes-fieldset>`, `<govuk-radios-fieldset>` or `<govuk-date-input-fieldset>` — the short names pair with the fieldset that the root element generates for a `<legend>` of its own.
 

--- a/docs/components/details.md
+++ b/docs/components/details.md
@@ -11,13 +11,13 @@
 
 ```razor
 <govuk-details>
-    <govuk-details-summary>
+    <summary>
         Help with nationality
-    </govuk-details-summary>
-    <govuk-details-text>
+    </summary>
+    <text>
         We need to know your nationality so we can work out which elections you’re entitled to vote in.
         If you cannot provide your nationality, you’ll have to send copies of identity documents through the post.
-    </govuk-details-text>
+    </text>
 </govuk-details>
 ```
 
@@ -27,13 +27,13 @@
 
 ```razor
 <govuk-details open="true">
-    <govuk-details-summary>
+    <summary>
         Help with nationality
-    </govuk-details-summary>
-    <govuk-details-text>
+    </summary>
+    <text>
         We need to know your nationality so we can work out which elections you’re entitled to vote in.
         If you cannot provide your nationality, you’ll have to send copies of identity documents through the post.
-    </govuk-details-text>
+    </text>
 </govuk-details>
 ```
 
@@ -47,14 +47,14 @@
 | `open` | `bool?` | Whether the details element should be expanded. The default is `false`. |
 
 
-#### `<govuk-details-summary>`
+#### `<summary>` / `<govuk-details-summary>`
 
 The content is the HTML to use within the details summary.
 
 Must be inside a `<govuk-details>` element.
 
 
-#### `<govuk-details-text>`
+#### `<text>` / `<govuk-details-text>`
 
 The content is the HTML to use within the disclosed part of the details element.
 

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Details/DetailsExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Details/DetailsExample.cshtml
@@ -2,12 +2,12 @@
 
 <example>
     <govuk-details>
-        <govuk-details-summary>
+        <summary>
             Help with nationality
-        </govuk-details-summary>
-        <govuk-details-text>
+        </summary>
+        <text>
             We need to know your nationality so we can work out which elections you’re entitled to vote in.
             If you cannot provide your nationality, you’ll have to send copies of identity documents through the post.
-        </govuk-details-text>
+        </text>
     </govuk-details>
 </example>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Details/DetailsExpandedExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Details/DetailsExpandedExample.cshtml
@@ -2,12 +2,12 @@
 
 <example>
     <govuk-details open="true">
-        <govuk-details-summary>
+        <summary>
             Help with nationality
-        </govuk-details-summary>
-        <govuk-details-text>
+        </summary>
+        <text>
             We need to know your nationality so we can work out which elections you’re entitled to vote in.
             If you cannot provide your nationality, you’ll have to send copies of identity documents through the post.
-        </govuk-details-text>
+        </text>
     </govuk-details>
 </example>

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DetailsContext.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DetailsContext.cs
@@ -5,51 +5,93 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 
 internal class DetailsContext
 {
+    private string? _summaryTagName;
+    private string? _textTagName;
+
     public (AttributeCollection Attributes, IHtmlContent Content)? Summary { get; private set; }
 
     public (AttributeCollection Attributes, IHtmlContent Content)? Text { get; private set; }
 
-    public void SetSummary(AttributeCollection attributes, IHtmlContent content)
+    public void SetSummary(AttributeCollection attributes, IHtmlContent content, string tagName)
     {
         ArgumentNullException.ThrowIfNull(attributes);
         ArgumentNullException.ThrowIfNull(content);
+        ArgumentNullException.ThrowIfNull(tagName);
+
+        CheckChildTagNameSpelling(tagName);
 
         if (Summary is not null)
         {
-            throw ExceptionHelper.OnlyOneElementIsPermittedIn(DetailsSummaryTagHelper.TagName, DetailsTagHelper.TagName);
+            throw ExceptionHelper.OnlyOneElementIsPermittedIn(
+                DetailsSummaryTagHelper.AllTagNames,
+                DetailsTagHelper.TagName);
         }
 
-        if (Text is not null)
+        if (_textTagName is string textTagName)
         {
-            throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(DetailsSummaryTagHelper.TagName, DetailsTextTagHelper.TagName);
+            throw ExceptionHelper.ChildElementMustBeSpecifiedBefore(tagName, textTagName);
         }
 
         Summary = (attributes, content);
+        _summaryTagName = tagName;
     }
 
-    public void SetText(AttributeCollection attributes, IHtmlContent content)
+    public void SetText(AttributeCollection attributes, IHtmlContent content, string tagName)
     {
         ArgumentNullException.ThrowIfNull(attributes);
         ArgumentNullException.ThrowIfNull(content);
+        ArgumentNullException.ThrowIfNull(tagName);
+
+        CheckChildTagNameSpelling(tagName);
 
         if (Text is not null)
         {
-            throw ExceptionHelper.OnlyOneElementIsPermittedIn(DetailsTextTagHelper.TagName, DetailsTagHelper.TagName);
+            throw ExceptionHelper.OnlyOneElementIsPermittedIn(
+                DetailsTextTagHelper.AllTagNames,
+                DetailsTagHelper.TagName);
         }
 
         Text = (attributes, content);
+        _textTagName = tagName;
     }
 
     public void ThrowIfNotComplete()
     {
         if (Summary is null)
         {
-            throw ExceptionHelper.AChildElementMustBeProvided(DetailsSummaryTagHelper.TagName);
+            throw ExceptionHelper.AChildElementMustBeProvided(DetailsSummaryTagHelper.AllTagNames);
         }
 
         if (Text is null)
         {
-            throw ExceptionHelper.AChildElementMustBeProvided(DetailsTextTagHelper.TagName);
+            throw ExceptionHelper.AChildElementMustBeProvided(DetailsTextTagHelper.AllTagNames);
         }
+    }
+
+    /// <summary>
+    /// Checks that <paramref name="tagName"/> is spelled the same way as the children specified so far.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Both children have &lt;govuk-details&gt; for their parent, so their spelling cannot be paired
+    /// up through <c>ParentTag</c>.
+    /// </para>
+    /// <para>
+    /// Both go through this context, so the check lives here rather than in the tag helpers, which
+    /// keeps it ahead of the ordering check — reordering does not fix a spelling mismatch.
+    /// </para>
+    /// </remarks>
+    private void CheckChildTagNameSpelling(string tagName)
+    {
+        var siblingTagName = _summaryTagName ?? _textTagName;
+
+        if (siblingTagName is not null && UsesShortTagName(tagName) != UsesShortTagName(siblingTagName))
+        {
+            throw ExceptionHelper.ShortAndGovUkPrefixedTagNamesCannotBeMixed(tagName, siblingTagName);
+        }
+
+        static bool UsesShortTagName(string tagName) => tagName is
+            DetailsSummaryTagHelper.ShortTagName or
+            DetailsTextTagHelper.ShortTagName;
     }
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DetailsSummaryTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DetailsSummaryTagHelper.cs
@@ -7,10 +7,14 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the summary in a GDS details component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = DetailsTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = DetailsTagHelper.TagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the details summary.")]
 public class DetailsSummaryTagHelper : TagHelper
 {
     internal const string TagName = "govuk-details-summary";
+    internal const string ShortTagName = ShortTagNames.Summary;
+
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <inheritdoc/>
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
@@ -27,7 +31,7 @@ public class DetailsSummaryTagHelper : TagHelper
             content = output.Content;
         }
 
-        detailsContext.SetSummary(new AttributeCollection(output.Attributes), content.Snapshot());
+        detailsContext.SetSummary(new AttributeCollection(output.Attributes), content.Snapshot(), context.TagName);
 
         output.SuppressOutput();
     }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DetailsTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DetailsTagHelper.cs
@@ -7,7 +7,11 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Generates a GDS details component.
 /// </summary>
 [HtmlTargetElement(TagName)]
-[RestrictChildren(DetailsSummaryTagHelper.TagName, DetailsTextTagHelper.TagName)]
+[RestrictChildren(
+    DetailsSummaryTagHelper.TagName,
+    DetailsSummaryTagHelper.ShortTagName,
+    DetailsTextTagHelper.TagName,
+    DetailsTextTagHelper.ShortTagName)]
 [OutputElementHint(DefaultComponentGenerator.ComponentElementTypes.Details)]
 public class DetailsTagHelper : TagHelper
 {

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/DetailsTextTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/DetailsTextTagHelper.cs
@@ -7,10 +7,14 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Represents the text in a GDS details component.
 /// </summary>
 [HtmlTargetElement(TagName, ParentTag = DetailsTagHelper.TagName)]
+[HtmlTargetElement(ShortTagName, ParentTag = DetailsTagHelper.TagName)]
 [TagHelperDocumentation(ContentDescription = "The content is the HTML to use within the disclosed part of the details element.")]
 public class DetailsTextTagHelper : TagHelper
 {
     internal const string TagName = "govuk-details-text";
+    internal const string ShortTagName = ShortTagNames.Text;
+
+    internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 
     /// <inheritdoc/>
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
@@ -27,7 +31,7 @@ public class DetailsTextTagHelper : TagHelper
             content = output.Content;
         }
 
-        detailsContext.SetText(new AttributeCollection(output.Attributes), content.Snapshot());
+        detailsContext.SetText(new AttributeCollection(output.Attributes), content.Snapshot(), context.TagName);
 
         output.SuppressOutput();
     }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/ShortTagNames.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/ShortTagNames.cs
@@ -51,6 +51,7 @@ internal static class ShortTagNames
     public const string Start = "start";
     public const string Suffix = "suffix";
     public const string Summary = "summary";
+    public const string Text = "text";
     public const string TabsItem = "tabs-item";
     public const string Tag = "tag";
     public const string Title = "title";

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
@@ -36,6 +36,7 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
     [InlineData("PhaseBanner", "short", "long", ".govuk-phase-banner__content__tag")]
     [InlineData("Tabs", "short", "long", ".govuk-tabs__tab")]
     [InlineData("ErrorSummary", "short", "long", ".govuk-error-summary__list a")]
+    [InlineData("Details", "short", "long", ".govuk-details__summary-text")]
     public async Task ShortTagNames_GenerateTheSameMarkupAsTheGovUkPrefixedNames(
         string component,
         string shortTestId,
@@ -71,6 +72,22 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
 
         Assert.Contains(
             "<nav> cannot be used alongside <govuk-service-navigation-start>; " +
+                "short tag names and govuk- prefixed tag names cannot be mixed.",
+            await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task Details_MixingShortAndGovUkPrefixedTagNames_Throws()
+    {
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, "/ShortTagNamesTests/DetailsMixed");
+        var response = await fixture.HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+
+        Assert.Contains(
+            "<text> cannot be used alongside <govuk-details-summary>; " +
                 "short tag names and govuk- prefixed tag names cannot be mixed.",
             await response.Content.ReadAsStringAsync());
     }
@@ -246,6 +263,12 @@ public class ShortTagNamesTestsController : Controller
 
     [HttpGet("ErrorSummaryMixed")]
     public IActionResult GetErrorSummaryMixed() => View("ErrorSummaryMixed", new ShortTagNamesTestsModel());
+
+    [HttpGet("Details")]
+    public IActionResult GetDetails() => View("Details", new ShortTagNamesTestsModel());
+
+    [HttpGet("DetailsMixed")]
+    public IActionResult GetDetailsMixed() => View("DetailsMixed", new ShortTagNamesTestsModel());
 
     [HttpGet("ServiceNavigationMixed")]
     public IActionResult GetServiceNavigationMixed() => View("ServiceNavigationMixed", new ShortTagNamesTestsModel());

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/Details.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/Details.cshtml
@@ -1,0 +1,22 @@
+@model GovUk.Frontend.AspNetCore.IntegrationTests.ShortTagNamesTestsModel
+
+@* The same component written with the short tag names and with the govuk- prefixed ones;
+   the two must generate identical markup *@
+
+<div data-testid="short">
+    <govuk-details open="true" id="details">
+        <summary class="app-details__summary">Help with nationality</summary>
+        <text class="app-details__text">
+            We need to know your nationality so we can work out which elections you're entitled to vote in.
+        </text>
+    </govuk-details>
+</div>
+
+<div data-testid="long">
+    <govuk-details open="true" id="details">
+        <govuk-details-summary class="app-details__summary">Help with nationality</govuk-details-summary>
+        <govuk-details-text class="app-details__text">
+            We need to know your nationality so we can work out which elections you're entitled to vote in.
+        </govuk-details-text>
+    </govuk-details>
+</div>

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/DetailsMixed.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/DetailsMixed.cshtml
@@ -1,0 +1,9 @@
+@model GovUk.Frontend.AspNetCore.IntegrationTests.ShortTagNamesTestsModel
+
+@* Both of the details' children share the same parent element, so their spelling cannot be
+   paired up through ParentTag; mixing the two must throw *@
+
+<govuk-details>
+    <govuk-details-summary>Help with nationality</govuk-details-summary>
+    <text>We need to know your nationality.</text>
+</govuk-details>

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/DetailsSummaryTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/DetailsSummaryTagHelperTests.cs
@@ -36,7 +36,7 @@ public class DetailsSummaryTagHelperTests : TagHelperTestBase<DetailsSummaryTagH
     {
         // Arrange
         var detailsContext = new DetailsContext();
-        detailsContext.SetSummary([], new HtmlString("The summary"));
+        detailsContext.SetSummary([], new HtmlString("The summary"), TagName);
 
         var context = CreateTagHelperContext(contexts: detailsContext);
 
@@ -55,7 +55,9 @@ public class DetailsSummaryTagHelperTests : TagHelperTestBase<DetailsSummaryTagH
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal("Only one <govuk-details-summary> element is permitted within each <govuk-details>.", ex.Message);
+        Assert.Equal(
+            $"Only one <{PrimaryTagName}> or <{ShortTagName}> element is permitted within each <{ParentTagName}>.",
+            ex.Message);
     }
 
     [Fact]
@@ -63,7 +65,10 @@ public class DetailsSummaryTagHelperTests : TagHelperTestBase<DetailsSummaryTagH
     {
         // Arrange
         var detailsContext = new DetailsContext();
-        detailsContext.SetText([], new HtmlString("The text"));
+        detailsContext.SetText(
+            [],
+            new HtmlString("The text"),
+            GetSiblingTagName(DetailsTextTagHelper.TagName, DetailsTextTagHelper.ShortTagName));
 
         var context = CreateTagHelperContext(contexts: detailsContext);
 
@@ -82,6 +87,9 @@ public class DetailsSummaryTagHelperTests : TagHelperTestBase<DetailsSummaryTagH
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal("<govuk-details-summary> must be specified before <govuk-details-text>.", ex.Message);
+        Assert.Equal(
+            $"<{TagName}> must be specified before " +
+                $"<{GetSiblingTagName(DetailsTextTagHelper.TagName, DetailsTextTagHelper.ShortTagName)}>.",
+            ex.Message);
     }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/DetailsTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/DetailsTagHelperTests.cs
@@ -19,10 +19,10 @@ public class DetailsTagHelperTests : TagHelperTestBase<DetailsTagHelper>
                 var detailsContext = (DetailsContext)context.Items[typeof(DetailsContext)];
 
                 var summary = new HtmlString("The summary");
-                detailsContext.SetSummary(new AttributeCollection(), summary);
+                detailsContext.SetSummary(new AttributeCollection(), summary, DetailsSummaryTagHelper.TagName);
 
                 var text = new HtmlString("The text");
-                detailsContext.SetText(new AttributeCollection(), text);
+                detailsContext.SetText(new AttributeCollection(), text, DetailsTextTagHelper.TagName);
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
@@ -58,10 +58,10 @@ public class DetailsTagHelperTests : TagHelperTestBase<DetailsTagHelper>
                 var detailsContext = (DetailsContext)context.Items[typeof(DetailsContext)];
 
                 var summary = new HtmlString("The summary");
-                detailsContext.SetSummary(new AttributeCollection(), summary);
+                detailsContext.SetSummary(new AttributeCollection(), summary, DetailsSummaryTagHelper.TagName);
 
                 var text = new HtmlString("The text");
-                detailsContext.SetText(new AttributeCollection(), text);
+                detailsContext.SetText(new AttributeCollection(), text, DetailsTextTagHelper.TagName);
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
@@ -108,7 +108,9 @@ public class DetailsTagHelperTests : TagHelperTestBase<DetailsTagHelper>
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal("A <govuk-details-summary> element must be provided.", ex.Message);
+        Assert.Equal(
+            $"A <{DetailsSummaryTagHelper.TagName}> or <{DetailsSummaryTagHelper.ShortTagName}> element must be provided.",
+            ex.Message);
     }
 
     [Fact]
@@ -123,7 +125,7 @@ public class DetailsTagHelperTests : TagHelperTestBase<DetailsTagHelper>
                 var detailsContext = (DetailsContext)context.Items[typeof(DetailsContext)];
 
                 var summary = new HtmlString("The summary");
-                detailsContext.SetSummary(new AttributeCollection(), summary);
+                detailsContext.SetSummary(new AttributeCollection(), summary, DetailsSummaryTagHelper.TagName);
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
@@ -140,7 +142,9 @@ public class DetailsTagHelperTests : TagHelperTestBase<DetailsTagHelper>
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal("A <govuk-details-text> element must be provided.", ex.Message);
+        Assert.Equal(
+            $"A <{DetailsTextTagHelper.TagName}> or <{DetailsTextTagHelper.ShortTagName}> element must be provided.",
+            ex.Message);
     }
 
     [Fact]
@@ -157,10 +161,10 @@ public class DetailsTagHelperTests : TagHelperTestBase<DetailsTagHelper>
                 var summaryAttributes = new AttributeCollection();
                 summaryAttributes.Add("data-test", "summary-value");
                 var summary = new HtmlString("The summary");
-                detailsContext.SetSummary(summaryAttributes, summary);
+                detailsContext.SetSummary(summaryAttributes, summary, DetailsSummaryTagHelper.TagName);
 
                 var text = new HtmlString("The text");
-                detailsContext.SetText(new AttributeCollection(), text);
+                detailsContext.SetText(new AttributeCollection(), text, DetailsTextTagHelper.TagName);
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
@@ -191,12 +195,12 @@ public class DetailsTagHelperTests : TagHelperTestBase<DetailsTagHelper>
                 var detailsContext = (DetailsContext)context.Items[typeof(DetailsContext)];
 
                 var summary = new HtmlString("The summary");
-                detailsContext.SetSummary(new AttributeCollection(), summary);
+                detailsContext.SetSummary(new AttributeCollection(), summary, DetailsSummaryTagHelper.TagName);
 
                 var textAttributes = new AttributeCollection();
                 textAttributes.Add("data-test", "text-value");
                 var text = new HtmlString("The text");
-                detailsContext.SetText(textAttributes, text);
+                detailsContext.SetText(textAttributes, text, DetailsTextTagHelper.TagName);
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 return Task.FromResult<TagHelperContent>(tagHelperContent);

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/DetailsTextTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/DetailsTextTagHelperTests.cs
@@ -11,7 +11,10 @@ public class DetailsTextTagHelperTests : TagHelperTestBase<DetailsTextTagHelper>
     {
         // Arrange
         var detailsContext = new DetailsContext();
-        detailsContext.SetSummary([], new HtmlString("The summary"));
+        detailsContext.SetSummary(
+            [],
+            new HtmlString("The summary"),
+            GetSiblingTagName(DetailsSummaryTagHelper.TagName, DetailsSummaryTagHelper.ShortTagName));
 
         var context = CreateTagHelperContext(contexts: detailsContext);
 
@@ -37,8 +40,11 @@ public class DetailsTextTagHelperTests : TagHelperTestBase<DetailsTextTagHelper>
     {
         // Arrange
         var detailsContext = new DetailsContext();
-        detailsContext.SetSummary([], new HtmlString("The summary"));
-        detailsContext.SetText([], new HtmlString("The text"));
+        detailsContext.SetSummary(
+            [],
+            new HtmlString("The summary"),
+            GetSiblingTagName(DetailsSummaryTagHelper.TagName, DetailsSummaryTagHelper.ShortTagName));
+        detailsContext.SetText([], new HtmlString("The text"), TagName);
 
         var context = CreateTagHelperContext(contexts: detailsContext);
 
@@ -57,6 +63,8 @@ public class DetailsTextTagHelperTests : TagHelperTestBase<DetailsTextTagHelper>
 
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
-        Assert.Equal("Only one <govuk-details-text> element is permitted within each <govuk-details>.", ex.Message);
+        Assert.Equal(
+            $"Only one <{PrimaryTagName}> or <{ShortTagName}> element is permitted within each <{ParentTagName}>.",
+            ex.Message);
     }
 }


### PR DESCRIPTION
`<summary>` and `<text>` go inside `<govuk-details>`. `<summary>` is the name the accordion item already uses; `<text>` is new:

```razor
<govuk-details>
    <summary>Help with nationality</summary>
    <text>We need to know your nationality so we can work out which elections you're entitled to vote in.</text>
</govuk-details>
```

Both children have `<govuk-details>` for their parent, so, as with the error summary and the pagination, their spelling cannot be paired up through `ParentTag` and mixing throws. Both go through `DetailsContext`, so the check lives there rather than in the two tag helpers, which keeps it ahead of the ordering check — reordering does not fix a spelling mismatch.

The context now records the tag name each child was written with, so the message about the summary coming after the text uses the spelling from the view. Its two "only one element is permitted" and two "must be provided" messages name both spellings, as every other component's do.

The summary and text tests seeded each other with the `govuk-` prefixed spelling, which the spelling check now rejects when the element under test is the short one; they pair the sibling with the name under test, as the accordion and service navigation tests do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)