### PR TITLE
Rename Obsolete*TagHelper classes to Legacy*TagHelper

### DIFF
--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/LegacySummaryCardTitleTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/LegacySummaryCardTitleTagHelper.cs
@@ -14,7 +14,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 [Obsolete(
     "Use the <" + SummaryCardTitleTagHelper.ShortTagName + "> element instead.",
     DiagnosticId = DiagnosticIds.UseSummaryCardTitleElementInstead)]
-public class ObsoleteSummaryCardTitleTagHelper : SummaryCardTitleTagHelper
+public class LegacySummaryCardTitleTagHelper : SummaryCardTitleTagHelper
 {
     internal new const string ShortTagName = ShortTagNames.Title;
 }

--- a/src/GovUk.Frontend.AspNetCore/TagHelpers/SummaryCardTagHelper.cs
+++ b/src/GovUk.Frontend.AspNetCore/TagHelpers/SummaryCardTagHelper.cs
@@ -11,7 +11,7 @@ namespace GovUk.Frontend.AspNetCore.TagHelpers;
 [RestrictChildren(
     SummaryCardTitleTagHelper.TagName,
     SummaryCardTitleTagHelper.ShortTagName,
-    ObsoleteSummaryCardTitleTagHelper.ShortTagName,
+    LegacySummaryCardTitleTagHelper.ShortTagName,
     SummaryCardActionsTagHelper.TagName,
     SummaryCardActionsTagHelper.ShortTagName,
     SummaryListTagHelper.TagName)]

--- a/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/LegacySummaryCardTitleTagHelperTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/TagHelpers/LegacySummaryCardTitleTagHelperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace GovUk.Frontend.AspNetCore.Tests.TagHelpers;
 
-public class ObsoleteSummaryCardTitleTagHelperTests : TagHelperTestBase<ObsoleteSummaryCardTitleTagHelper>
+public class LegacySummaryCardTitleTagHelperTests : TagHelperTestBase<LegacySummaryCardTitleTagHelper>
 {
     [Fact]
     public async Task ProcessAsync_DeprecatedTagName_SetsTitleOnContext()
@@ -26,7 +26,7 @@ public class ObsoleteSummaryCardTitleTagHelperTests : TagHelperTestBase<Obsolete
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
 
-        var tagHelper = new ObsoleteSummaryCardTitleTagHelper()
+        var tagHelper = new LegacySummaryCardTitleTagHelper()
         {
             HeadingLevel = headingLevel
         };


### PR DESCRIPTION
## What

Renames the `Obsolete*TagHelper` naming convention to `Legacy*TagHelper`. In practice there was exactly one class matching the pattern:

- `ObsoleteSummaryCardTitleTagHelper` → `LegacySummaryCardTitleTagHelper` (and its test class)
- Updated the `[RestrictChildren]` reference in `SummaryCardTagHelper`

Both files were moved with `git mv`, so the rename is recorded as a rename rather than a delete + add.

## Why

`Obsolete` overloaded the `[Obsolete]` attribute that these types already carry. `Legacy` reads better for "this type exists only to keep supporting a superseded element name", and leaves `Obsolete` to mean the attribute.

## Reviewer notes

- The type is `public`, so this is a source- and binary-breaking change for anyone referencing it by name. It's marked `[EditorBrowsable(EditorBrowsableState.Never)]` and `[Obsolete(..., DiagnosticId = GFA0007)]`, so it shouldn't appear in IntelliSense or be referenced deliberately, but it is a public API rename rather than an internal one.
- No behaviour change: the tag name constant (`ShortTagNames.Title`), the `[HtmlTargetElement]` registration, and the obsoletion diagnostic ID are all unchanged, so Razor markup using the deprecated element continues to work exactly as before.

## Testing

- `dotnet build` of the library: succeeds, 0 warnings.
- All 922 tests in `GovUk.Frontend.AspNetCore.Tests.TagHelpers` pass (2 pre-existing skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)