### PR TITLE
Read the build info from the application assembly only

### DIFF
--- a/src/GovUk.Frontend.AspNetCore/ConfigureGovUkFrontendOptions.cs
+++ b/src/GovUk.Frontend.AspNetCore/ConfigureGovUkFrontendOptions.cs
@@ -1,25 +1,45 @@
 using System.Reflection;
-using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 namespace GovUk.Frontend.AspNetCore;
 
-internal class ConfigureGovUkFrontendOptions(ApplicationPartManager applicationPartManager) : IConfigureOptions<GovUkFrontendOptions>
+internal class ConfigureGovUkFrontendOptions(IHostEnvironment? hostEnvironment) : IConfigureOptions<GovUkFrontendOptions>
 {
     public void Configure(GovUkFrontendOptions options)
     {
-        var buildInfoAttributes = applicationPartManager.ApplicationParts.OfType<AssemblyPart>()
-            .Select(ap => ap.Assembly)
-            .Select(a => a.GetCustomAttribute<GovUkFrontendBuildInfoAttribute>())
-            .Where(attr => attr is not null)
-            .ToArray();
+        // The targets that emit the attribute are transitive, so every project in the build that references
+        // the package carries one, describing how that project was built. Only the application's own answer
+        // is meaningful here; a class library's says nothing about where the app serves its files from.
+        var buildInfo = GetApplicationAssembly()?.GetCustomAttribute<GovUkFrontendBuildInfoAttribute>();
 
-        if (buildInfoAttributes.Length is 0)
+        if (buildInfo is null)
         {
             return;
         }
 
-        var buildInfo = buildInfoAttributes.Single()!;
         options.BuildInfo = buildInfo;
+    }
+
+    private Assembly? GetApplicationAssembly()
+    {
+        // How the framework itself identifies the application; a test host sets it to the assembly under test.
+        var applicationName = hostEnvironment?.ApplicationName;
+
+        if (string.IsNullOrEmpty(applicationName))
+        {
+            return Assembly.GetEntryAssembly();
+        }
+
+        try
+        {
+            return Assembly.Load(new AssemblyName(applicationName));
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or FileLoadException or BadImageFormatException)
+        {
+            // ApplicationName is just a string and need not name a loadable assembly. The build info is
+            // optional, so fall back rather than bringing the application down over it.
+            return Assembly.GetEntryAssembly();
+        }
     }
 }

--- a/src/GovUk.Frontend.AspNetCore/GovUkFrontendExtensions.cs
+++ b/src/GovUk.Frontend.AspNetCore/GovUkFrontendExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 
@@ -50,7 +51,10 @@ public static class GovUkFrontendExtensions
             new DefaultComponentGenerator(sp.GetRequiredService<IGovUkFrontendLocalizer>()));
         services.TryAddSingleton<IModelHelper, DefaultModelHelper>();
         services.AddSingleton<IConfigureOptions<MvcOptions>, ConfigureMvcOptions>();
-        services.AddSingleton<IConfigureOptions<GovUkFrontendOptions>, ConfigureGovUkFrontendOptions>();
+        // Resolved through IHostEnvironment, which a bare service collection won't have; the configurator
+        // falls back to the entry assembly there.
+        services.AddSingleton<IConfigureOptions<GovUkFrontendOptions>>(
+            sp => new ConfigureGovUkFrontendOptions(sp.GetService<IHostEnvironment>()));
         // Resolved through IWebHostEnvironment, which a non-web host won't have; such a host has nothing
         // to serve the files from either, so the defaults are the right answer there.
         services.TryAddSingleton(sp => GovUkFrontendPaths.Create(


### PR DESCRIPTION
## What changed

`ConfigureGovUkFrontendOptions` no longer scans `ApplicationPartManager` for `GovUkFrontendBuildInfoAttribute`. It now resolves a single assembly — the one named by `IHostEnvironment.ApplicationName` — and reads the attribute from that.

## Why

The targets that emit the attribute live in `buildTransitive`, so *every* project in the build that references the package carries one describing how that project was built. Scanning every application part therefore picked up class libraries' attributes alongside the application's, and the `Single()` call threw outright once more than one part had one. That's reachable today: a class library that references the package gets its own attribute, and registering it as an application part (an RCL, say) brings it into the part manager. A library's answer also says nothing about where the app serves its files from, so even the one-attribute case was reading the wrong thing when it came from a library.

`ApplicationName` is how the framework itself identifies the hosting application, and what MVC's own part discovery keys off.

## Notes for reviewers

Two fallbacks, both to `Assembly.GetEntryAssembly()`:

- No `IHostEnvironment` (a bare `ServiceCollection`, as in the unit tests) or an empty `ApplicationName`.
- An `ApplicationName` that doesn't name a loadable assembly — it's just a string and need not be one. The build info is optional, so falling back beats bringing the application down over it.

The registration in `GovUkFrontendExtensions` moves to a factory using `sp.GetService<IHostEnvironment>()`, mirroring how `GovUkFrontendPaths` already handles the optional `IWebHostEnvironment`.

Under `WebApplicationFactory`, `ApplicationName` is set to the assembly under test, so integration tests still see the app's build info. Nothing changes for this repo's own tests: no in-repo test project imports the targets (only `GovUk.Frontend.AspNetCore.Docs.csproj` does), so there's no attribute to find either way.

No test was added for the new lookup. The only way to exercise the positive path is to stamp a real `GovUkFrontendBuildInfoAttribute` onto the test assembly, and because the fallback resolves the entry assembly, that attribute would then also be picked up by every other test that builds a bare `ServiceCollection`. A separate fixture assembly would avoid that if it's wanted.

## Testing

- `dotnet build` of the library: clean, 0 warnings.
- Full unit suite on net10.0: 1968 tests, 0 failures, 2 pre-existing skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)