### PR TITLE
Only emit GovUkFrontendBuildInfoAttribute when support is enabled

### DIFF
--- a/src/GovUk.Frontend.AspNetCore/GovUkFrontendBuildInfoAttribute.cs
+++ b/src/GovUk.Frontend.AspNetCore/GovUkFrontendBuildInfoAttribute.cs
@@ -7,14 +7,11 @@ namespace GovUk.Frontend.AspNetCore;
 [AttributeUsage(AttributeTargets.Assembly)]
 [EditorBrowsable(EditorBrowsableState.Never)]
 public sealed class GovUkFrontendBuildInfoAttribute(
-    bool enableGovUkFrontendSupport,
     string? govUkFrontendAssetsDirectory,
     string? govUkFrontendJavaScriptDirectory,
     string? govUkFrontendStylesheetDirectory) :
     Attribute
 {
-    public bool EnableGovUkFrontendSupport { get; } = enableGovUkFrontendSupport;
-
     public string? GovUkFrontendAssetsDirectory { get; } = govUkFrontendAssetsDirectory;
 
     public string? GovUkFrontendJavaScriptDirectory { get; } = govUkFrontendJavaScriptDirectory;

--- a/src/GovUk.Frontend.AspNetCore/GovUkFrontendExtensions.cs
+++ b/src/GovUk.Frontend.AspNetCore/GovUkFrontendExtensions.cs
@@ -149,7 +149,9 @@ public static class GovUkFrontendExtensions
 
         var options = app.ApplicationServices.GetRequiredService<IOptions<GovUkFrontendOptions>>().Value;
 
-        if (options.BuildInfo?.EnableGovUkFrontendSupport is true)
+        // The targets only emit the build info when the project asked for govuk-frontend support, so its
+        // absence means there is nothing here for the middleware to serve.
+        if (options.BuildInfo is not null)
         {
             app.UseMiddleware<VersionedAssetMiddleware>();
         }

--- a/src/GovUk.Frontend.AspNetCore/GovUkFrontendOptions.cs
+++ b/src/GovUk.Frontend.AspNetCore/GovUkFrontendOptions.cs
@@ -75,6 +75,11 @@ public class GovUkFrontendOptions
     /// </remarks>
     public bool PrependErrorToTitle { get; set; }
 
+    /// <summary>
+    /// What the package's build targets recorded about this project, or <see langword="null"/> if they
+    /// didn't run for it - either because the project doesn't reference the package or because it set
+    /// <c>EnableGovUkFrontendSupport</c> to <c>false</c>.
+    /// </summary>
     internal GovUkFrontendBuildInfoAttribute? BuildInfo { get; set; }
 
     /// <summary>

--- a/src/GovUk.Frontend.AspNetCore/Package/buildTransitive/GovUk.Frontend.AspNetCore.targets
+++ b/src/GovUk.Frontend.AspNetCore/Package/buildTransitive/GovUk.Frontend.AspNetCore.targets
@@ -71,12 +71,14 @@
        already valid C# has to go in as a non-literal, where it gets quoted and escaped properly. That
        leaves 'null' as the only value here that has to stay a literal: an unquoted directory would be
        read as an identifier, and a quoted one would carry unescaped '\' and '"' straight into the
-       source. The boolean is normalised because MSBuild treats 'True' as true but C# does not. -->
-  <Target Name="AddGovUkFrontendBuildInfoAttribute" BeforeTargets="BeforeBuild">
-    <PropertyGroup>
-      <_govUkEnableSupportArg>false</_govUkEnableSupportArg>
-      <_govUkEnableSupportArg Condition="'$(EnableGovUkFrontendSupport)' == 'true'">true</_govUkEnableSupportArg>
+       source.
 
+       The attribute is only emitted when support is enabled, so its presence is what tells the library
+       the build targets ran for this project. -->
+  <Target Name="AddGovUkFrontendBuildInfoAttribute"
+          BeforeTargets="BeforeBuild"
+          Condition="'$(EnableGovUkFrontendSupport)' == 'true'">
+    <PropertyGroup>
       <_govUkAssetsDirectoryArg>null</_govUkAssetsDirectoryArg>
       <_govUkAssetsDirectoryIsLiteral>true</_govUkAssetsDirectoryIsLiteral>
       <_govUkAssetsDirectoryArg Condition="'$(_ShouldRestoreAssets)' == 'true'">$(GovUkFrontendAssetsDirectory)</_govUkAssetsDirectoryArg>
@@ -95,14 +97,12 @@
 
     <ItemGroup>
       <AssemblyAttribute Include="GovUk.Frontend.AspNetCore.GovUkFrontendBuildInfoAttribute">
-        <_Parameter1>$(_govUkEnableSupportArg)</_Parameter1>
-        <_Parameter1_IsLiteral>true</_Parameter1_IsLiteral>
-        <_Parameter2>$(_govUkAssetsDirectoryArg)</_Parameter2>
-        <_Parameter2_IsLiteral>$(_govUkAssetsDirectoryIsLiteral)</_Parameter2_IsLiteral>
-        <_Parameter3>$(_govUkJavaScriptDirectoryArg)</_Parameter3>
-        <_Parameter3_IsLiteral>$(_govUkJavaScriptDirectoryIsLiteral)</_Parameter3_IsLiteral>
-        <_Parameter4>$(_govUkStylesheetDirectoryArg)</_Parameter4>
-        <_Parameter4_IsLiteral>$(_govUkStylesheetDirectoryIsLiteral)</_Parameter4_IsLiteral>
+        <_Parameter1>$(_govUkAssetsDirectoryArg)</_Parameter1>
+        <_Parameter1_IsLiteral>$(_govUkAssetsDirectoryIsLiteral)</_Parameter1_IsLiteral>
+        <_Parameter2>$(_govUkJavaScriptDirectoryArg)</_Parameter2>
+        <_Parameter2_IsLiteral>$(_govUkJavaScriptDirectoryIsLiteral)</_Parameter2_IsLiteral>
+        <_Parameter3>$(_govUkStylesheetDirectoryArg)</_Parameter3>
+        <_Parameter3_IsLiteral>$(_govUkStylesheetDirectoryIsLiteral)</_Parameter3_IsLiteral>
       </AssemblyAttribute>
     </ItemGroup>
   </Target>

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/Infrastructure/GeneratedBuildInfo.cs
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/Infrastructure/GeneratedBuildInfo.cs
@@ -16,16 +16,13 @@ public sealed partial class GeneratedBuildInfo
     private GeneratedBuildInfo(string arguments, IReadOnlyList<string?> values)
     {
         RawArguments = arguments;
-        EnableGovUkFrontendSupport = values[0] == "true";
-        AssetsDirectory = values[1];
-        JavaScriptDirectory = values[2];
-        StylesheetDirectory = values[3];
+        AssetsDirectory = values[0];
+        JavaScriptDirectory = values[1];
+        StylesheetDirectory = values[2];
     }
 
     /// <summary>The argument list exactly as it appears in the generated source.</summary>
     public string RawArguments { get; }
-
-    public bool EnableGovUkFrontendSupport { get; }
 
     public string? AssetsDirectory { get; }
 
@@ -33,7 +30,19 @@ public sealed partial class GeneratedBuildInfo
 
     public string? StylesheetDirectory { get; }
 
-    public static GeneratedBuildInfo Read(FixtureProject project, string targetFramework)
+    /// <summary>
+    /// Reads the attribute the targets emitted, failing if they didn't emit one.
+    /// </summary>
+    public static GeneratedBuildInfo Read(FixtureProject project, string targetFramework) =>
+        ReadOrDefault(project, targetFramework) ??
+        throw new InvalidOperationException(
+            $"No GovUkFrontendBuildInfoAttribute was generated for '{targetFramework}'.");
+
+    /// <summary>
+    /// Reads the attribute the targets emitted, or <see langword="null"/> if they emitted none, which is
+    /// what a project with support disabled gets.
+    /// </summary>
+    public static GeneratedBuildInfo? ReadOrDefault(FixtureProject project, string targetFramework)
     {
         var objDirectory = Path.Combine(project.Directory, "obj", FixtureProject.Configuration, targetFramework);
 
@@ -52,17 +61,16 @@ public sealed partial class GeneratedBuildInfo
 
         if (!match.Success)
         {
-            throw new InvalidOperationException(
-                $"No GovUkFrontendBuildInfoAttribute found in '{assemblyInfoFiles[0]}'.{Environment.NewLine}{source}");
+            return null;
         }
 
         var arguments = match.Groups[1].Value;
         var values = ParseArguments(arguments);
 
-        if (values.Count != 4)
+        if (values.Count != 3)
         {
             throw new InvalidOperationException(
-                $"Expected 4 arguments to GovUkFrontendBuildInfoAttribute but found {values.Count}: {arguments}");
+                $"Expected 3 arguments to GovUkFrontendBuildInfoAttribute but found {values.Count}: {arguments}");
         }
 
         return new GeneratedBuildInfo(arguments, values);

--- a/tests/GovUk.Frontend.AspNetCore.PackageTests/RestoreTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.PackageTests/RestoreTests.cs
@@ -41,7 +41,6 @@ public class RestoreTests(PackageTestContext context)
 
         AssertBuildInfoForEveryTargetFramework(
             project,
-            enableSupport: true,
             assetsDirectory: "wwwroot/assets",
             javaScriptDirectory: "wwwroot",
             stylesheetDirectory: "wwwroot");
@@ -60,12 +59,7 @@ public class RestoreTests(PackageTestContext context)
         project.AssertDirectoryIsEmptyOrMissing("wwwroot");
         project.AssertDirectoryIsEmptyOrMissing("lib");
 
-        AssertBuildInfoForEveryTargetFramework(
-            project,
-            enableSupport: false,
-            assetsDirectory: null,
-            javaScriptDirectory: null,
-            stylesheetDirectory: null);
+        AssertNoBuildInfoForAnyTargetFramework(project);
     }
 
     [Fact]
