### PR TITLE
Refresh the README's MSBuild documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,10 @@ Both elements can now generate their `formaction` attribute from the `asp-` attr
 <govuk-cookie-banner-message-action-button text="Accept analytics cookies" type="submit" asp-controller="Cookies" asp-action="Accept" />
 ```
 
-`EnableGovUkFrontendSupport` is now on by default for projects using the `Microsoft.NET.Web.Sdk` SDK.
+`EnableGovUkFrontendSupport` is now on by default for projects using the `Microsoft.NET.Sdk.Web` SDK.
+
+The library no longer embeds the `govuk-frontend` files or serves them from middleware; they're copied into your project by the package's build targets instead.
+`FrontendPackageHostingOptions` has been removed along with it, and applications need to serve their own `wwwroot` — through `MapStaticAssets()` or `UseStaticFiles()` — for the copied files to be reachable.
 
 `<govuk-pagination>` can generate its own items. Specify `current-page`, `total-pages` and `generate-page-href` instead of writing a child element per page:
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,12 @@ Or via the .NET Core command line interface:
 
     dotnet add package GovUk.Frontend.AspNetCore
 
-### 2. Update your project file to copy `govuk-frontend` assets into your application.
+### 2. Check the `govuk-frontend` assets are copied into your application
+
+Projects using the `Microsoft.NET.Sdk.Web` SDK get the assets copied into their `wwwroot` folder on build without any further configuration.
+Any other project type has to opt in by setting `EnableGovUkFrontendSupport` in its project file:
 ```diff
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 +    <EnableGovUkFrontendSupport>true</EnableGovUkFrontendSupport>
   </PropertyGroup>
@@ -241,12 +244,14 @@ See the `Samples.MvcStarter` project for an example of this working.
 
 ## GOV.UK Frontend assets
 
-Assets will be copied into your `wwwroot` folder when `EnableGovUkFrontendSupport` is `true` in your project file.
-The table below shows the additional MSBuild properties you can set to configure which assets are copied into your project and where they are copied to.
+Assets are copied into your project when it builds, provided `EnableGovUkFrontendSupport` is `true`.
+That is the default for projects using the `Microsoft.NET.Sdk.Web` SDK; every other project type has to set it explicitly.
+The table below shows the MSBuild properties you can set to configure which assets are copied into your project and where they are copied to.
 Each category of files has a `Restore*` boolean to enable or disable copying it and a `*Directory` to control where the files are copied to.
 
 | MSBuild property                       | Description                                                                | Default                         |
 |----------------------------------------|----------------------------------------------------------------------------|---------------------------------|
+| `EnableGovUkFrontendSupport`           | Whether to copy any `govuk-frontend` files into your project.              | `true` for web projects         |
 | `RestoreGovUkFrontendAssets`           | Whether to copy the static assets (fonts, images, icons etc.).             | `true`                          |
 | `GovUkFrontendAssetsDirectory`         | The directory to copy the static assets into.                              | `wwwroot/assets`                |
 | `RestoreGovUkFrontendJavascript`       | Whether to copy the `govuk-frontend.min.js` file.                          | `true`                          |
@@ -258,6 +263,11 @@ Each category of files has a `Restore*` boolean to enable or disable copying it 
 | `RestoreGovUkFrontendSupportPackage`   | Whether to copy support files.                                             | `false`                         |
 | `GovUkFrontendSupportPackageDirectory` | The directory to copy support files into.                                  | `lib/govuk-frontend-aspnetcore` |
 
+`EnableGovUkFrontendSupport` defaults to `true` for projects using the `Microsoft.NET.Sdk.Web` SDK and to `false` for everything else.
+The `Restore*` properties only take effect when it is `true`; setting it to `false` stops the build copying anything at all.
+
+Setting `GovUkFrontendSupportPackageDirectory` turns `RestoreGovUkFrontendSupportPackage` on, so there's no need to set both.
+
 If you want the entire `govuk-frontend` NPM package to be available e.g. so you can reference SASS files from your own stylesheet,
 set `RestoreGovUkFrontendNpmPackage` to `true` (and optionally override `GovUkFrontendNpmPackageDirectory`).
 See [the SASS sample](samples/Samples.Sass) for a full example of how to set up your project with SASS integration.
@@ -268,18 +278,15 @@ See [the SASS sample](samples/Samples.Sass) for a full example of how to set up 
 > Typically it is sufficient to use `assets/fonts/` and `assets/images/` (i.e. the default location but without the leading `/`).
 
 > [!NOTE]
