### PR TITLE
Make the title short tag names component-specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,12 +117,12 @@ The generic header takes `<logo>` inside `<govuk-generic-header>`:
 </govuk-generic-header>
 ```
 
-The footer takes `<nav>`, `<meta>`, `<content-licence>` and `<copyright>` inside `<govuk-footer>`, with `<title>` and `<nav-items>` inside the `<nav>`, `<meta-items>` and `<content>` inside the `<meta>`, and a `<nav-item>` or `<meta-item>` inside each of the item lists:
+The footer takes `<nav>`, `<meta>`, `<content-licence>` and `<copyright>` inside `<govuk-footer>`, with `<nav-title>` and `<nav-items>` inside the `<nav>`, `<meta-items>` and `<content>` inside the `<meta>`, and a `<nav-item>` or `<meta-item>` inside each of the item lists:
 
 ```razor
 <govuk-footer>
     <nav width="two-thirds" columns="2">
-        <title>Services and information</title>
+        <nav-title>Services and information</nav-title>
         <nav-items>
             <nav-item href="#">Benefits</nav-item>
             <nav-item asp-controller="Home" asp-action="Index">Births, deaths, marriages and care</nav-item>
@@ -140,11 +140,11 @@ The footer takes `<nav>`, `<meta>`, `<content-licence>` and `<copyright>` inside
 
 As with the service navigation, the footer's two spellings cannot be mixed. Each section's children pair with the spelling of the section they are in, and mixing the spellings of the `<govuk-footer>`'s own children — which all have the same parent element, so cannot be paired up that way — throws.
 
-The notification banner takes `<title>` inside `<govuk-notification-banner>`, the same short name the summary card and the footer's nav sections take for their titles:
+The notification banner takes `<notification-banner-title>` inside `<govuk-notification-banner>`:
 
 ```razor
 <govuk-notification-banner type="NotificationBannerType.Success">
-    <title heading-level="3">Important information</title>
+    <notification-banner-title heading-level="3">Important information</notification-banner-title>
     <p class="govuk-notification-banner__heading">You have 7 days left to send your application.</p>
 </govuk-notification-banner>
 ```
@@ -186,11 +186,11 @@ The tabs take `<tabs-item>` inside `<govuk-tabs>`:
 </govuk-tabs>
 ```
 
-The error summary takes `<title>`, `<description>` and `<error-summary-item>` inside `<govuk-error-summary>`, with the item generating its `href` from the `asp-` attributes just as `<govuk-error-summary-item>` does:
+The error summary takes `<error-summary-title>`, `<description>` and `<error-summary-item>` inside `<govuk-error-summary>`, with the item generating its `href` from the `asp-` attributes just as `<govuk-error-summary-item>` does:
 
 ```razor
 <govuk-error-summary>
-    <title>There is a problem</title>
+    <error-summary-title>There is a problem</error-summary-title>
     <error-summary-item href="#passport-issued-day">The date your passport was issued must be in the past</error-summary-item>
     <error-summary-item for="Postcode" />
 </govuk-error-summary>
@@ -229,6 +229,9 @@ The cookie banner takes `<message>` inside `<govuk-cookie-banner>`, with `<headi
 Every child pairs with the spelling of the element it is written in, as the accordion item's children do, so there is no way to mix the two. The deprecated `<govuk-cookie-banner-message-action>` keeps its `govuk-` prefixed spelling only; write `<action-button>` inside a `<message-actions>` instead.
 
 The `govuk-` prefixed names continue to work everywhere they did before, and remain the only spelling accepted inside a `<govuk-checkboxes-fieldset>`, `<govuk-radios-fieldset>` or `<govuk-date-input-fieldset>` — the short names pair with the fieldset that the root element generates for a `<legend>` of its own.
+
+The summary card's `<title>` element is now `<card-title>`, so that every short name for a title says which component's title it is, as `<panel-title>` already did, and none of them read as the `<title>` element that goes in the page's `<head>`.
+The old element still works, with everything it generated before, but using it produces a deprecation warning with the diagnostic ID `GFA0007`.
 
 `TabsOptions.Title` is now `string?` rather than `TemplateString?`. It only ever comes from the `title` attribute, so it is always text.
 

--- a/docs/components/error-summary.md
+++ b/docs/components/error-summary.md
@@ -26,7 +26,7 @@
 
 ```razor
 <govuk-error-summary>
