### PR TITLE
Drop the VSTest packages and finish the xunit.v3 4.0.0 upgrade

### DIFF
--- a/tests/GovUk.FrontEnd.AspNetCore.TestCommon/GovUk.FrontEnd.AspNetCore.TestCommon.csproj
+++ b/tests/GovUk.FrontEnd.AspNetCore.TestCommon/GovUk.FrontEnd.AspNetCore.TestCommon.csproj
@@ -13,8 +13,7 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.5.2" />
     <PackageReference Include="AngleSharp.Diffing" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit.v3.assert" Version="3.1.0" />
+    <PackageReference Include="xunit.v3.assert" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/GovUk.Frontend.AspNetCore.IntegrationTests.csproj
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/GovUk.Frontend.AspNetCore.IntegrationTests.csproj
@@ -12,10 +12,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.21.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="xunit.v3" Version="3.1.0" />
   </ItemGroup>
 

--- a/tests/GovUk.Frontend.AspNetCore.IntegrationTests/GovUk.Frontend.AspNetCore.IntegrationTests.csproj
+++ b/tests/GovUk.Frontend.AspNetCore.IntegrationTests/GovUk.Frontend.AspNetCore.IntegrationTests.csproj
@@ -10,9 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.21.0" />
-    <PackageReference Include="xunit.v3" Version="3.1.0" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/GovUk.Frontend.AspNetCore.PackageTests.csproj
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/GovUk.Frontend.AspNetCore.PackageTests.csproj
@@ -16,10 +16,6 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.7.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
 

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/GovUk.Frontend.AspNetCore.PackageTests.csproj
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/GovUk.Frontend.AspNetCore.PackageTests.csproj
@@ -4,6 +4,8 @@
     <!-- These tests drive the SDK as a child process, so the host only needs one TFM; the frameworks
          under test are a property of the generated fixture projects. -->
     <TargetFramework>net10.0</TargetFramework>
+    <!-- xunit.v3 hosts the tests itself; the web SDK projects get this from their own defaults -->
+    <OutputType>Exe</OutputType>
 
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -15,7 +17,6 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.7.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
 

--- a/tests/GovUk.Frontend.AspNetCore.Tests/GovUk.Frontend.AspNetCore.Tests.csproj
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/GovUk.Frontend.AspNetCore.Tests.csproj
@@ -9,9 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit.v3" Version="3.1.0" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/GovUk.Frontend.AspNetCore.Tests/GovUk.Frontend.AspNetCore.Tests.csproj
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/GovUk.Frontend.AspNetCore.Tests.csproj
@@ -11,10 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="xunit.v3" Version="3.1.0" />
   </ItemGroup>
 

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TagHelperTestCase.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/TagHelperTestCase.cs
@@ -109,7 +109,10 @@ public class TagHelperTestCase : XunitTestCase, ISelfExecutingXunitTestCase
         IMessageBus messageBus,
         object?[] constructorArguments,
         ExceptionAggregator aggregator,
-        CancellationTokenSource cancellationTokenSource) =>
+        CancellationTokenSource cancellationTokenSource,
+        ParallelMode parallelMode,
+        ExecutionScheduler scheduler,
+        FixtureMappingManager methodFixtureMappings) =>
             TagHelperTestCaseRunner.Instance.Run(
                 TagHelperTestCaseInfo!,
                 this,
@@ -119,7 +122,10 @@ public class TagHelperTestCase : XunitTestCase, ISelfExecutingXunitTestCase
                 TestCaseDisplayName,
                 SkipReason,
                 explicitOption,
-                constructorArguments);
+                constructorArguments,
+                parallelMode,
+                scheduler,
+                methodFixtureMappings);
 
     protected override void Deserialize(IXunitSerializationInfo info)
     {
@@ -163,7 +169,10 @@ public class TagHelperTestCaseRunnerContext(
     string displayName,
     string? skipReason,
     ExplicitOption explicitOption,
-    object?[] constructorArguments) : XunitTestCaseRunnerBaseContext<IXunitTestCase, IXunitTest>(testCase, tests, messageBus, aggregator, cancellationTokenSource, displayName, skipReason, explicitOption, constructorArguments)
+    object?[] constructorArguments,
+    ParallelMode parallelMode,
+    ExecutionScheduler scheduler,
+    FixtureMappingManager methodFixtureMappings) : XunitTestCaseRunnerBaseContext<IXunitTestCase, IXunitTest>(testCase, tests, explicitOption, messageBus, aggregator, displayName, skipReason, cancellationTokenSource, parallelMode, scheduler, constructorArguments, methodFixtureMappings)
 {
     public TagHelperTestCaseInfo TagHelperTestCaseInfo => tagHelperTestCaseInfo;
 }