-> If `EnableGovUkFrontendSupport` is not set to `true` in your project file,
-static assets (fonts, images, icons etc.) and the compiled JavaScript and CSS from the GOV.UK Frontend package will be hosted automatically
-i.e. without the assets being copied into your `wwwroot`.
-This behaviour will be removed in a future version.
+> The `CopyGovUkFrontendAssetsToWebRoot` property is deprecated; use `RestoreGovUkFrontendAssets` instead.
+> Setting it still works, but the build emits a warning.
 
-If you do not want any assets to be automatically hosted, set `FrontendPackageHostingOptions` to `None`:
-```cs
-services.AddGovUkFrontend(options =>
-{
-    options.FrontendPackageHostingOptions = FrontendPackageHostingOptions.None;
-});
-```
+The library serves nothing itself, so the copied files need to be served by your application — through `MapStaticAssets()` or `UseStaticFiles()`, as in the installation guide above.
+When the library generates URLs for files the build didn't copy, it assumes the default locations — `/assets`, `/govuk-frontend.min.css` and `/govuk-frontend.min.js` —
+so anything you're managing yourself should be served from there.
+
+`app.UseGovUkFrontend()` adds middleware that applies long-lived cache headers to the files the build copied, which are requested with the `govuk-frontend` version in the query string.
+Files the build didn't copy are left alone, since they can change without the `govuk-frontend` version changing.
 
 
 ## Components

--- a/samples/Samples.DateInput/Samples.DateInput.csproj
+++ b/samples/Samples.DateInput/Samples.DateInput.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <EnableGovUkFrontendSupport>true</EnableGovUkFrontendSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Samples.MvcStarter/Samples.MvcStarter.csproj
+++ b/samples/Samples.MvcStarter/Samples.MvcStarter.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <EnableGovUkFrontendSupport>true</EnableGovUkFrontendSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Samples.Sass/README.md
+++ b/samples/Samples.Sass/README.md
@@ -9,7 +9,6 @@ To replicate this setup in your own project, follow these steps:
 2. Restore `govuk-frontend` assets on build by adding the following to your `.csproj` file:
    ```xml
    <PropertyGroup>
-     <EnableGovUkFrontendSupport>true</EnableGovUkFrontendSupport>
      <RestoreGovUkFrontendStylesheet>false</RestoreGovUkFrontendStylesheet>
      <RestoreGovUkFrontendNpmPackage>true</RestoreGovUkFrontendNpmPackage>
      <RestoreGovUkFrontendSupportPackage>true</RestoreGovUkFrontendSupportPackage>

--- a/samples/Samples.Sass/Samples.Sass.csproj
+++ b/samples/Samples.Sass/Samples.Sass.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <EnableGovUkFrontendSupport>true</EnableGovUkFrontendSupport>
     <RestoreGovUkFrontendStylesheet>false</RestoreGovUkFrontendStylesheet>
     <RestoreGovUkFrontendNpmPackage>true</RestoreGovUkFrontendNpmPackage>
     <RestoreGovUkFrontendSupportPackage>true</RestoreGovUkFrontendSupportPackage>


### PR DESCRIPTION
The README still documented the MSBuild setup as it was at v4.4.0. Two things have changed since:

- `EnableGovUkFrontendSupport` defaults to `true` for Web SDK projects (#510), so the installation guide no longer presents setting it as a step every project has to take. It is now listed in the property table alongside the `Restore*` properties it gates.
- Embedded hosting of the frontend files was removed (#511). The assets section still said they would be hosted automatically when `EnableGovUkFrontendSupport` was off, and offered a `FrontendPackageHostingOptions.None` snippet that no longer compiles. That is replaced with what actually happens now: the application serves its own `wwwroot`, files the build did not copy are assumed to be at the default locations, and `UseGovUkFrontend()` adds the cache headers for the copied ones.

Also documents two behaviours the targets have always had but the README never mentioned: setting `GovUkFrontendSupportPackageDirectory` implies `RestoreGovUkFrontendSupportPackage`, and `CopyGovUkFrontendAssetsToWebRoot` is deprecated in favour of `RestoreGovUkFrontendAssets`.

The changelog gains an entry for the hosting removal, which was a breaking change with nothing written about it, and a fix for `Microsoft.NET.Web.Sdk` -> `Microsoft.NET.Sdk.Web`.

The three samples and the Sass sample's README set `EnableGovUkFrontendSupport` too, and all three use the Web SDK, so that has been dropped. `just build-samples` still restores the assets into each of them, and the Sass sample still gets its `lib/govuk-frontend` and `lib/govuk-frontend-aspnetcore` copies with no `govuk-frontend.min.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)