-    <title>There is a problem</title>
+    <error-summary-title>There is a problem</error-summary-title>
     <error-summary-item href="#passport-issued-day">The date your passport was issued must be in the past</error-summary-item>
     <error-summary-item href="#postcode-input">Enter a postcode, like AA1 1AA</error-summary-item>
 </govuk-error-summary>
@@ -65,7 +65,7 @@
 | `disable-auto-focus` | `bool?` | Whether to disable the behavior that focuses the error summary when the page loads. |
 
 
-#### `<title>` / `<govuk-error-summary-title>`
+#### `<error-summary-title>` / `<govuk-error-summary-title>`
 
 The content is the HTML to use within the title for the error summary. If this element is not specified then the content is 'There is a problem'.
 

--- a/docs/components/footer.md
+++ b/docs/components/footer.md
@@ -39,7 +39,7 @@
 ```razor
 <govuk-footer>
     <nav width="two-thirds" columns="2">
-        <title>Two column list</title>
+        <nav-title>Two column list</nav-title>
         <nav-items>
             <nav-item href="#">Navigation item 1</nav-item>
             <nav-item href="#">Navigation item 2</nav-item>
@@ -50,7 +50,7 @@
         </nav-items>
     </nav>
     <nav width="one-third">
-        <title>Single column list</title>
+        <nav-title>Single column list</nav-title>
         <nav-items>
             <nav-item href="#">Navigation item 1</nav-item>
             <nav-item href="#">Navigation item 2</nav-item>
@@ -69,7 +69,7 @@
 ```razor
 <govuk-footer>
     <nav width="two-thirds" columns="2">
-        <title>Services and information</title>
+        <nav-title>Services and information</nav-title>
         <nav-items>
             <nav-item href="#">Benefits</nav-item>
             <nav-item href="#">Births, deaths, marriages and care</nav-item>
@@ -90,7 +90,7 @@
         </nav-items>
     </nav>
     <nav width="one-third">
-        <title>Departments and policy</title>
+        <nav-title>Departments and policy</nav-title>
         <nav-items>
             <nav-item href="#">How government works</nav-item>
             <nav-item href="#">Departments</nav-item>
@@ -181,7 +181,7 @@ Must be inside a `<govuk-footer>` element.
 | `width` | `string` | The width of this navigation section. For example, `one-third`, `two-thirds` or `one-half`. If not specified, `full` will be used. |
 
 
-#### `<title>` / `<govuk-footer-nav-title>`
+#### `<nav-title>` / `<govuk-footer-nav-title>`
 
 Must be inside a `<nav>` or `<govuk-footer-nav>` element.
 

--- a/docs/components/notification-banner.md
+++ b/docs/components/notification-banner.md
@@ -37,9 +37,9 @@
 
 ```razor
 <govuk-notification-banner>
-    <title heading-level="2" id="banner-title">
+    <notification-banner-title heading-level="2" id="banner-title">
         Important information
-    </title>
+    </notification-banner-title>
     <p class="govuk-notification-banner__heading">
         You have 7 days left to send your application.
         <a class="govuk-notification-banner__link" href="#">View application</a>.
@@ -77,7 +77,7 @@ The content is the HTML to use within the notification banner.
 | `type` | `GovUk.Frontend.AspNetCore.NotificationBannerType?` | The type of notification. |
 
 
-#### `<title>` / `<govuk-notification-banner-title>`
+#### `<notification-banner-title>` / `<govuk-notification-banner-title>`
 
 The content is the HTML to use within the notification banner's title. Use a self-closing tag to keep the default content.
 

--- a/docs/components/summary-list.md
+++ b/docs/components/summary-list.md
@@ -75,7 +75,7 @@
 
 ```razor
 <govuk-summary-card>
-    <title>University of Gloucestershire</title>
+    <card-title>University of Gloucestershire</card-title>
     <card-actions>
         <action href="#" visually-hidden-text="of University of Gloucestershire">Delete choice</action>
         <action href="#" visually-hidden-text="from University of Gloucestershire">Withdraw</action>
@@ -170,7 +170,7 @@ Must be inside a `<row-actions>` or `<govuk-summary-list-row-actions>` element.
 #### `<govuk-summary-card>`
 
 