@@ -156,7 +150,6 @@ public class RestoreTests(PackageTestContext context)
 
         AssertBuildInfoForEveryTargetFramework(
             project,
-            enableSupport: true,
             assetsDirectory: "wwwroot/govuk/assets",
             javaScriptDirectory: "wwwroot/govuk",
             stylesheetDirectory: "wwwroot/govuk");
@@ -238,7 +231,6 @@ public class RestoreTests(PackageTestContext context)
         // Support is still on, so the middleware is still added; it just has nothing to mark as immutable.
         AssertBuildInfoForEveryTargetFramework(
             project,
-            enableSupport: true,
             assetsDirectory: null,
             javaScriptDirectory: null,
             stylesheetDirectory: null);
@@ -267,12 +259,7 @@ public class RestoreTests(PackageTestContext context)
         project.AssertDirectoryIsEmptyOrMissing("wwwroot");
         project.AssertDirectoryIsEmptyOrMissing("lib");
 
-        AssertBuildInfoForEveryTargetFramework(
-            project,
-            enableSupport: false,
-            assetsDirectory: null,
-            javaScriptDirectory: null,
-            stylesheetDirectory: null);
+        AssertNoBuildInfoForAnyTargetFramework(project);
     }
 
     [Fact]
@@ -386,7 +373,6 @@ public class RestoreTests(PackageTestContext context)
 
         AssertBuildInfoForEveryTargetFramework(
             project,
-            enableSupport: true,
             assetsDirectory: "wwwroot/assets",
             javaScriptDirectory: "wwwroot",
             stylesheetDirectory: "wwwroot");