@@ -181,7 +190,10 @@ public class TagHelperTestCaseRunner : XunitTestCaseRunnerBase<TagHelperTestCase
         string displayName,
         string? skipReason,
         ExplicitOption explicitOption,
-        object?[] constructorArguments)
+        object?[] constructorArguments,
+        ParallelMode parallelMode,
+        ExecutionScheduler scheduler,
+        FixtureMappingManager methodFixtureMappings)
     {
         // See XunitRunnerHelper.RunXunitTestCase
 
@@ -231,7 +243,10 @@ public class TagHelperTestCaseRunner : XunitTestCaseRunnerBase<TagHelperTestCase
             displayName,
             skipReason,
             explicitOption,
-            constructorArguments);
+            constructorArguments,
+            parallelMode,
+            scheduler,
+            methodFixtureMappings);
 
         await ctxt.InitializeAsync();
 
@@ -248,7 +263,10 @@ public class TagHelperTestCaseRunner : XunitTestCaseRunnerBase<TagHelperTestCase
             ctxt.ExplicitOption,
             ctxt.Aggregator.Clone(),
             ctxt.CancellationTokenSource,
-            ctxt.BeforeAfterTestAttributes);
+            ctxt.BeforeAfterTestAttributes,
+            ctxt.ParallelMode,
+            ctxt.Scheduler,
+            ctxt.CaseFixtureMappings);
     }
 }
 
@@ -260,7 +278,10 @@ public class TagHelperTestRunnerContext(
     ExceptionAggregator aggregator,
     CancellationTokenSource cancellationTokenSource,
     IReadOnlyCollection<IBeforeAfterTestAttribute> beforeAfterAttributes,
-    object?[] constructorArguments) : XunitTestRunnerContext(test, messageBus, explicitOption, aggregator, cancellationTokenSource, beforeAfterAttributes, constructorArguments)
+    object?[] constructorArguments,
+    ParallelMode parallelMode,
+    ExecutionScheduler scheduler,
+    FixtureMappingManager caseFixtureMappings) : XunitTestRunnerContext(test, explicitOption, messageBus, aggregator, cancellationTokenSource, parallelMode, scheduler, beforeAfterAttributes, constructorArguments, caseFixtureMappings)
 {
     public TagHelperTestCaseInfo TagHelperTestCaseInfo => tagHelperTestCaseInfo;
 }
@@ -277,7 +298,10 @@ public class TagHelperTestRunner : XunitTestRunnerBase<TagHelperTestRunnerContex
         ExplicitOption explicitOption,
         ExceptionAggregator aggregator,
         CancellationTokenSource cancellationTokenSource,
-        IReadOnlyCollection<IBeforeAfterTestAttribute> beforeAfterAttributes)
+        IReadOnlyCollection<IBeforeAfterTestAttribute> beforeAfterAttributes,
+        ParallelMode parallelMode,
+        ExecutionScheduler scheduler,
+        FixtureMappingManager caseFixtureMappings)
     {
         await using var ctxt = new TagHelperTestRunnerContext(
             tagHelperTestCaseInfo,
@@ -287,7 +311,10 @@ public class TagHelperTestRunner : XunitTestRunnerBase<TagHelperTestRunnerContex
             aggregator,
             cancellationTokenSource,
             beforeAfterAttributes,
-            constructorArguments
+            constructorArguments,
+            parallelMode,
+            scheduler,
+            caseFixtureMappings
         );
         await ctxt.InitializeAsync();
 


### PR DESCRIPTION
The test runner is Microsoft.Testing.Platform now, and xunit.v3 4.0.0 has dropped VSTest support altogether, so `xunit.runner.visualstudio` and `Microsoft.NET.Test.Sdk` no longer do anything. Both go, from all four test projects — `Microsoft.NET.Test.Sdk` was pinned at four different versions across them, none of which mattered.

With `Microsoft.NET.Test.Sdk` gone, nothing sets `OutputType` for the package tests, and xunit.v3 4.0.0 refuses to build a test project that isn't executable, so that project asks for `Exe` itself. The other three use the web SDK, which already defaults to it.

`Tests`, `IntegrationTests` and `TestCommon` move from xunit.v3 3.1.0 to 4.0.0, joining the package tests, which dependabot took there in #561 and #560.

4.0.0 threads the parallel mode, the scheduler and the fixture mappings through `ISelfExecutingXunitTestCase.Run` and reorders the runner context constructors to carry them, so the custom tag helper test case — the one that expands each test over every tag name a tag helper targets — passes them along. The old context constructors are still there but can't supply the new values, hence the move to the new ones.

The unit test count is unchanged at 5772, so both the per-tag-name expansion and the theory pre-enumeration that `xunit.runner.json` asks for still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)