-#### `<title>` / `<govuk-summary-card-title>`
+#### `<card-title>` / `<govuk-summary-card-title>`
 
 The content is the HTML to use for the card's title.
 

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/ErrorSummary/ErrorSummaryWithTitleExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/ErrorSummary/ErrorSummaryWithTitleExample.cshtml
@@ -2,7 +2,7 @@
 
 <example>
     <govuk-error-summary>
-        <title>There is a problem</title>
+        <error-summary-title>There is a problem</error-summary-title>
         <error-summary-item href="#passport-issued-day">The date your passport was issued must be in the past</error-summary-item>
         <error-summary-item href="#postcode-input">Enter a postcode, like AA1 1AA</error-summary-item>
     </govuk-error-summary>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Footer/FooterWithLinksAndSecondaryNavigationExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Footer/FooterWithLinksAndSecondaryNavigationExample.cshtml
@@ -4,7 +4,7 @@
     <example>
         <govuk-footer>
             <nav width="two-thirds" columns="2">
-                <title>Services and information</title>
+                <nav-title>Services and information</nav-title>
                 <nav-items>
                     <nav-item href="#">Benefits</nav-item>
                     <nav-item href="#">Births, deaths, marriages and care</nav-item>
@@ -25,7 +25,7 @@
                 </nav-items>
             </nav>
             <nav width="one-third">
-                <title>Departments and policy</title>
+                <nav-title>Departments and policy</nav-title>
                 <nav-items>
                     <nav-item href="#">How government works</nav-item>
                     <nav-item href="#">Departments</nav-item>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Footer/FooterWithSecondaryNavigationExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/Footer/FooterWithSecondaryNavigationExample.cshtml
@@ -4,7 +4,7 @@
     <example>
         <govuk-footer>
             <nav width="two-thirds" columns="2">
-                <title>Two column list</title>
+                <nav-title>Two column list</nav-title>
                 <nav-items>
                     <nav-item href="#">Navigation item 1</nav-item>
                     <nav-item href="#">Navigation item 2</nav-item>
@@ -15,7 +15,7 @@
                 </nav-items>
             </nav>
             <nav width="one-third">
-                <title>Single column list</title>
+                <nav-title>Single column list</nav-title>
                 <nav-items>
                     <nav-item href="#">Navigation item 1</nav-item>
                     <nav-item href="#">Navigation item 2</nav-item>

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/NotificationBanner/NotificationBannerWithOverriddenTitleExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/NotificationBanner/NotificationBannerWithOverriddenTitleExample.cshtml
@@ -2,9 +2,9 @@
 
 <example>
     <govuk-notification-banner>
-        <title heading-level="2" id="banner-title">
+        <notification-banner-title heading-level="2" id="banner-title">
             Important information
-        </title>
+        </notification-banner-title>
         <p class="govuk-notification-banner__heading">
             You have 7 days left to send your application.
             <a class="govuk-notification-banner__link" href="#">View application</a>.

--- a/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/SummaryList/SummaryListWithCardExample.cshtml
+++ b/src/GovUk.Frontend.AspNetCore.Docs/Pages/Examples/SummaryList/SummaryListWithCardExample.cshtml
@@ -2,7 +2,7 @@
 
 <example>
     <govuk-summary-card>
-        <title>University of Gloucestershire</title>
+        <card-title>University of Gloucestershire</card-title>
         <card-actions>
             <action href="#" visually-hidden-text="of University of Gloucestershire">Delete choice</action>
             <action href="#" visually-hidden-text="from University of Gloucestershire">Withdraw</action>

--- a/src/GovUk.Frontend.AspNetCore/DiagnosticIds.cs
+++ b/src/GovUk.Frontend.AspNetCore/DiagnosticIds.cs
@@ -8,4 +8,5 @@ internal static class DiagnosticIds
     public const string UseErrorPrefixAttributeInstead = "GFA0004";
     public const string UseGenerateErrorSummariesInstead = "GFA0005";
     public const string UseCookieBannerMessageActionButtonElementInstead = "GFA0006";