@@ -454,7 +440,6 @@ public class RestoreTests(PackageTestContext context)
 
     private static void AssertBuildInfoForEveryTargetFramework(
         FixtureProject project,
-        bool enableSupport,
         string? assetsDirectory,
         string? javaScriptDirectory,
         string? stylesheetDirectory)
@@ -463,10 +448,21 @@ public class RestoreTests(PackageTestContext context)
         {
             var buildInfo = GeneratedBuildInfo.Read(project, targetFramework);
 
-            Assert.Equal(enableSupport, buildInfo.EnableGovUkFrontendSupport);
             Assert.Equal(assetsDirectory, buildInfo.AssetsDirectory);
             Assert.Equal(javaScriptDirectory, buildInfo.JavaScriptDirectory);
             Assert.Equal(stylesheetDirectory, buildInfo.StylesheetDirectory);
+        }
+    }
+
+    /// <summary>
+    /// With support disabled there is nothing for the library to act on, so the targets emit no attribute
+    /// at all rather than one saying so.
+    /// </summary>
+    private static void AssertNoBuildInfoForAnyTargetFramework(FixtureProject project)
+    {
+        foreach (var targetFramework in project.TargetFrameworks)
+        {
+            Assert.Null(GeneratedBuildInfo.ReadOrDefault(project, targetFramework));
         }
     }
 }