+    public const string UseSummaryCardTitleElementInstead = "GFA0007";
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/ErrorSummaryTitleTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/ErrorSummaryTitleTagHelper.cs
@@ -12,7 +12,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 public class ErrorSummaryTitleTagHelper : TagHelper
 {
     internal const string TagName = "govuk-error-summary-title";
-    internal const string ShortTagName = ShortTagNames.Title;
+    internal const string ShortTagName = ShortTagNames.ErrorSummaryTitle;
 
     internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/FooterNavTitleTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/FooterNavTitleTagHelper.cs
@@ -11,7 +11,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 public class FooterNavTitleTagHelper : TagHelper
 {
     internal const string TagName = "govuk-footer-nav-title";
-    internal const string ShortTagName = ShortTagNames.Title;
+    internal const string ShortTagName = ShortTagNames.NavTitle;
 
     internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/NotificationBannerTitleTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/NotificationBannerTitleTagHelper.cs
@@ -11,7 +11,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 public class NotificationBannerTitleTagHelper : TagHelper
 {
     internal const string TagName = "govuk-notification-banner-title";
-    internal const string ShortTagName = ShortTagNames.Title;
+    internal const string ShortTagName = ShortTagNames.NotificationBannerTitle;
 
     internal static IReadOnlyCollection<string> AllTagNames { get; } = [TagName, ShortTagName];
 

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/ObsoleteSummaryCardTitleTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/ObsoleteSummaryCardTitleTagHelper.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace GovUk.Frontend.AspNetCore.TagHelpers;
+
+/// <summary>
+/// Represents the title in the GDS summary card component.
+/// </summary>
+/// <remarks>
+/// This element has been replaced by <c>card-title</c>.
+/// </remarks>
+[HtmlTargetElement(ShortTagName, ParentTag = SummaryCardTagHelper.TagName)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+[Obsolete(
+    "Use the <" + SummaryCardTitleTagHelper.ShortTagName + "> element instead.",
+    DiagnosticId = DiagnosticIds.UseSummaryCardTitleElementInstead)]
+public class ObsoleteSummaryCardTitleTagHelper : SummaryCardTitleTagHelper
+{
+    internal new const string ShortTagName = ShortTagNames.Title;
+}

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/ShortTagNames.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/ShortTagNames.cs
@@ -12,6 +12,7 @@ internal static class ShortTagNames
     public const string BeforeInputs = "before-inputs";
     public const string BreadcrumbsItem = "breadcrumbs-item";
     public const string CardActions = "card-actions";
+    public const string CardTitle = "card-title";
     public const string CheckboxesItem = "checkboxes-item";
     public const string Conditional = "conditional";
     public const string Content = "content";
@@ -24,6 +25,7 @@ internal static class ShortTagNames
     public const string End = "end";
     public const string ErrorMessage = "error-message";
     public const string ErrorSummaryItem = "error-summary-item";
+    public const string ErrorSummaryTitle = "error-summary-title";
     public const string Heading = "heading";
     public const string Hint = "hint";
     public const string Key = "key";
@@ -39,7 +41,9 @@ internal static class ShortTagNames
     public const string Nav = "nav";
     public const string NavItem = "nav-item";
     public const string NavItems = "nav-items";
+    public const string NavTitle = "nav-title";
     public const string Next = "next";
+    public const string NotificationBannerTitle = "notification-banner-title";
     public const string PaginationItem = "pagination-item";
     public const string PanelActions = "panel-actions";
     public const string PanelBody = "panel-body";
@@ -56,7 +60,10 @@ internal static class ShortTagNames
     public const string Text = "text";
     public const string TabsItem = "tabs-item";
     public const string Tag = "tag";
+
+    // The deprecated short name for the summary card's title, replaced by CardTitle
     public const string Title = "title";
+
     public const string Value = "value";
     public const string Year = "year";
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/SummaryCardTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/SummaryCardTagHelper.cs
@@ -7,12 +7,15 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 /// Generates a GOV.UK summary card component.
 /// </summary>
 [HtmlTargetElement(TagName)]
+#pragma warning disable GFA0007 // Type or member is obsolete
 [RestrictChildren(
     SummaryCardTitleTagHelper.TagName,
     SummaryCardTitleTagHelper.ShortTagName,
+    ObsoleteSummaryCardTitleTagHelper.ShortTagName,
     SummaryCardActionsTagHelper.TagName,
     SummaryCardActionsTagHelper.ShortTagName,
     SummaryListTagHelper.TagName)]
+#pragma warning restore GFA0007 // Type or member is obsolete
 [OutputElementHint(DefaultComponentGenerator.ComponentElementTypes.SummaryCard)]
 public class SummaryCardTagHelper : TagHelper
 {

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/SummaryCardTitleTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/SummaryCardTitleTagHelper.cs
@@ -12,7 +12,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 public class SummaryCardTitleTagHelper : TagHelper
 {
     internal const string TagName = "govuk-summary-card-title";
-    internal const string ShortTagName = ShortTagNames.Title;
+    internal const string ShortTagName = ShortTagNames.CardTitle;
 
     private const int MinHeadingLevel = 1;
     private const int MaxHeadingLevel = 6;

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTests.cs
@@ -38,6 +38,7 @@ public class ShortTagNamesTests(ShortTagNamesTestsFixture fixture) : IClassFixtu
     [InlineData("ErrorSummary", "short", "long", ".govuk-error-summary__list a")]
     [InlineData("Details", "short", "long", ".govuk-details__summary-text")]
     [InlineData("CookieBanner", "short", "long", ".govuk-cookie-banner__heading")]
+    [InlineData("SummaryList", "short", "long", ".govuk-summary-card__title")]
     public async Task ShortTagNames_GenerateTheSameMarkupAsTheGovUkPrefixedNames(
         string component,
         string shortTestId,
@@ -273,6 +274,9 @@ public class ShortTagNamesTestsController : Controller
 
     [HttpGet("CookieBanner")]
     public IActionResult GetCookieBanner() => View("CookieBanner", new ShortTagNamesTestsModel());
+
+    [HttpGet("SummaryList")]
+    public IActionResult GetSummaryList() => View("SummaryList", new ShortTagNamesTestsModel());
 
     [HttpGet("ServiceNavigationMixed")]
     public IActionResult GetServiceNavigationMixed() => View("ServiceNavigationMixed", new ShortTagNamesTestsModel());

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/ErrorSummary.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/ErrorSummary.cshtml
@@ -5,7 +5,7 @@
 
 <div data-testid="short">
     <govuk-error-summary disable-auto-focus="true">
-        <title>There is a problem</title>
+        <error-summary-title>There is a problem</error-summary-title>
         <description>Check the following before continuing.</description>
         <error-summary-item href="#passport-issued-day">The date your passport was issued must be in the past</error-summary-item>
         <error-summary-item asp-controller="ShortTagNamesTests" asp-action="GetErrorSummary">Enter a postcode, like AA1 1AA</error-summary-item>

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/Footer.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/Footer.cshtml
@@ -6,14 +6,14 @@
 <div data-testid="short">
     <govuk-footer container-class="app-width-container">
         <nav width="two-thirds" columns="2">
-            <title>Services and information</title>
+            <nav-title>Services and information</nav-title>
             <nav-items>
                 <nav-item href="/">Benefits</nav-item>
                 <nav-item asp-controller="ShortTagNamesTests" asp-action="GetFooter">Births, deaths, marriages and care</nav-item>
             </nav-items>
         </nav>
         <nav width="one-third">
-            <title>Departments and policy</title>
+            <nav-title>Departments and policy</nav-title>
             <nav-items>
                 <nav-item href="/">How government works</nav-item>
             </nav-items>

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/NotificationBanner.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/NotificationBanner.cshtml
@@ -5,7 +5,7 @@
 
 <div data-testid="short">
     <govuk-notification-banner type="GovUk.Frontend.AspNetCore.NotificationBannerType.Success" disable-auto-focus="true">
-        <title heading-level="3" id="banner-title">Important information</title>
+        <notification-banner-title heading-level="3" id="banner-title">Important information</notification-banner-title>
         <p class="govuk-notification-banner__heading">
             You have 7 days left to send your application.
             <a class="govuk-notification-banner__link" href="/">View application</a>.

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/SummaryList.cshtml
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/ShortTagNamesTestsViews/SummaryList.cshtml
@@ -1,0 +1,40 @@
+@model GovUk.Frontend.AspNetCore.IntegrationTests.ShortTagNamesTestsModel
+
+@* The same component written with the short tag names and with the govuk- prefixed ones;
+   the two must generate identical markup *@
+
+<div data-testid="short">
+    <govuk-summary-card>
+        <card-title>University of Gloucestershire</card-title>
+        <card-actions>
+            <action href="#" visually-hidden-text="of University of Gloucestershire">Delete choice</action>
+        </card-actions>
+        <govuk-summary-list>
+            <row>
+                <key>Course</key>
+                <value>English (3DMD)</value>
+                <row-actions>
+                    <action href="#" visually-hidden-text="course">Change</action>
+                </row-actions>
+            </row>
+        </govuk-summary-list>
+    </govuk-summary-card>
+</div>
+
+<div data-testid="long">
+    <govuk-summary-card>
+        <govuk-summary-card-title>University of Gloucestershire</govuk-summary-card-title>
+        <govuk-summary-card-actions>
+            <govuk-summary-card-action href="#" visually-hidden-text="of University of Gloucestershire">Delete choice</govuk-summary-card-action>
+        </govuk-summary-card-actions>
+        <govuk-summary-list>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Course</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>English (3DMD)</govuk-summary-list-row-value>
+                <govuk-summary-list-row-actions>
+                    <govuk-summary-list-row-action href="#" visually-hidden-text="course">Change</govuk-summary-list-row-action>
+                </govuk-summary-list-row-actions>
+            </govuk-summary-list-row>
+        </govuk-summary-list>
+    </govuk-summary-card>
+</div>

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ErrorSummaryContextTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ErrorSummaryContextTests.cs
@@ -93,7 +93,7 @@ public class ErrorSummaryContextTests
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
         Assert.Equal(
-            "Only one <govuk-error-summary-title> or <title> element is permitted within each <govuk-error-summary>.",
+            "Only one <govuk-error-summary-title> or <error-summary-title> element is permitted within each <govuk-error-summary>.",
             ex.Message);
     }
 
@@ -132,7 +132,7 @@ public class ErrorSummaryContextTests
         // Assert
         Assert.IsType<InvalidOperationException>(ex);
         Assert.Equal(
-            "<govuk-error-summary-description> cannot be used alongside <title>; " +
+            "<govuk-error-summary-description> cannot be used alongside <error-summary-title>; " +
                 "short tag names and govuk- prefixed tag names cannot be mixed.",
             ex.Message);
     }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ObsoleteSummaryCardTitleTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/ObsoleteSummaryCardTitleTagHelperTests.cs
@@ -1,0 +1,43 @@
+using GovUk.Frontend.AspNetCore.TagHelpers;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+#pragma warning disable GFA0007 // Type or member is obsolete
+
+namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
+
+public class ObsoleteSummaryCardTitleTagHelperTests : TagHelperTestBase<ObsoleteSummaryCardTitleTagHelper>
+{
+    [Fact]
+    public async Task ProcessAsync_DeprecatedTagName_SetsTitleOnContext()
+    {
+        // Arrange
+        var titleContent = "Title";
+        var headingLevel = 3;
+
+        var summaryCardContext = new SummaryCardContext();
+
+        var context = CreateTagHelperContext(tagName: ShortTagNames.Title, contexts: summaryCardContext);
+
+        var output = CreateTagHelperOutput(
+            tagName: ShortTagNames.Title,
+            getChildContentAsync: (useCachedResult, encoder) =>
+            {
+                var tagHelperContent = new DefaultTagHelperContent();
+                tagHelperContent.SetContent(titleContent);
+                return Task.FromResult<TagHelperContent>(tagHelperContent);
+            });
+
+        var tagHelper = new ObsoleteSummaryCardTitleTagHelper()
+        {
+            HeadingLevel = headingLevel
+        };
+
+        tagHelper.Init(context);
+
+        // Act
+        await tagHelper.ProcessAsync(context, output);
+
+        // Assert
+        Assert.Equal(titleContent, summaryCardContext.Title?.Html?.ToHtmlString());
+        Assert.Equal(headingLevel, summaryCardContext.Title?.HeadingLevel);
+    }
+}


### PR DESCRIPTION
`<title>` was the short tag name for four different components' titles — the error summary, the footer's nav sections, the notification banner and the summary card. It says nothing about which component's title it is, and it reads as the `<title>` element that goes in the page's `<head>`.

Each now takes a name that names its component, as the panel's `<panel-title>` already did:

| Element | Short tag name |
| --- | --- |
| `<govuk-error-summary-title>` | `<error-summary-title>` |
| `<govuk-footer-nav-title>` | `<nav-title>` |
| `<govuk-notification-banner-title>` | `<notification-banner-title>` |
| `<govuk-summary-card-title>` | `<card-title>` |

The first three are new in the unreleased 5.0.0, so they are simply renamed. The summary card's `<title>` shipped in 4.x, so it still works and generates exactly what it did before, but using it now produces a deprecation warning with the diagnostic ID `GFA0007` — the same pattern as the cookie banner's deprecated action element (`GFA0006`).

The short tag name integration tests now cover the summary list and card, which had none, so both spellings of the card's title are exercised end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)