--- a/tests/GovUk.Frontend.AspNetCore.Tests/GovUkFrontendPathsTests.cs
+++ b/tests/GovUk.Frontend.AspNetCore.Tests/GovUkFrontendPathsTests.cs
@@ -6,7 +6,7 @@ public class GovUkFrontendPathsTests
     public void Create_WithTheDefaultDirectories_MapsThemToTheDefaultUrls()
     {
         // Arrange
-        var buildInfo = new GovUkFrontendBuildInfoAttribute(true, "wwwroot/assets", "wwwroot", "wwwroot");
+        var buildInfo = new GovUkFrontendBuildInfoAttribute("wwwroot/assets", "wwwroot", "wwwroot");
 
         // Act
         var paths = GovUkFrontendPaths.Create(CreateEnvironment(), buildInfo);
@@ -23,7 +23,7 @@ public class GovUkFrontendPathsTests
     public void Create_WithCustomDirectories_MapsThemRelativeToTheWebRoot()
     {
         // Arrange
-        var buildInfo = new GovUkFrontendBuildInfoAttribute(true, "wwwroot/govuk/assets", "wwwroot/govuk", "wwwroot/govuk");
+        var buildInfo = new GovUkFrontendBuildInfoAttribute("wwwroot/govuk/assets", "wwwroot/govuk", "wwwroot/govuk");
 
         // Act
         var paths = GovUkFrontendPaths.Create(CreateEnvironment(), buildInfo);
@@ -38,7 +38,7 @@ public class GovUkFrontendPathsTests
     public void Create_WithWindowsStyleSeparators_NormalizesThem()
     {
         // Arrange
-        var buildInfo = new GovUkFrontendBuildInfoAttribute(true, @"wwwroot\govuk\assets", @"wwwroot\govuk", @"wwwroot\govuk");
+        var buildInfo = new GovUkFrontendBuildInfoAttribute(@"wwwroot\govuk\assets", @"wwwroot\govuk", @"wwwroot\govuk");
 
         // Act
         var paths = GovUkFrontendPaths.Create(CreateEnvironment(), buildInfo);
@@ -54,7 +54,7 @@ public class GovUkFrontendPathsTests
     {
         // Arrange
         var environment = CreateEnvironment(webRoot: "/app/public");
-        var buildInfo = new GovUkFrontendBuildInfoAttribute(true, "public/assets", "public", "public");
+        var buildInfo = new GovUkFrontendBuildInfoAttribute("public/assets", "public", "public");
 
         // Act
         var paths = GovUkFrontendPaths.Create(environment, buildInfo);
@@ -68,7 +68,7 @@ public class GovUkFrontendPathsTests
     public void Create_WithADirectoryOutsideTheWebRoot_ReportsNoPath()
     {
         // Arrange - nothing outside the web root gets served, so there is no URL for it
-        var buildInfo = new GovUkFrontendBuildInfoAttribute(true, "lib/assets", "lib", "lib");
+        var buildInfo = new GovUkFrontendBuildInfoAttribute("lib/assets", "lib", "lib");
 
         // Act
         var paths = GovUkFrontendPaths.Create(CreateEnvironment(), buildInfo);
@@ -83,7 +83,7 @@ public class GovUkFrontendPathsTests
     public void Create_WithASiblingDirectoryWhoseNameStartsWithTheWebRoot_ReportsNoPath()
     {
         // Arrange
-        var buildInfo = new GovUkFrontendBuildInfoAttribute(true, "wwwrootstuff/assets", "wwwrootstuff", "wwwrootstuff");
+        var buildInfo = new GovUkFrontendBuildInfoAttribute("wwwrootstuff/assets", "wwwrootstuff", "wwwrootstuff");
 
         // Act
         var paths = GovUkFrontendPaths.Create(CreateEnvironment(), buildInfo);
@@ -99,7 +99,7 @@ public class GovUkFrontendPathsTests
     {
         // Arrange
         var environment = CreateEnvironment(contentRoot: "/app", webRoot: "/var/www");
-        var buildInfo = new GovUkFrontendBuildInfoAttribute(true, "wwwroot/assets", "wwwroot", "wwwroot");
+        var buildInfo = new GovUkFrontendBuildInfoAttribute("wwwroot/assets", "wwwroot", "wwwroot");
 
         // Act
         var paths = GovUkFrontendPaths.Create(environment, buildInfo);
@@ -124,7 +124,7 @@ public class GovUkFrontendPathsTests
     public void Create_WithNoEnvironment_ReportsNoPaths()
     {
         // Arrange
-        var buildInfo = new GovUkFrontendBuildInfoAttribute(true, "wwwroot/assets", "wwwroot", "wwwroot");
+        var buildInfo = new GovUkFrontendBuildInfoAttribute("wwwroot/assets", "wwwroot", "wwwroot");
 
         // Act
         var paths = GovUkFrontendPaths.Create(environment: null, buildInfo);


### PR DESCRIPTION
## What

The targets no longer emit `GovUkFrontendBuildInfoAttribute` at all when `EnableGovUkFrontendSupport` is `false`, and the attribute's `enableGovUkFrontendSupport` parameter (and its `EnableGovUkFrontendSupport` property) is gone.

## Why

The flag was the only thing distinguishing an attribute worth reading from one whose sole message was "ignore me". Emitting the attribute conditionally says the same thing more directly, and once the target is conditioned on the property the flag can only ever be `true` — so it was redundant.

## Changes

- `GovUkFrontendBuildInfoAttribute` now takes just the three directories.
- `AddGovUkFrontendBuildInfoAttribute` carries `Condition="'$(EnableGovUkFrontendSupport)' == 'true'"`, and its parameters shift up by one. The comment about normalising `True`/`true` for C# went with the boolean; a note explaining that the attribute's presence *is* the signal replaced it.
- `UseGovUkFrontend` adds `VersionedAssetMiddleware` when `options.BuildInfo is not null`.
- Documented on `GovUkFrontendOptions.BuildInfo` that null means the targets didn't run — either the package isn't referenced, or support is off.

## Notes for reviewers

`GeneratedBuildInfo` in the package tests gained a `ReadOrDefault` that returns null when no attribute was generated; `Read` still throws. Both still fail if the generated assembly info file itself is missing, so the new "no attribute" assertion can't pass vacuously — it proves the file was generated and the attribute isn't in it.

The two package tests that previously asserted `enableSupport: false` (`NonWebSdkProject_WithNoConfiguration_RestoresNothing` and `WithSupportDisabled_RestoresNothingEvenWhenTheRestoreOptionsAreEnabled`) now assert no attribute at all.

Note the distinction that survives: support enabled with every `Restore*` option off still emits the attribute, with all three directories null. That case keeps the middleware registered with nothing to mark immutable, which `WithAllRestoreOptionsDisabled_RestoresNothingAndReportsNoDirectories` covers.

This is a source-breaking change to a public type, but it's `[EditorBrowsable(Never)]` and only ever constructed by the generated assembly info, so a consumer would have had to be writing it by hand to notice.

## Testing

All suites pass: 5904 unit, 354 integration, 49 package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)